### PR TITLE
Force quiet mode

### DIFF
--- a/PhpcsChanged/GitWorkflow.php
+++ b/PhpcsChanged/GitWorkflow.php
@@ -45,7 +45,7 @@ function isNewGitFile(string $gitFile, string $git, callable $executeCommand, ca
 }
 
 function getGitBasePhpcsOutput(string $gitFile, string $git, string $phpcs, string $phpcsStandardOption, callable $executeCommand, callable $debug): string {
-	$oldFilePhpcsOutputCommand = "${git} show HEAD:" . escapeshellarg($gitFile) . " | {$phpcs} --report=json" . $phpcsStandardOption;
+	$oldFilePhpcsOutputCommand = "${git} show HEAD:" . escapeshellarg($gitFile) . " | {$phpcs} --report=json -q" . $phpcsStandardOption;
 	$debug('running orig phpcs command:', $oldFilePhpcsOutputCommand);
 	$oldFilePhpcsOutput = $executeCommand($oldFilePhpcsOutputCommand);
 	if (! $oldFilePhpcsOutput) {
@@ -56,7 +56,7 @@ function getGitBasePhpcsOutput(string $gitFile, string $git, string $phpcs, stri
 }
 
 function getGitNewPhpcsOutput(string $gitFile, string $phpcs, string $cat, string $phpcsStandardOption, callable $executeCommand, callable $debug): string {
-	$newFilePhpcsOutputCommand = "{$cat} " . escapeshellarg($gitFile) . " | {$phpcs} --report=json" . $phpcsStandardOption;
+	$newFilePhpcsOutputCommand = "{$cat} " . escapeshellarg($gitFile) . " | {$phpcs} --report=json -q" . $phpcsStandardOption;
 	$debug('running new phpcs command:', $newFilePhpcsOutputCommand);
 	$newFilePhpcsOutput = $executeCommand($newFilePhpcsOutputCommand);
 	if (! $newFilePhpcsOutput) {

--- a/PhpcsChanged/SvnWorkflow.php
+++ b/PhpcsChanged/SvnWorkflow.php
@@ -42,7 +42,7 @@ function isNewSvnFile(string $svnFile, string $svn, callable $executeCommand, ca
 }
 
 function getSvnBasePhpcsOutput(string $svnFile, string $svn, string $phpcs, string $phpcsStandardOption, callable $executeCommand, callable $debug): string {
-	$oldFilePhpcsOutputCommand = "${svn} cat " . escapeshellarg($svnFile) . " | {$phpcs} --report=json" . $phpcsStandardOption;
+	$oldFilePhpcsOutputCommand = "${svn} cat " . escapeshellarg($svnFile) . " | {$phpcs} --report=json -q" . $phpcsStandardOption;
 	$debug('running orig phpcs command:', $oldFilePhpcsOutputCommand);
 	$oldFilePhpcsOutput = $executeCommand($oldFilePhpcsOutputCommand);
 	if (! $oldFilePhpcsOutput) {
@@ -53,7 +53,7 @@ function getSvnBasePhpcsOutput(string $svnFile, string $svn, string $phpcs, stri
 }
 
 function getSvnNewPhpcsOutput(string $svnFile, string $phpcs, string $cat, string $phpcsStandardOption, callable $executeCommand, callable $debug): string {
-	$newFilePhpcsOutputCommand = "{$cat} " . escapeshellarg($svnFile) . " | {$phpcs} --report=json" . $phpcsStandardOption;
+	$newFilePhpcsOutputCommand = "{$cat} " . escapeshellarg($svnFile) . " | {$phpcs} --report=json -q" . $phpcsStandardOption;
 	$debug('running new phpcs command:', $newFilePhpcsOutputCommand);
 	$newFilePhpcsOutput = $executeCommand($newFilePhpcsOutputCommand);
 	if (! $newFilePhpcsOutput) {

--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ Here's an example using svn:
 
 ```
 svn diff file.php > file.php.diff
-svn cat file.php | phpcs --report=json > file.php.orig.phpcs
-cat file.php | phpcs --report=json > file.php.phpcs
+svn cat file.php | phpcs --report=json -q > file.php.orig.phpcs
+cat file.php | phpcs --report=json -q > file.php.phpcs
 phpcs-changed --report json --diff file.php.diff --phpcs-orig file.php.orig.phpcs --phpcs-new file.php.phpcs
 ```
 


### PR DESCRIPTION
While the quiet mode in PHPCS is the default setting, it can be changed via `show_progress` config. Turning the `show_progress` on / disabling the quiet mode, makes the PHPCS to not only output the JSON contianing warnings and errors, but also a progress on individual files (eg.: `E 1 / 1 (100%)`), which then breaks the phpcs-changed's JSON parsing.

By using the `-q` flag in the `phpcs --format=json` commands, we would force the quiet mode for phpcs-changed run commands only, not affecting local settings, and making sure the phpcs-changed works no matter what the local setting is.

Fixes #7 