### PR TITLE
Treat unchanged files as normal

### DIFF
--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace PhpcsChanged\Cli;
 
-use PhpcsChanged\NonFatalException;
+use PhpcsChanged\NoChangesException;
 use PhpcsChanged\Reporter;
 use PhpcsChanged\JsonReporter;
 use PhpcsChanged\FullReporter;
@@ -156,14 +156,15 @@ function runSvnWorkflow($svnFile, $options, ShellOperator $shell, callable $debu
 		$isNewFile = isNewSvnFile($svnFile, $svn, [$shell, 'executeCommand'], $debug);
 		$oldFilePhpcsOutput = $isNewFile ? '' : getSvnBasePhpcsOutput($svnFile, $svn, $phpcs, $phpcsStandardOption, [$shell, 'executeCommand'], $debug);
 		$newFilePhpcsOutput = getSvnNewPhpcsOutput($svnFile, $phpcs, $cat, $phpcsStandardOption, [$shell, 'executeCommand'], $debug);
-	} catch( NonFatalException $err ) {
+	} catch( NoChangesException $err ) {
 		$debug($err->getMessage());
-		$shell->exitWithCode(0);
-		throw $err; // Just in case we do not actually exit
+		$unifiedDiff = '';
+		$oldFilePhpcsOutput = '';
+		$newFilePhpcsOutput = '';
 	} catch( \Exception $err ) {
 		$shell->printError($err->getMessage());
 		$shell->exitWithCode(1);
-		throw $err; // Just in case we do not actually exit
+		throw $err; // Just in case we do not actually exit, like in tests
 	}
 
 	$debug('processing data...');
@@ -190,10 +191,11 @@ function runGitWorkflow($gitFile, $options, ShellOperator $shell, callable $debu
 		$isNewFile = isNewGitFile($gitFile, $git, [$shell, 'executeCommand'], $debug);
 		$oldFilePhpcsOutput = $isNewFile ? '' : getGitBasePhpcsOutput($gitFile, $git, $phpcs, $phpcsStandardOption, [$shell, 'executeCommand'], $debug);
 		$newFilePhpcsOutput = getGitNewPhpcsOutput($gitFile, $phpcs, $cat, $phpcsStandardOption, [$shell, 'executeCommand'], $debug);
-	} catch(NonFatalException $err) {
+	} catch( NoChangesException $err ) {
 		$debug($err->getMessage());
-		$shell->exitWithCode(0);
-		throw $err; // Just in case we do not actually exit
+		$unifiedDiff = '';
+		$oldFilePhpcsOutput = '';
+		$newFilePhpcsOutput = '';
 	} catch(\Exception $err) {
 		$shell->printError($err->getMessage());
 		$shell->exitWithCode(1);

--- a/PhpcsChanged/GitWorkflow.php
+++ b/PhpcsChanged/GitWorkflow.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace PhpcsChanged\GitWorkflow;
 
-use PhpcsChanged\NonFatalException;
+use PhpcsChanged\NoChangesException;
 use PhpcsChanged\ShellException;
 
 function validateGitFileExists(string $gitFile, string $git, callable $isReadable, callable $executeCommand, callable $debug): void {
@@ -24,7 +24,7 @@ function getGitUnifiedDiff(string $gitFile, string $git, callable $executeComman
 	$debug('running diff command:', $unifiedDiffCommand);
 	$unifiedDiff = $executeCommand($unifiedDiffCommand);
 	if (! $unifiedDiff) {
-		throw new NonFatalException("Cannot get git diff for file '{$gitFile}'; skipping");
+		throw new NoChangesException("Cannot get git diff for file '{$gitFile}'; skipping");
 	}
 	$debug('diff command output:', $unifiedDiff);
 	return $unifiedDiff;

--- a/PhpcsChanged/NoChangesException.php
+++ b/PhpcsChanged/NoChangesException.php
@@ -3,5 +3,5 @@ declare(strict_types=1);
 
 namespace PhpcsChanged;
 
-class NonFatalException extends \Exception {
+class NoChangesException extends \Exception {
 }

--- a/PhpcsChanged/SvnWorkflow.php
+++ b/PhpcsChanged/SvnWorkflow.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace PhpcsChanged\SvnWorkflow;
 
-use PhpcsChanged\NonFatalException;
+use PhpcsChanged\NoChangesException;
 use PhpcsChanged\ShellException;
 
 function validateSvnFileExists(string $svnFile, string $svn, callable $isReadable, callable $executeCommand, callable $debug): void {
@@ -24,7 +24,7 @@ function getSvnUnifiedDiff(string $svnFile, string $svn, callable $executeComman
 	$debug('running diff command:', $unifiedDiffCommand);
 	$unifiedDiff = $executeCommand($unifiedDiffCommand);
 	if (! $unifiedDiff) {
-		throw new NonFatalException("Cannot get svn diff for file '{$svnFile}'; skipping");
+		throw new NoChangesException("Cannot get svn diff for file '{$svnFile}'; skipping");
 	}
 	$debug('diff command output:', $unifiedDiff);
 	return $unifiedDiff;

--- a/index.php
+++ b/index.php
@@ -17,7 +17,7 @@ require_once __DIR__ . '/PhpcsChanged/Cli.php';
 require_once __DIR__ . '/PhpcsChanged/Reporter.php';
 require_once __DIR__ . '/PhpcsChanged/JsonReporter.php';
 require_once __DIR__ . '/PhpcsChanged/FullReporter.php';
-require_once __DIR__ . '/PhpcsChanged/NonFatalException.php';
+require_once __DIR__ . '/PhpcsChanged/NoChangesException.php';
 require_once __DIR__ . '/PhpcsChanged/ShellException.php';
 require_once __DIR__ . '/PhpcsChanged/SvnWorkflow.php';
 require_once __DIR__ . '/PhpcsChanged/GitWorkflow.php';


### PR DESCRIPTION
Previously unchanged files caused a `NonFatalException` which allowed
the linter to skip them and move on to the next file. This was done
under the assumption that running the linter on such files was done by
mistake, since by definition they have no changed lines.

However, this behavior denies the Reporter the opportunity to make that
decision itself.

It can also be confusing when run on _only_ unchanged files because in
those cases even with the JSON reporter, no output is produced and no
error code is set.

With this diff, unchanged files will be treated simply has having no
phpcs messages, and the Reporter can decide how best to deal with that.