### PR TITLE
Downgrade PHP requirement to 7.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/php:7.2-browsers
+      - image: circleci/php:7.1-browsers
       
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         ]
     },
     "require": {
-        "php": "^7.2"
+        "php": "^7.1"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",


### PR DESCRIPTION
This downgrades the required PHP version to 7.1 from 7.2. I'm not certain why I chose 7.2 in the first place. There doesn't seem to be any dependencies that would need that version and I don't believe I used any 7.2-specific features.