### PR TITLE
Add git workflow

### DIFF
--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -80,12 +80,13 @@ EOF;
 
 	echo <<<EOF
 Automatic mode will try to gather data itself if you specify the version
-control system (only svn supported right now):
+control system:
 
 EOF;
 
 	printTwoColumns([
-		'--svn <FILE>' => 'This is the file to check.',
+		'--svn <FILE>' => 'This is the svn-versioned file to check.',
+		'--git <FILE>' => 'This is the git-versioned file to check.',
 	]);
 
 	echo <<<EOF
@@ -103,10 +104,10 @@ EOF;
 	]);
 	echo <<<EOF
 
-If using automatic mode, this requires three shell commands: 'svn', 'cat', and
-'phpcs'. If those commands are not in your PATH or you would like to override
-them, you can use the environment variables 'SVN', 'CAT', and 'PHPCS',
-respectively, to specify the full path for each one.
+If using automatic mode, this requires three shell commands: 'svn' or 'git',
+'cat', and 'phpcs'. If those commands are not in your PATH or you would like to
+override them, you can use the environment variables 'SVN', 'GIT', 'CAT', and
+'PHPCS', respectively, to specify the full path for each one.
 
 EOF;
 	exit(0);

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -150,7 +150,7 @@ function runSvnWorkflow($svnFile, $options, ShellOperator $shell, callable $debu
 
 		$phpcsStandard = $options['standard'] ?? null;
 		$phpcsStandardOption = $phpcsStandard ? ' --standard=' . escapeshellarg($phpcsStandard) : '';
-		validateSvnFileExists($svnFile, [$shell, 'isReadable']);
+		validateSvnFileExists($svnFile, $svn, [$shell, 'isReadable'], [$shell, 'executeCommand'], $debug);
 		$unifiedDiff = getSvnUnifiedDiff($svnFile, $svn, [$shell, 'executeCommand'], $debug);
 		$isNewFile = isNewSvnFile($svnFile, $svn, [$shell, 'executeCommand'], $debug);
 		$oldFilePhpcsOutput = $isNewFile ? '' : getSvnBasePhpcsOutput($svnFile, $svn, $phpcs, $phpcsStandardOption, [$shell, 'executeCommand'], $debug);

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -24,10 +24,14 @@ function getDebug($debugEnabled) {
 	};
 }
 
