### PR TITLE
Support new files in svn workflow

### DIFF
--- a/PhpcsChanged/PhpcsMessages.php
+++ b/PhpcsChanged/PhpcsMessages.php
@@ -32,6 +32,9 @@ class PhpcsMessages {
 	}
 
 	public static function fromPhpcsJson(string $messages, string $forcedFileName = null): self {
+		if (empty($messages)) {
+			return self::fromArrays([], $forcedFileName ?? 'STDIN');
+		}
 		$parsed = json_decode($messages, true);
 		if (! $parsed) {
 			throw new \Exception('Failed to decode phpcs JSON: ' . var_export($messages, true));

--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,37 @@
+# PHP CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-php/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      - image: circleci/php:7.1-browsers
+      
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/mysql:9.4
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "composer.json" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run: composer install -n --prefer-dist
+
+      - save_cache:
+          paths:
+            - ./vendor
+          key: v1-dependencies-{{ checksum "composer.json" }}
+        
+      # run tests!
+      - run: composer test

--- a/tests/PhpcsChangedTest.php
+++ b/tests/PhpcsChangedTest.php
@@ -45,6 +45,28 @@ EOF;
 		$this->assertEquals($expected->getLineNumbers(), $actual->getLineNumbers());
 	}
 
+	public function testGetNewPhpcsMessagesWithNewFile() {
+		$diff = <<<EOF
+Index: foo.php
+===================================================================
+--- foo.php     (revision 0)
++++ foo.php     (working copy)
+@@ -0,0 +1,3 @@
++<?php
++
++echo "hello world";
+EOF;
+		$oldFilePhpcs = [];
+		$newFilePhpcs = [
+			[ 'line' => 3 ],
+		];
+		$actual = getNewPhpcsMessages($diff, PhpcsMessages::fromArrays($oldFilePhpcs), PhpcsMessages::fromArrays($newFilePhpcs));
+		$expected = PhpcsMessages::fromArrays([
+			[ 'line' => 3 ],
+		]);
+		$this->assertEquals($expected->getLineNumbers(), $actual->getLineNumbers());
+	}
+
 	public function testGetNewPhpcsMessagesWithChangedLine() {
 		$diff = <<<EOF
 Index: review-stuck-orders.php
@@ -153,6 +175,24 @@ EOF;
 		$newFilePhpcs = '{"totals":{"errors":0,"warnings":2,"fixable":0},"files":{"STDIN":{"errors":0,"warnings":2,"messages":[{"line":20,"type":"WARNING","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":21,"type":"WARNING","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}';
 		$actual = getNewPhpcsMessages($diff, PhpcsMessages::fromPhpcsJson($oldFilePhpcs), PhpcsMessages::fromPhpcsJson($newFilePhpcs))->toPhpcsJson();
 		$expected = '{"totals":{"errors":0,"warnings":1,"fixable":0},"files":{"bin/review-stuck-orders.php":{"errors":0,"warnings":1,"messages":[{"line":20,"type":"WARNING","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}';
+		$this->assertEquals($expected, $actual);
+	}
+
+	public function testGetNewPhpcsMessagesWithPhpcsJsonAndNewFile() {
+		$diff = <<<EOF
+Index: foo.php
+===================================================================
+--- foo.php     (revision 0)
++++ foo.php     (working copy)
+@@ -0,0 +1,3 @@
++<?php
++
++echo "hello world";
+EOF;
+		$oldFilePhpcs = '';
+		$newFilePhpcs = '{"totals":{"errors":0,"warnings":2,"fixable":0},"files":{"STDIN":{"errors":0,"warnings":2,"messages":[{"line":20,"type":"WARNING","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":21,"type":"WARNING","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}';
+		$actual = getNewPhpcsMessages($diff, PhpcsMessages::fromPhpcsJson($oldFilePhpcs), PhpcsMessages::fromPhpcsJson($newFilePhpcs))->toPhpcsJson();
+		$expected = '{"totals":{"errors":0,"warnings":2,"fixable":0},"files":{"foo.php":{"errors":0,"warnings":2,"messages":[{"line":20,"type":"WARNING","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":21,"type":"WARNING","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}';
 		$this->assertEquals($expected, $actual);
 	}
 

--- a/tests/PhpcsMessagesTest.php
+++ b/tests/PhpcsMessagesTest.php
@@ -14,6 +14,13 @@ final class PhpcsMessagesTest extends TestCase {
 		$this->assertEquals($expected, $messages->getLineNumbers());
 	}
 
+	public function testFromPhpcsJsonWithEmptyJson() {
+		$expected = [];
+		$json = '';
+		$messages = PhpcsMessages::fromPhpcsJson($json);
+		$this->assertEquals($expected, $messages->getLineNumbers());
+	}
+
 	public function testGetPhpcsJson() {
 		$expected = '{"totals":{"errors":0,"warnings":1,"fixable":0},"files":{"STDIN":{"errors":0,"warnings":1,"messages":[{"line":20,"type":"WARNING","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}';
 		$messages = PhpcsMessages::fromArrays([


### PR DESCRIPTION
Currently if you run the CLI command `phpcs-changed` using the `--svn` option on a just-added file (one with no svn history), then you will get an error.

This PR changes the behavior such that it handles those files correctly, reporting all phpcs errors.