### PR TITLE
Handle empty vcs files

### DIFF
--- a/PhpcsChanged/GitWorkflow.php
+++ b/PhpcsChanged/GitWorkflow.php
@@ -63,5 +63,9 @@ function getGitNewPhpcsOutput(string $gitFile, string $phpcs, string $cat, strin
 		throw new ShellException("Cannot get new phpcs output for file '{$gitFile}'");
 	}
 	$debug('new phpcs command output:', $newFilePhpcsOutput);
+	if (false !== strpos($newFilePhpcsOutput, 'You must supply at least one file or directory to process')) {
+		$debug('phpcs output implies file is empty');
+		return '';
+	}
 	return $newFilePhpcsOutput;
 }

--- a/PhpcsChanged/SvnWorkflow.php
+++ b/PhpcsChanged/SvnWorkflow.php
@@ -60,5 +60,9 @@ function getSvnNewPhpcsOutput(string $svnFile, string $phpcs, string $cat, strin
 		throw new ShellException("Cannot get new phpcs output for file '{$svnFile}'");
 	}
 	$debug('new phpcs command output:', $newFilePhpcsOutput);
+	if (false !== strpos($newFilePhpcsOutput, 'You must supply at least one file or directory to process')) {
+		$debug('phpcs output implies file is empty');
+		return '';
+	}
 	return $newFilePhpcsOutput;
 }


### PR DESCRIPTION
When a newly added file is empty, then the command `cat filename.php | phpcs` fails with the error `You must supply at least one file or directory to process`. In that case, however, we know there are no phpcs errors so we can just skip that command.

Fixes #5 