-function printErrorAndExit($output) {
+function printError($output) {
 	fwrite(STDERR, 'phpcs-changed: Fatal error!' . PHP_EOL);
 	fwrite(STDERR, $output . PHP_EOL);
-	die(1);
+}
+
+function printErrorAndExit($output) {
+	printError($output);
+	exit(1);
 }
 
 function getLongestString(array $strings): int {
@@ -51,7 +55,7 @@ function printVersion() {
 phpcs-changed version {$version}
 
 EOF;
-	die(0);
+	exit(0);
 }
 
 function printHelp() {
@@ -105,7 +109,7 @@ them, you can use the environment variables 'SVN', 'CAT', and 'PHPCS',
 respectively, to specify the full path for each one.
 
 EOF;
-	die(0);
+	exit(0);
 }
 
 function getReporter(string $reportType): Reporter {
@@ -152,9 +156,12 @@ function runSvnWorkflow($svnFile, $options, ShellOperator $shell, callable $debu
 		$newFilePhpcsOutput = getSvnNewPhpcsOutput($svnFile, $phpcs, $cat, $phpcsStandardOption, [$shell, 'executeCommand'], $debug);
 	} catch( NonFatalException $err ) {
 		$debug($err->getMessage());
-		exit(0);
+		$shell->exitWithCode(0);
+		throw $err; // Just in case we do not actually exit
 	} catch( \Exception $err ) {
-		printErrorAndExit($err->getMessage());
+		$shell->printError($err->getMessage());
+		$shell->exitWithCode(1);
+		throw $err; // Just in case we do not actually exit
 	}
 
 	$debug('processing data...');

--- a/PhpcsChanged/GitWorkflow.php
+++ b/PhpcsChanged/GitWorkflow.php
@@ -1,0 +1,67 @@
+<?php
+declare(strict_types=1);
+
+namespace PhpcsChanged\GitWorkflow;
+
+use PhpcsChanged\NonFatalException;
+use PhpcsChanged\ShellException;
+
+function validateGitFileExists(string $gitFile, string $git, callable $isReadable, callable $executeCommand, callable $debug): void {
+	if (! $isReadable($gitFile)) {
+		throw new ShellException("Cannot read file '{$gitFile}'");
+	}
+	$gitStatusCommand = "${git} status --short " . escapeshellarg($gitFile);
+	$debug('checking git existence of file with command:', $gitStatusCommand);
+	$gitStatusOutput = $executeCommand($gitStatusCommand);
+	$debug('git status output:', $gitStatusOutput);
+	if (isset($gitStatusOutput[0]) && $gitStatusOutput[0] === '?') {
+		throw new ShellException("File does not appear to be tracked by git: '{$gitFile}'");
+	}
+}
+
+function getGitUnifiedDiff(string $gitFile, string $git, callable $executeCommand, callable $debug): string {
+	$unifiedDiffCommand = "{$git} diff --staged --no-prefix " . escapeshellarg($gitFile);
+	$debug('running diff command:', $unifiedDiffCommand);
+	$unifiedDiff = $executeCommand($unifiedDiffCommand);
+	if (! $unifiedDiff) {
+		throw new NonFatalException("Cannot get git diff for file '{$gitFile}'; skipping");
+	}
+	$debug('diff command output:', $unifiedDiff);
+	return $unifiedDiff;
+}
+
+function isNewGitFile(string $gitFile, string $git, callable $executeCommand, callable $debug): bool {
+	$gitStatusCommand = "${git} status --short " . escapeshellarg($gitFile);
+	$debug('checking git status of file with command:', $gitStatusCommand);
+	$gitStatusOutput = $executeCommand($gitStatusCommand);
+	$debug('git status output:', $gitStatusOutput);
+	if (! $gitStatusOutput || false === strpos($gitStatusOutput, $gitFile)) {
+		throw new ShellException("Cannot get git status for file '{$gitFile}'");
+	}
+	if (isset($gitStatusOutput[0]) && $gitStatusOutput[0] === '?') {
+		throw new ShellException("File does not appear to be tracked by git: '{$gitFile}'");
+	}
+	return isset($gitStatusOutput[0]) && $gitStatusOutput[0] === 'A';
+}
+
+function getGitBasePhpcsOutput(string $gitFile, string $git, string $phpcs, string $phpcsStandardOption, callable $executeCommand, callable $debug): string {
+	$oldFilePhpcsOutputCommand = "${git} show HEAD:" . escapeshellarg($gitFile) . " | {$phpcs} --report=json" . $phpcsStandardOption;
+	$debug('running orig phpcs command:', $oldFilePhpcsOutputCommand);
+	$oldFilePhpcsOutput = $executeCommand($oldFilePhpcsOutputCommand);
+	if (! $oldFilePhpcsOutput) {
+		throw new ShellException("Cannot get old phpcs output for file '{$gitFile}'");
+	}
+	$debug('orig phpcs command output:', $oldFilePhpcsOutput);
+	return $oldFilePhpcsOutput;
+}
+
+function getGitNewPhpcsOutput(string $gitFile, string $phpcs, string $cat, string $phpcsStandardOption, callable $executeCommand, callable $debug): string {
+	$newFilePhpcsOutputCommand = "{$cat} " . escapeshellarg($gitFile) . " | {$phpcs} --report=json" . $phpcsStandardOption;
+	$debug('running new phpcs command:', $newFilePhpcsOutputCommand);
+	$newFilePhpcsOutput = $executeCommand($newFilePhpcsOutputCommand);
+	if (! $newFilePhpcsOutput) {
+		throw new ShellException("Cannot get new phpcs output for file '{$gitFile}'");
+	}
+	$debug('new phpcs command output:', $newFilePhpcsOutput);
+	return $newFilePhpcsOutput;
+}

--- a/PhpcsChanged/ShellException.php
+++ b/PhpcsChanged/ShellException.php
@@ -1,0 +1,7 @@
+<?php
+declare(strict_types=1);
+
+namespace PhpcsChanged;
+
+class ShellException extends \Exception {
+}

--- a/PhpcsChanged/ShellOperator.php
+++ b/PhpcsChanged/ShellOperator.php
@@ -12,4 +12,8 @@ interface ShellOperator {
 	public function executeCommand(string $command): string;
 
 	public function isReadable(string $fileName): bool;
+
+	public function exitWithCode(int $code): void;
+
+	public function printError(string $message): void;
 }

--- a/PhpcsChanged/UnixShell.php
+++ b/PhpcsChanged/UnixShell.php
@@ -17,7 +17,7 @@ class UnixShell implements ShellOperator {
 	}
 
 	public function executeCommand(string $command): string {
-		return shell_exec($command);
+		return shell_exec($command) ?? '';
 	}
 
 	public function isReadable(string $fileName): bool {

--- a/PhpcsChanged/UnixShell.php
+++ b/PhpcsChanged/UnixShell.php
@@ -23,4 +23,13 @@ class UnixShell implements ShellOperator {
 	public function isReadable(string $fileName): bool {
 		return is_readable($fileName);
 	}
+
+	public function exitWithCode(int $code): void {
+		exit($code);
+	}
+
+	public function printError(string $output): void {
+		fwrite(STDERR, 'phpcs-changed: Fatal error!' . PHP_EOL);
+		fwrite(STDERR, $output . PHP_EOL);
+	}
 }

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ cat file.php | phpcs --report=json > file.php.phpcs
 phpcs-changed --report json --diff file.php.diff --phpcs-orig file.php.orig.phpcs --phpcs-new file.php.phpcs
 ```
 
-Alernatively, we can have the script use svn and phpcs itself:
+Alernatively, we can have the script use svn and phpcs itself by using the `--svn` option:
 
 ```
 phpcs-changed --svn file.php --report json
@@ -139,6 +139,13 @@ Both will output something like:
   }
 }
 ```
+
+If the file was versioned by git, we can do the same with the `--git` option:
+
+```
+phpcs-changed --git file.php --report json
+```
+
 
 ### CLI Options
 

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -13,6 +13,7 @@ use function PhpcsChanged\Cli\{
 	getDebug,
 	runManualWorkflow,
 	runSvnWorkflow,
+	runGitWorkflow,
 	reportMessagesAndExit
 };
 use PhpcsChanged\UnixShell;
@@ -26,6 +27,7 @@ $options = getopt(
 		'phpcs-orig:',
 		'phpcs-new:',
 		'svn:',
+		'git:',
 		'standard:',
 		'report:',
 		'debug',
@@ -56,6 +58,12 @@ $svnFile = $options['svn'] ?? null;
 if ($svnFile) {
 	$shell = new UnixShell();
 	reportMessagesAndExit(runSvnWorkflow($svnFile, $options, $shell, $debug), $reportType);
+}
+
+$gitFile = $options['git'] ?? null;
+if ($gitFile) {
+	$shell = new UnixShell();
+	reportMessagesAndExit(runGitWorkflow($gitFile, $options, $shell, $debug), $reportType);
 }
 
 printHelp();

--- a/index.php
+++ b/index.php
@@ -20,6 +20,7 @@ require_once __DIR__ . '/PhpcsChanged/FullReporter.php';
 require_once __DIR__ . '/PhpcsChanged/NonFatalException.php';
 require_once __DIR__ . '/PhpcsChanged/ShellException.php';
 require_once __DIR__ . '/PhpcsChanged/SvnWorkflow.php';
+require_once __DIR__ . '/PhpcsChanged/GitWorkflow.php';
 require_once __DIR__ . '/PhpcsChanged/ShellOperator.php';
 require_once __DIR__ . '/PhpcsChanged/UnixShell.php';
 

--- a/index.php
+++ b/index.php
@@ -5,6 +5,7 @@ namespace PhpcsChanged;
 
 use PhpcsChanged\DiffLineMap;
 use PhpcsChanged\PhpcsMessages;
+use PhpcsChanged\ShellException;
 
 require_once __DIR__ . '/PhpcsChanged/Version.php';
 require_once __DIR__ . '/PhpcsChanged/DiffLine.php';
@@ -17,6 +18,7 @@ require_once __DIR__ . '/PhpcsChanged/Reporter.php';
 require_once __DIR__ . '/PhpcsChanged/JsonReporter.php';
 require_once __DIR__ . '/PhpcsChanged/FullReporter.php';
 require_once __DIR__ . '/PhpcsChanged/NonFatalException.php';
+require_once __DIR__ . '/PhpcsChanged/ShellException.php';
 require_once __DIR__ . '/PhpcsChanged/SvnWorkflow.php';
 require_once __DIR__ . '/PhpcsChanged/ShellOperator.php';
 require_once __DIR__ . '/PhpcsChanged/UnixShell.php';
@@ -42,7 +44,7 @@ function getNewPhpcsMessagesFromFiles(string $diffFile, string $phpcsOldFile, st
 	$oldFilePhpcsOutput = file_get_contents($phpcsOldFile);
 	$newFilePhpcsOutput = file_get_contents($phpcsNewFile);
 	if (! $unifiedDiff || ! $oldFilePhpcsOutput || ! $newFilePhpcsOutput) {
-		throw new \Exception('Cannot read input files.'); // TODO: make custom Exception
+		throw new ShellException('Cannot read input files.');
 	}
 	return getNewPhpcsMessages(
 		$unifiedDiff,

--- a/tests/GitWorkflowTest.php
+++ b/tests/GitWorkflowTest.php
@@ -1,0 +1,277 @@
+<?php
+declare(strict_types=1);
+
+require_once dirname(__DIR__) . '/index.php';
+
+use PHPUnit\Framework\TestCase;
+use PhpcsChanged\PhpcsMessages;
+use PhpcsChanged\NonFatalException;
+use PhpcsChanged\ShellOperator;
+use PhpcsChanged\ShellException;
+use function PhpcsChanged\Cli\runGitWorkflow;
+use function PhpcsChanged\GitWorkflow\{isNewGitFile, getGitUnifiedDiff};
+
+final class GitWorkflowTest extends TestCase {
+	public function testIsNewGitFileReturnsTrueForNewFile() {
+		$gitFile = 'foobar.php';
+		$git = 'git';
+		$executeCommand = function($command) {
+			if (false !== strpos($command, "git status --short 'foobar.php'")) {
+				return 'A foobar.php';
+			}
+		};
+		$debug = function($message) {}; //phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		$this->assertTrue(isNewGitFile($gitFile, $git, $executeCommand, $debug));
+	}
+
+	public function testIsNewGitFileReturnsFalseForOldFile() {
+		$gitFile = 'foobar.php';
+		$git = 'git';
+		$executeCommand = function($command) {
+			if (false !== strpos($command, "git status --short 'foobar.php'")) {
+				return ' M foobar.php'; // note the leading space
+			}
+		};
+		$debug = function($message) {}; //phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		$this->assertFalse(isNewGitFile($gitFile, $git, $executeCommand, $debug));
+	}
+
+	public function testGetGitUnifiedDiff() {
+		$gitFile = 'foobar.php';
+		$git = 'git';
+		$diff = <<<EOF
+diff --git bin/foobar.php bin/foobar.php
+index 038d718..d6c3357 100644
+--- bin/foobar.php
++++ bin/foobar.php
+@@ -17,6 +17,7 @@
+ use Billing\Purchases\Order;
+ use Billing\Services;
+ use Billing\Ebanx;
++use Foobar;
+ use Billing\Emergent;
+ use Billing\Monetary_Amount;
+ use Stripe\Error;
+EOF;
+		$executeCommand = function($command) use ($diff) {
+			if (! $command || false === strpos($command, "git diff --staged --no-prefix 'foobar.php'")) {
+				return '';
+			}
+			return $diff;
+		};
+		$debug = function($message) {}; //phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		$this->assertEquals($diff, getGitUnifiedDiff($gitFile, $git, $executeCommand, $debug));
+	}
+
+	public function testGetGitUnifiedDiffThrowsNonFatalIfDiffFails() {
+		$this->expectException(NonFatalException::class);
+		$gitFile = 'foobar.php';
+		$git = 'git';
+		$executeCommand = function($command) {
+			if (! $command || false === strpos($command, "git diff --staged --no-prefix 'foobar.php'")) {
+				return 'foobar';
+			}
+			return '';
+		};
+		$debug = function($message) {}; //phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		getGitUnifiedDiff($gitFile, $git, $executeCommand, $debug);
+	}
+
+	public function testFullGitWorkflow() {
+		$gitFile = 'foobar.php';
+		$debug = function($message) {}; //phpcs:ignore VariableAnalysis
+		$shell = new class() implements ShellOperator {
+			public function isReadable(string $fileName): bool {
+				return ($fileName === 'foobar.php');
+			}
+
+			public function exitWithCode(int $code): void {} // phpcs:ignore VariableAnalysis
+
+			public function printError(string $message): void {} // phpcs:ignore VariableAnalysis
+
+			public function validateExecutableExists(string $name, string $command): void {} // phpcs:ignore VariableAnalysis
+
+			public function executeCommand(string $command): string {
+				if (false !== strpos($command, "git diff --staged --no-prefix 'foobar.php'")) {
+					return <<<EOF
+diff --git bin/foobar.php bin/foobar.php
+index 038d718..d6c3357 100644
+--- bin/foobar.php
++++ bin/foobar.php
+@@ -17,6 +17,7 @@
+ use Billing\Purchases\Order;
+ use Billing\Services;
+ use Billing\Ebanx;
++use Foobar;
+ use Billing\Emergent;
+ use Billing\Monetary_Amount;
+ use Stripe\Error;
+EOF;
+				}
+				if (false !== strpos($command, "git status --short 'foobar.php'")) {
+					return ' M foobar.php'; // note the leading space
+				}
+				if (false !== strpos($command, "git show HEAD:'foobar.php'")) {
+					return '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":99,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}';
+				}
+				if (false !== strpos($command, "cat 'foobar.php'")) {
+					return '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":21,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}';
+				}
+				return '';
+			}
+		};
+		$options = [];
+		$expected = PhpcsMessages::fromArrays([
+			[
+				'type' => 'ERROR',
+				'severity' => 5,
+				'fixable' => false,
+				'column' => 5,
+				'source' => 'ImportDetection.Imports.RequireImports.Import',
+				'line' => 20,
+				'message' => 'Found unused symbol Emergent.',
+			],
+		], 'bin/foobar.php');
+		$messages = runGitWorkflow($gitFile, $options, $shell, $debug);
+		$this->assertEquals($expected->getMessages(), $messages->getMessages());
+	}
+
+	public function testFullGitWorkflowForUnchangedFile() {
+		$this->expectException(NonFatalException::class);
+		$gitFile = 'foobar.php';
+		$debug = function($message) {}; //phpcs:ignore VariableAnalysis
+		$shell = new class() implements ShellOperator {
+			public function isReadable(string $fileName): bool {
+				return ($fileName === 'foobar.php');
+			}
+
+			public function validateExecutableExists(string $name, string $command): void {} // phpcs:ignore VariableAnalysis
+
+			public function exitWithCode(int $code): void {} // phpcs:ignore VariableAnalysis
+
+			public function printError(string $message): void {} // phpcs:ignore VariableAnalysis
+
+			public function executeCommand(string $command): string {
+				if (false !== strpos($command, "git diff --staged --no-prefix 'foobar.php'")) {
+					return <<<EOF
+EOF;
+				}
+				if (false !== strpos($command, "git status --short 'foobar.php'")) {
+					return '';
+				}
+				if (false !== strpos($command, "git show HEAD:'foobar.php'")) {
+					return '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":99,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}';
+				}
+				if (false !== strpos($command, "cat 'foobar.php'")) {
+					return '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":99,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}';
+				}
+				return '';
+			}
+		};
+		$options = [];
+		runGitWorkflow($gitFile, $options, $shell, $debug);
+	}
+
+	public function testFullGitWorkflowForNonGitFile() {
+		$this->expectException(ShellException::class);
+		$gitFile = 'foobar.php';
+		$debug = function($message) {}; //phpcs:ignore VariableAnalysis
+		$shell = new class() implements ShellOperator {
+			public function isReadable(string $fileName): bool {
+				return ($fileName === 'foobar.php');
+			}
+
+			public function validateExecutableExists(string $name, string $command): void {} // phpcs:ignore VariableAnalysis
+
+			public function exitWithCode(int $code): void {} // phpcs:ignore VariableAnalysis
+
+			public function printError(string $message): void {} // phpcs:ignore VariableAnalysis
+
+			public function executeCommand(string $command): string {
+				if (false !== strpos($command, "git diff --staged --no-prefix 'foobar.php'")) {
+					return <<<EOF
+EOF;
+				}
+				if (false !== strpos($command, "git status --short 'foobar.php'")) {
+					return "?? foobar.php";
+				}
+				if (false !== strpos($command, "git show HEAD:'foobar.php'")) {
+					return "fatal: Path 'foobar.php' exists on disk, but not in 'HEAD'.";
+				}
+				if (false !== strpos($command, "cat 'foobar.php'")) {
+					return '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":99,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}';
+				}
+				throw new \Exception("Unknown command: {$command}");
+			}
+		};
+		$options = [];
+		runGitWorkflow($gitFile, $options, $shell, $debug);
+	}
+
+	public function testFullGitWorkflowForNewFile() {
+		$gitFile = 'foobar.php';
+		$debug = function($message) {}; //phpcs:ignore VariableAnalysis
+		$shell = new class() implements ShellOperator {
+			public function isReadable(string $fileName): bool {
+				return ($fileName === 'foobar.php');
+			}
+
+			public function validateExecutableExists(string $name, string $command): void {} // phpcs:ignore VariableAnalysis
+
+			public function exitWithCode(int $code): void {} // phpcs:ignore VariableAnalysis
+
+			public function printError(string $message): void {} // phpcs:ignore VariableAnalysis
+
+			public function executeCommand(string $command): string {
+				if (false !== strpos($command, "git diff --staged --no-prefix 'foobar.php'")) {
+					return <<<EOF
+diff --git bin/foobar.php bin/foobar.php
+new file mode 100644
+index 0000000..efa970f
+--- /dev/null
++++ bin/foobar.php
+@@ -0,0 +1,8 @@
++<?php
++use Billing\Purchases\Order;
++use Billing\Services;
++use Billing\Ebanx;
++use Foobar;
++use Billing\Emergent;
++use Billing\Monetary_Amount;
++use Stripe\Error;
+EOF;
+				}
+				if (false !== strpos($command, "git status --short 'foobar.php'")) {
+					return 'A foobar.php';
+				}
+				if (false !== strpos($command, "cat 'foobar.php'")) {
+					return '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":4,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":5,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}';
+				}
+				throw new \Exception("Unknown command: {$command}");
+			}
+		};
+		$options = [];
+		$expected = PhpcsMessages::fromArrays([
+			[
+				'type' => 'ERROR',
+				'severity' => 5,
+				'fixable' => false,
+				'column' => 5,
+				'source' => 'ImportDetection.Imports.RequireImports.Import',
+				'line' => 4,
+				'message' => 'Found unused symbol Emergent.',
+			],
+			[
+				'type' => 'ERROR',
+				'severity' => 5,
+				'fixable' => false,
+				'column' => 5,
+				'source' => 'ImportDetection.Imports.RequireImports.Import',
+				'line' => 5,
+				'message' => 'Found unused symbol Emergent.',
+			],
+		], '/dev/null');
+		$messages = runGitWorkflow($gitFile, $options, $shell, $debug);
+		$this->assertEquals($expected->getMessages(), $messages->getMessages());
+	}
+}


### PR DESCRIPTION
This adds a `--git` CLI shortcut and a git workflow to automatically collect the three necessary pieces of data for a git-versioned file in the same way that the `--svn` shortcut does for svn-versioned files.

- [x] Add tests
- [x] Add workflow
- [x] Add CLI command
- [x] Add docs
- [x] Handle untracked and unchanged files

Fixes #3 