### PR TITLE
Allow processing multiple files at once

### DIFF
--- a/PhpcsChanged/FullReporter.php
+++ b/PhpcsChanged/FullReporter.php
@@ -10,26 +10,50 @@ use function PhpcsChanged\Cli\getLongestString;
 
 class FullReporter implements Reporter {
 	public function getFormattedMessages(PhpcsMessages $messages): string {
-		$file = isset($messages->getMessages()[0]) ? $messages->getMessages()[0]->getFile() ?? 'STDIN' : 'STDIN';
-		$errorsCount = count(array_values(array_filter($messages->getMessages(), function($message) {
-			return $message->getType() === 'ERROR';
-		})));
-		$warningsCount = count(array_values(array_filter($messages->getMessages(), function($message) {
-			return $message->getType() === 'WARNING';
-		})));
+		$files = array_map(function(PhpcsMessage $message): string {
+			return $message->getFile() ?? 'STDIN';
+		}, $messages->getMessages());
+		if (empty($files)) {
+			$files = ['STDIN'];
+		}
+
 		$lineCount = count($messages->getMessages());
-		$linePlural = ($lineCount === 1) ? '' : 'S';
-		$errorPlural = ($errorsCount === 1) ? '' : 'S';
-		$warningPlural = ($warningsCount === 1) ? '' : 'S';
-		$longestNumber = getLongestString(array_map(function(PhpcsMessage $message): int {
-			return $message->getLineNumber();
-		}, $messages->getMessages()));
-		$formattedLines = implode("\n", array_map(function(PhpcsMessage $message) use ($longestNumber): string {
-			return sprintf(" %{$longestNumber}d | %s | %s", $message->getLineNumber(), $message->getType(), $message->getMessage());
-		}, $messages->getMessages()));
 		if ($lineCount < 1) {
 			return '';
 		}
+
+		return implode("\n", array_filter(array_map(function(string $file) use ($messages): ?string {
+			$messagesForFile = array_values(array_filter($messages->getMessages(), function(PhpcsMessage $message) use ($file): bool {
+				return $message->getFile() === $file;
+			}));
+			return $this->getFormattedMessagesForFile($messagesForFile, $file);
+		}, $files)));
+	}
+
+	private function getFormattedMessagesForFile(array $messages, string $file): ?string {
+		$lineCount = count($messages);
+		if ($lineCount < 1) {
+			return null;
+		}
+		$errorsCount = count(array_values(array_filter($messages, function($message) {
+			return $message->getType() === 'ERROR';
+		})));
+		$warningsCount = count(array_values(array_filter($messages, function($message) {
+			return $message->getType() === 'WARNING';
+		})));
+
+		$linePlural = ($lineCount === 1) ? '' : 'S';
+		$errorPlural = ($errorsCount === 1) ? '' : 'S';
+		$warningPlural = ($warningsCount === 1) ? '' : 'S';
+
+		$longestNumber = getLongestString(array_map(function(PhpcsMessage $message): int {
+			return $message->getLineNumber();
+		}, $messages));
+
+		$formattedLines = implode("\n", array_map(function(PhpcsMessage $message) use ($longestNumber): string {
+			return sprintf(" %{$longestNumber}d | %s | %s", $message->getLineNumber(), $message->getType(), $message->getMessage());
+		}, $messages));
+
 		return <<<EOF
 
 FILE: {$file}

--- a/PhpcsChanged/FullReporter.php
+++ b/PhpcsChanged/FullReporter.php
@@ -24,7 +24,7 @@ class FullReporter implements Reporter {
 
 		return implode("\n", array_filter(array_map(function(string $file) use ($messages): ?string {
 			$messagesForFile = array_values(array_filter($messages->getMessages(), function(PhpcsMessage $message) use ($file): bool {
-				return $message->getFile() === $file;
+				return ($message->getFile() ?? 'STDIN') === $file;
 			}));
 			return $this->getFormattedMessagesForFile($messagesForFile, $file);
 		}, $files)));

--- a/PhpcsChanged/PhpcsMessages.php
+++ b/PhpcsChanged/PhpcsMessages.php
@@ -18,6 +18,12 @@ class PhpcsMessages {
 		$this->messages = $messages;
 	}
 
+	public static function merge(array $messages): self {
+		return self::fromPhpcsMessages(array_merge(...array_map(function(PhpcsMessages $message) {
+			return $message->getMessages();
+		}, $messages)));
+	}
+
 	public static function fromPhpcsMessages(array $messages, string $fileName = null): self {
 		return new self(array_map(function(PhpcsMessage $message) use ($fileName) {
 			if ($fileName) {

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -10,6 +10,7 @@ require_once __DIR__ . '/../index.php';
 use function PhpcsChanged\Cli\{
 	printHelp,
 	printVersion,
+	printErrorAndExit,
 	getDebug,
 	runManualWorkflow,
 	runSvnWorkflow,
@@ -18,6 +19,7 @@ use function PhpcsChanged\Cli\{
 };
 use PhpcsChanged\UnixShell;
 
+$optind = 0;
 $options = getopt(
 	'h',
 	[
@@ -26,13 +28,16 @@ $options = getopt(
 		'diff:',
 		'phpcs-orig:',
 		'phpcs-new:',
-		'svn:',
-		'git:',
+		'svn',
+		'git',
 		'standard:',
 		'report:',
 		'debug',
-	]
+	],
+	$optind
 );
+
+$fileNames = array_slice($argv, $optind);
 
 if (isset($options['h']) || isset($options['help'])) {
 	printHelp();
@@ -54,13 +59,17 @@ if ($diffFile && $phpcsOldFile && $phpcsNewFile) {
 	reportMessagesAndExit(runManualWorkflow($diffFile, $phpcsOldFile, $phpcsNewFile), $reportType);
 }
 
-$svnFile = $options['svn'] ?? null;
+if (empty($fileNames)) {
+	printErrorAndExit('No files specified.');
+}
+
+$svnFile = isset($options['svn']) ? $fileNames[0] : null;
 if ($svnFile) {
 	$shell = new UnixShell();
 	reportMessagesAndExit(runSvnWorkflow($svnFile, $options, $shell, $debug), $reportType);
 }
 
-$gitFile = $options['git'] ?? null;
+$gitFile = isset($options['git']) ? $fileNames[0] : null;
 if ($gitFile) {
 	$shell = new UnixShell();
 	reportMessagesAndExit(runGitWorkflow($gitFile, $options, $shell, $debug), $reportType);

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -70,7 +70,7 @@ function run(array $options, array $fileNames, callable $debug): void {
 		return;
 	}
 
-	if ($options['svn']) {
+	if (isset($options['svn'])) {
 		$shell = new UnixShell();
 		reportMessagesAndExit(
 			runSvnWorkflow($fileNames, $options, $shell, $debug),

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -79,11 +79,10 @@ function run(array $options, array $fileNames, callable $debug): void {
 		return;
 	}
 
-	$gitFile = isset($options['git']) ? $fileNames[0] : null;
-	if ($gitFile) {
+	if (isset($options['git'])) {
 		$shell = new UnixShell();
 		reportMessagesAndExit(
-			runGitWorkflow($gitFile, $options, $shell, $debug),
+			runGitWorkflow($fileNames, $options, $shell, $debug),
 			$reportType
 		);
 		return;

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -32,7 +32,7 @@ $options = getopt(
 		'git',
 		'standard:',
 		'report:',
-		'debug',
+		'debug'
 	],
 	$optind
 );
@@ -48,31 +48,48 @@ if (isset($options['version'])) {
 }
 
 $debug = getDebug(isset($options['debug']));
-$debug('Running...');
+run($options, $fileNames, $debug);
 
-$reportType = $options['report'] ?? 'full';
-$diffFile = $options['diff'] ?? null;
-$phpcsOldFile = $options['phpcs-orig'] ?? null;
-$phpcsNewFile = $options['phpcs-new'] ?? null;
+function run(array $options, array $fileNames, callable $debug): void {
+	$debug('Running...');
+	$reportType = $options['report'] ?? 'full';
+	$diffFile = $options['diff'] ?? null;
+	$phpcsOldFile = $options['phpcs-orig'] ?? null;
+	$phpcsNewFile = $options['phpcs-new'] ?? null;
 
-if ($diffFile && $phpcsOldFile && $phpcsNewFile) {
-	reportMessagesAndExit(runManualWorkflow($diffFile, $phpcsOldFile, $phpcsNewFile), $reportType);
+	if ($diffFile && $phpcsOldFile && $phpcsNewFile) {
+		reportMessagesAndExit(
+			runManualWorkflow($diffFile, $phpcsOldFile, $phpcsNewFile),
+			$reportType
+		);
+		return;
+	}
+
+	if (empty($fileNames)) {
+		printErrorAndExit('No files specified.');
+		return;
+	}
+
+	$svnFile = isset($options['svn']) ? $fileNames[0] : null;
+	if ($svnFile) {
+		$shell = new UnixShell();
+		reportMessagesAndExit(
+			runSvnWorkflow($svnFile, $options, $shell, $debug),
+			$reportType
+		);
+		return;
+	}
+
+	$gitFile = isset($options['git']) ? $fileNames[0] : null;
+	if ($gitFile) {
+		$shell = new UnixShell();
+		reportMessagesAndExit(
+			runGitWorkflow($gitFile, $options, $shell, $debug),
+			$reportType
+		);
+		return;
+	}
+
+	printHelp();
 }
 
-if (empty($fileNames)) {
-	printErrorAndExit('No files specified.');
-}
-
-$svnFile = isset($options['svn']) ? $fileNames[0] : null;
-if ($svnFile) {
-	$shell = new UnixShell();
-	reportMessagesAndExit(runSvnWorkflow($svnFile, $options, $shell, $debug), $reportType);
-}
-
-$gitFile = isset($options['git']) ? $fileNames[0] : null;
-if ($gitFile) {
-	$shell = new UnixShell();
-	reportMessagesAndExit(runGitWorkflow($gitFile, $options, $shell, $debug), $reportType);
-}
-
-printHelp();

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -70,11 +70,10 @@ function run(array $options, array $fileNames, callable $debug): void {
 		return;
 	}
 
-	$svnFile = isset($options['svn']) ? $fileNames[0] : null;
-	if ($svnFile) {
+	if ($options['svn']) {
 		$shell = new UnixShell();
 		reportMessagesAndExit(
-			runSvnWorkflow($svnFile, $options, $shell, $debug),
+			runSvnWorkflow($fileNames, $options, $shell, $debug),
 			$reportType
 		);
 		return;

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -38,6 +38,12 @@ $options = getopt(
 );
 
 $fileNames = array_slice($argv, $optind);
+$fileNamesExpanded = array_reduce($fileNames, function(array $expandedNames, string $file): array {
+	if (is_dir($file)) {
+		return array_merge($expandedNames, glob("{$file}/**/*.php"));
+	}
+	return array_merge($expandedNames, [$file]);
+}, []);
 
 if (isset($options['h']) || isset($options['help'])) {
 	printHelp();
@@ -48,10 +54,10 @@ if (isset($options['version'])) {
 }
 
 $debug = getDebug(isset($options['debug']));
-run($options, $fileNames, $debug);
+run($options, $fileNamesExpanded, $debug);
 
-function run(array $options, array $fileNames, callable $debug): void {
-	$debug('Running...');
+function run(array $options, array $fileNamesExpanded, callable $debug): void {
+	$debug('Running on filenames: ' . implode(', ', $fileNamesExpanded));
 	$reportType = $options['report'] ?? 'full';
 	$diffFile = $options['diff'] ?? null;
 	$phpcsOldFile = $options['phpcs-orig'] ?? null;
@@ -65,7 +71,7 @@ function run(array $options, array $fileNames, callable $debug): void {
 		return;
 	}
 
-	if (empty($fileNames)) {
+	if (empty($fileNamesExpanded)) {
 		printErrorAndExit('No files specified.');
 		return;
 	}
@@ -73,7 +79,7 @@ function run(array $options, array $fileNames, callable $debug): void {
 	if (isset($options['svn'])) {
 		$shell = new UnixShell();
 		reportMessagesAndExit(
-			runSvnWorkflow($fileNames, $options, $shell, $debug),
+			runSvnWorkflow($fileNamesExpanded, $options, $shell, $debug),
 			$reportType
 		);
 		return;
@@ -82,7 +88,7 @@ function run(array $options, array $fileNames, callable $debug): void {
 	if (isset($options['git'])) {
 		$shell = new UnixShell();
 		reportMessagesAndExit(
-			runGitWorkflow($fileNames, $options, $shell, $debug),
+			runGitWorkflow($fileNamesExpanded, $options, $shell, $debug),
 			$reportType
 		);
 		return;

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "prefer-stable": true,
     "scripts": {
         "test": "./vendor/bin/phpunit --color=always --verbose",
-        "lint": "./vendor/bin/phpcs -s PhpcsChanged/",
+        "lint": "./vendor/bin/phpcs -s PhpcsChanged bin tests index.php",
         "phpstan": "./vendor/bin/phpstan analyze PhpcsChanged/"
     },
     "bin": [

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
     "prefer-stable": true,
     "scripts": {
         "test": "./vendor/bin/phpunit --color=always --verbose",
+        "lint": "./vendor/bin/phpcs -s PhpcsChanged/",
         "phpstan": "./vendor/bin/phpstan analyze PhpcsChanged/"
     },
     "bin": [

--- a/tests/GitWorkflowTest.php
+++ b/tests/GitWorkflowTest.php
@@ -117,7 +117,7 @@ EOF;
 				'message' => 'Found unused symbol Emergent.',
 			],
 		], 'bin/foobar.php');
-		$messages = runGitWorkflow($gitFile, $options, $shell, $debug);
+		$messages = runGitWorkflow([$gitFile], $options, $shell, $debug);
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 
@@ -154,7 +154,7 @@ EOF;
 		};
 		$options = [];
 		$expected = PhpcsMessages::fromArrays([], '/dev/null');
-		$messages = runGitWorkflow($gitFile, $options, $shell, $debug);
+		$messages = runGitWorkflow([$gitFile], $options, $shell, $debug);
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 
@@ -191,7 +191,7 @@ EOF;
 		};
 		$options = [];
 		$expected = PhpcsMessages::fromArrays([], '/dev/null');
-		$messages = runGitWorkflow($gitFile, $options, $shell, $debug);
+		$messages = runGitWorkflow([$gitFile], $options, $shell, $debug);
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 
@@ -228,7 +228,7 @@ EOF;
 			}
 		};
 		$options = [];
-		runGitWorkflow($gitFile, $options, $shell, $debug);
+		runGitWorkflow([$gitFile], $options, $shell, $debug);
 	}
 
 	public function testFullGitWorkflowForNewFile() {
@@ -294,7 +294,7 @@ EOF;
 				'message' => 'Found unused symbol Emergent.',
 			],
 		], '/dev/null');
-		$messages = runGitWorkflow($gitFile, $options, $shell, $debug);
+		$messages = runGitWorkflow([$gitFile], $options, $shell, $debug);
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 
@@ -345,7 +345,7 @@ Run "phpcs --help" for usage information
 		};
 		$options = [];
 		$expected = PhpcsMessages::fromArrays([], '/dev/null');
-		$messages = runGitWorkflow($gitFile, $options, $shell, $debug);
+		$messages = runGitWorkflow([$gitFile], $options, $shell, $debug);
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 }

--- a/tests/SvnWorkflowTest.php
+++ b/tests/SvnWorkflowTest.php
@@ -43,7 +43,7 @@ Schedule: add
 			return "Path: foobar.php
 Name: foobar.php
 Working Copy Root Path: /home/public_html
-URL: https://svn.localhost/trunk/wp-content/mu-plugins/gdpr.php
+URL: https://svn.localhost/trunk/wp-content/mu-plugins/foobar.php
 Relative URL: ^/trunk/foobar.php
 Repository Root: https://svn.localhost
 Repository UUID: 1111-1111-1111-1111
@@ -88,7 +88,7 @@ EOF;
 		$this->assertEquals($diff, getSvnUnifiedDiff($svnFile, $svn, $executeCommand, $debug));
 	}
 
-	public function testFullSvnWorkflow() {
+	public function testFullSvnWorkflowForOneFile() {
 		$svnFile = 'foobar.php';
 		$debug = function($message) {}; //phpcs:ignore VariableAnalysis
 		$shell = new class() implements ShellOperator {
@@ -124,7 +124,7 @@ EOF;
 Path: foobar.php
 Name: foobar.php
 Working Copy Root Path: /home/public_html
-URL: https://svn.localhost/trunk/wp-content/mu-plugins/gdpr.php
+URL: https://svn.localhost/trunk/wp-content/mu-plugins/foobar.php
 Relative URL: ^/trunk/foobar.php
 Repository Root: https://svn.localhost
 Repository UUID: 1111-1111-1111-1111
@@ -163,6 +163,136 @@ EOF;
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 
+	public function testFullSvnWorkflowForMultipleFiles() {
+		$svnFiles = ['foobar.php', 'baz.php'];
+		$debug = function($message) {}; //phpcs:ignore VariableAnalysis
+		$shell = new class() implements ShellOperator {
+			public function isReadable(string $fileName): bool {
+				return ($fileName === 'foobar.php' || $fileName === 'baz.php');
+			}
+
+			public function validateExecutableExists(string $name, string $command): void {} // phpcs:ignore VariableAnalysis
+
+			public function printError(string $message): void {} // phpcs:ignore VariableAnalysis
+
+			public function exitWithCode(int $code): void {} // phpcs:ignore VariableAnalysis
+
+			public function executeCommand(string $command): string {
+				if (false !== strpos($command, "svn diff 'foobar.php'")) {
+					return <<<EOF
+Index: foobar.php
+===================================================================
+--- bin/foobar.php	(revision 183265)
++++ bin/foobar.php	(working copy)
+@@ -17,6 +17,7 @@
+ use Billing\Purchases\Order;
+ use Billing\Services;
+ use Billing\Ebanx;
++use Foobar;
+ use Billing\Emergent;
+ use Billing\Monetary_Amount;
+ use Stripe\Error;
+EOF;
+				}
+				if (false !== strpos($command, "svn diff 'baz.php'")) {
+					return <<<EOF
+Index: baz.php
+===================================================================
+--- bin/baz.php	(revision 183265)
++++ bin/baz.php	(working copy)
+@@ -17,6 +17,7 @@
+ use Billing\Purchases\Order;
+ use Billing\Services;
+ use Billing\Ebanx;
++use Baz;
+ use Billing\Emergent;
+ use Billing\Monetary_Amount;
+ use Stripe\Error;
+EOF;
+				}
+				if (false !== strpos($command, "svn info 'foobar.php'")) {
+					return <<<EOF
+Path: foobar.php
+Name: foobar.php
+Working Copy Root Path: /home/public_html
+URL: https://svn.localhost/trunk/wp-content/mu-plugins/foobar.php
+Relative URL: ^/trunk/foobar.php
+Repository Root: https://svn.localhost
+Repository UUID: 1111-1111-1111-1111
+Revision: 188280
+Node Kind: file
+Schedule: normal
+Last Changed Author: me
+Last Changed Rev: 175729
+Last Changed Date: 2018-05-22 17:34:00 +0000 (Tue, 22 May 2018)
+Text Last Updated: 2018-05-22 17:34:00 +0000 (Tue, 22 May 2018)
+Checksum: abcdefg
+EOF;
+				}
+				if (false !== strpos($command, "svn info 'baz.php'")) {
+					return <<<EOF
+Path: baz.php
+Name: baz.php
+Working Copy Root Path: /home/public_html
+URL: https://svn.localhost/trunk/wp-content/mu-plugins/baz.php
+Relative URL: ^/trunk/baz.php
+Repository Root: https://svn.localhost
+Repository UUID: 1111-1111-1111-1111
+Revision: 188280
+Node Kind: file
+Schedule: normal
+Last Changed Author: me
+Last Changed Rev: 175729
+Last Changed Date: 2018-05-22 17:34:00 +0000 (Tue, 22 May 2018)
+Text Last Updated: 2018-05-22 17:34:00 +0000 (Tue, 22 May 2018)
+Checksum: abcdefg
+EOF;
+				}
+				if (false !== strpos($command, "svn cat 'foobar.php'")) {
+					return '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":99,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}';
+				}
+				if (false !== strpos($command, "cat 'foobar.php'")) {
+					return '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":21,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}';
+				}
+				if (false !== strpos($command, "svn cat 'baz.php'")) {
+					return '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Baz."},{"line":99,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Baz."}]}}}';
+				}
+				if (false !== strpos($command, "cat 'baz.php'")) {
+					return '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Baz."},{"line":21,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Baz."}]}}}';
+				}
+				return '';
+			}
+		};
+		$options = [];
+		$expected = PhpcsMessages::merge([
+			PhpcsMessages::fromArrays([
+				[
+					'type' => 'ERROR',
+					'severity' => 5,
+					'fixable' => false,
+					'column' => 5,
+					'source' => 'ImportDetection.Imports.RequireImports.Import',
+					'line' => 20,
+					'message' => 'Found unused symbol Emergent.',
+				],
+			], 'bin/foobar.php'),
+			PhpcsMessages::fromArrays([
+				[
+					'type' => 'ERROR',
+					'severity' => 5,
+					'fixable' => false,
+					'column' => 5,
+					'source' => 'ImportDetection.Imports.RequireImports.Import',
+					'line' => 20,
+					'message' => 'Found unused symbol Baz.',
+				],
+			], 'bin/baz.php'),
+		]);
+		$messages = runSvnWorkflow($svnFiles, $options, $shell, $debug);
+		var_dump($expected->getMessages());
+		$this->assertEquals($expected->getMessages(), $messages->getMessages());
+	}
+
 	public function testFullSvnWorkflowForUnchangedFileWithPhpCsMessages() {
 		$svnFile = 'foobar.php';
 		$debug = function($message) {}; //phpcs:ignore VariableAnalysis
@@ -187,7 +317,7 @@ EOF;
 Path: foobar.php
 Name: foobar.php
 Working Copy Root Path: /home/public_html
-URL: https://svn.localhost/trunk/wp-content/mu-plugins/gdpr.php
+URL: https://svn.localhost/trunk/wp-content/mu-plugins/foobar.php
 Relative URL: ^/trunk/foobar.php
 Repository Root: https://svn.localhost
 Repository UUID: 1111-1111-1111-1111
@@ -240,7 +370,7 @@ EOF;
 Path: foobar.php
 Name: foobar.php
 Working Copy Root Path: /home/public_html
-URL: https://svn.localhost/trunk/wp-content/mu-plugins/gdpr.php
+URL: https://svn.localhost/trunk/wp-content/mu-plugins/foobar.php
 Relative URL: ^/trunk/foobar.php
 Repository Root: https://svn.localhost
 Repository UUID: 1111-1111-1111-1111

--- a/tests/SvnWorkflowTest.php
+++ b/tests/SvnWorkflowTest.php
@@ -289,7 +289,6 @@ EOF;
 			], 'bin/baz.php'),
 		]);
 		$messages = runSvnWorkflow($svnFiles, $options, $shell, $debug);
-		var_dump($expected->getMessages());
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 

--- a/tests/SvnWorkflowTest.php
+++ b/tests/SvnWorkflowTest.php
@@ -159,7 +159,7 @@ EOF;
 				'message' => 'Found unused symbol Emergent.',
 			],
 		], 'bin/foobar.php');
-		$messages = runSvnWorkflow($svnFile, $options, $shell, $debug);
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, $debug);
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 
@@ -212,7 +212,7 @@ EOF;
 		};
 		$options = [];
 		$expected = PhpcsMessages::fromArrays([], 'STDIN');
-		$messages = runSvnWorkflow($svnFile, $options, $shell, $debug);
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, $debug);
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 
@@ -265,7 +265,7 @@ EOF;
 		};
 		$options = [];
 		$expected = PhpcsMessages::fromArrays([], 'STDIN');
-		$messages = runSvnWorkflow($svnFile, $options, $shell, $debug);
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, $debug);
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 
@@ -307,7 +307,7 @@ EOF;
 			}
 		};
 		$options = [];
-		runSvnWorkflow($svnFile, $options, $shell, $debug);
+		runSvnWorkflow([$svnFile], $options, $shell, $debug);
 	}
 
 	public function testFullSvnWorkflowForNewFile() {
@@ -378,7 +378,7 @@ EOF;
 				'message' => 'Found unused symbol Emergent.',
 			],
 		], 'STDIN');
-		$messages = runSvnWorkflow($svnFile, $options, $shell, $debug);
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, $debug);
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 
@@ -434,7 +434,7 @@ Run "phpcs --help" for usage information
 		$debug = function($message) {}; //phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		$options = [];
 		$expected = PhpcsMessages::fromArrays([], 'STDIN');
-		$messages = runSvnWorkflow($svnFile, $options, $shell, $debug);
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, $debug);
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 }


### PR DESCRIPTION
Currently `phpcs-changed` operates only on one file at a time, but there's no good reason for this. This PR modifies the tool to be able to run on a list of files, both via the API and on the command-line.
