### PR TITLE
Improve git mode

### DIFF
--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -224,7 +224,7 @@ function runGitWorkflowForFile(string $gitFile, array $options, ShellOperator $s
 
 	try {
 		validateGitFileExists($gitFile, $git, [$shell, 'isReadable'], [$shell, 'executeCommand'], $debug);
-		$unifiedDiff = getGitUnifiedDiff($gitFile, $git, [$shell, 'executeCommand'], $debug);
+		$unifiedDiff = getGitUnifiedDiff($gitFile, $git, [$shell, 'executeCommand'], $options, $debug);
 		$isNewFile = isNewGitFile($gitFile, $git, [$shell, 'executeCommand'], $debug);
 		$oldFilePhpcsOutput = $isNewFile ? '' : getGitBasePhpcsOutput($gitFile, $git, $phpcs, $phpcsStandardOption, [$shell, 'executeCommand'], $debug);
 		$newFilePhpcsOutput = getGitNewPhpcsOutput($gitFile, $phpcs, $cat, $phpcsStandardOption, [$shell, 'executeCommand'], $debug);

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -226,7 +226,7 @@ function runGitWorkflowForFile(string $gitFile, array $options, ShellOperator $s
 		validateGitFileExists($gitFile, $git, [$shell, 'isReadable'], [$shell, 'executeCommand'], $debug);
 		$unifiedDiff = getGitUnifiedDiff($gitFile, $git, [$shell, 'executeCommand'], $options, $debug);
 		$isNewFile = isNewGitFile($gitFile, $git, [$shell, 'executeCommand'], $debug);
-		$oldFilePhpcsOutput = $isNewFile ? '' : getGitBasePhpcsOutput($gitFile, $git, $phpcs, $phpcsStandardOption, [$shell, 'executeCommand'], $debug);
+		$oldFilePhpcsOutput = $isNewFile ? '' : getGitBasePhpcsOutput($gitFile, $git, $phpcs, $phpcsStandardOption, [$shell, 'executeCommand'], $options, $debug);
 		$newFilePhpcsOutput = getGitNewPhpcsOutput($gitFile, $phpcs, $cat, $phpcsStandardOption, [$shell, 'executeCommand'], $debug);
 	} catch( NoChangesException $err ) {
 		$debug($err->getMessage());

--- a/PhpcsChanged/GitWorkflow.php
+++ b/PhpcsChanged/GitWorkflow.php
@@ -45,8 +45,9 @@ function isNewGitFile(string $gitFile, string $git, callable $executeCommand, ca
 	return isset($gitStatusOutput[0]) && $gitStatusOutput[0] === 'A';
 }
 
-function getGitBasePhpcsOutput(string $gitFile, string $git, string $phpcs, string $phpcsStandardOption, callable $executeCommand, callable $debug): string {
-	$oldFilePhpcsOutputCommand = "${git} show HEAD:$(${git} ls-files --full-name " . escapeshellarg($gitFile) . ") | {$phpcs} --report=json -q" . $phpcsStandardOption . ' --stdin-path=' .  escapeshellarg($gitFile) . ' -';
+function getGitBasePhpcsOutput(string $gitFile, string $git, string $phpcs, string $phpcsStandardOption, callable $executeCommand, array $options, callable $debug): string {
+	$rev = isset($options['git-unstaged']) ? ':0' : 'HEAD';
+	$oldFilePhpcsOutputCommand = "${git} show {$rev}:$(${git} ls-files --full-name " . escapeshellarg($gitFile) . ") | {$phpcs} --report=json -q" . $phpcsStandardOption . ' --stdin-path=' .  escapeshellarg($gitFile) . ' -';
 	$debug('running orig phpcs command:', $oldFilePhpcsOutputCommand);
 	$oldFilePhpcsOutput = $executeCommand($oldFilePhpcsOutputCommand);
 	if (! $oldFilePhpcsOutput) {

--- a/PhpcsChanged/GitWorkflow.php
+++ b/PhpcsChanged/GitWorkflow.php
@@ -45,7 +45,7 @@ function isNewGitFile(string $gitFile, string $git, callable $executeCommand, ca
 }
 
 function getGitBasePhpcsOutput(string $gitFile, string $git, string $phpcs, string $phpcsStandardOption, callable $executeCommand, callable $debug): string {
-	$oldFilePhpcsOutputCommand = "${git} show HEAD:" . escapeshellarg($gitFile) . " | {$phpcs} --report=json -q" . $phpcsStandardOption . ' --stdin-path=' .  escapeshellarg($gitFile) . ' -';
+	$oldFilePhpcsOutputCommand = "${git} show HEAD:$(${git} ls-files --full-name " . escapeshellarg($gitFile) . ") | {$phpcs} --report=json -q" . $phpcsStandardOption . ' --stdin-path=' .  escapeshellarg($gitFile) . ' -';
 	$debug('running orig phpcs command:', $oldFilePhpcsOutputCommand);
 	$oldFilePhpcsOutput = $executeCommand($oldFilePhpcsOutputCommand);
 	if (! $oldFilePhpcsOutput) {

--- a/PhpcsChanged/GitWorkflow.php
+++ b/PhpcsChanged/GitWorkflow.php
@@ -19,8 +19,9 @@ function validateGitFileExists(string $gitFile, string $git, callable $isReadabl
 	}
 }
 
-function getGitUnifiedDiff(string $gitFile, string $git, callable $executeCommand, callable $debug): string {
-	$unifiedDiffCommand = "{$git} diff --staged --no-prefix " . escapeshellarg($gitFile);
+function getGitUnifiedDiff(string $gitFile, string $git, callable $executeCommand, array $options, callable $debug): string {
+	$stagedOption = isset($options['git-unstaged']) ? '' : ' --staged';
+	$unifiedDiffCommand = "{$git} diff{$stagedOption} --no-prefix " . escapeshellarg($gitFile);
 	$debug('running diff command:', $unifiedDiffCommand);
 	$unifiedDiff = $executeCommand($unifiedDiffCommand);
 	if (! $unifiedDiff) {

--- a/README.md
+++ b/README.md
@@ -75,11 +75,13 @@ Or, with `--report json`:
 }
 ```
 
-If the file was versioned by git, we can do the same with the `--git` option (note that this operates only on _staged_ changes):
+If the file was versioned by git, we can do the same with the `--git` option:
 
 ```
-phpcs-changed --git file.php
+phpcs-changed --git --git-unstaged file.php
 ```
+
+You should specify `--git-staged` or `--git-unstaged` to tell `phpcs-changed` if you want to compare the current staged changes or the current working copy changes, respectively. The default is `--git-staged`.
 
 ### CLI Options
 

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -30,6 +30,8 @@ $options = getopt(
 		'phpcs-new:',
 		'svn',
 		'git',
+		'git-unstaged',
+		'git-staged',
 		'standard:',
 		'report:',
 		'debug'

--- a/tests/GitWorkflowTest.php
+++ b/tests/GitWorkflowTest.php
@@ -96,7 +96,7 @@ EOF;
 				if (false !== strpos($command, "git status --short 'foobar.php'")) {
 					return ' M foobar.php'; // note the leading space
 				}
-				if (false !== strpos($command, "git show HEAD:'foobar.php'")) {
+				if (false !== strpos($command, "git show HEAD:$(git ls-files --full-name 'foobar.php')")) {
 					return '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":99,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}';
 				}
 				if (false !== strpos($command, "cat 'foobar.php'")) {
@@ -174,10 +174,10 @@ EOF;
 				if (false !== strpos($command, "git status --short 'baz.php'")) {
 					return ' M baz.php'; // note the leading space
 				}
-				if (false !== strpos($command, "git show HEAD:'foobar.php'")) {
+				if (false !== strpos($command, "git show HEAD:$(git ls-files --full-name 'foobar.php')")) {
 					return '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":99,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}';
 				}
-				if (false !== strpos($command, "git show HEAD:'baz.php'")) {
+				if (false !== strpos($command, "git show HEAD:$(git ls-files --full-name 'baz.php')")) {
 					return '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Baz."},{"line":99,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Baz."}]}}}';
 				}
 				if (false !== strpos($command, "cat 'foobar.php'")) {
@@ -240,7 +240,7 @@ EOF;
 				if (false !== strpos($command, "git status --short 'foobar.php'")) {
 					return '';
 				}
-				if (false !== strpos($command, "git show HEAD:'foobar.php'")) {
+				if (false !== strpos($command, "git show HEAD:$(git ls-files --full-name 'foobar.php')")) {
 					return '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":99,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}';
 				}
 				if (false !== strpos($command, "cat 'foobar.php'")) {
@@ -277,7 +277,7 @@ EOF;
 				if (false !== strpos($command, "git status --short 'foobar.php'")) {
 					return '';
 				}
-				if (false !== strpos($command, "git show HEAD:'foobar.php'")) {
+				if (false !== strpos($command, "git show HEAD:$(git ls-files --full-name 'foobar.php')")) {
 					return '{"totals":{"errors":0,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":0,"warnings":0,"messages":[]}}}';
 				}
 				if (false !== strpos($command, "cat 'foobar.php'")) {
@@ -315,7 +315,7 @@ EOF;
 				if (false !== strpos($command, "git status --short 'foobar.php'")) {
 					return "?? foobar.php";
 				}
-				if (false !== strpos($command, "git show HEAD:'foobar.php'")) {
+				if (false !== strpos($command, "git show HEAD:$(git ls-files --full-name 'foobar.php')")) {
 					return "fatal: Path 'foobar.php' exists on disk, but not in 'HEAD'.";
 				}
 				if (false !== strpos($command, "cat 'foobar.php'")) {

--- a/tests/GitWorkflowTest.php
+++ b/tests/GitWorkflowTest.php
@@ -59,7 +59,7 @@ EOF;
 			return $diff;
 		};
 		$debug = function($message) {}; //phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		$this->assertEquals($diff, getGitUnifiedDiff($gitFile, $git, $executeCommand, $debug));
+		$this->assertEquals($diff, getGitUnifiedDiff($gitFile, $git, $executeCommand, [], $debug));
 	}
 
 	public function testFullGitWorkflowForOneFile() {

--- a/tests/GitWorkflowTest.php
+++ b/tests/GitWorkflowTest.php
@@ -155,7 +155,7 @@ EOF;
 				if (false !== strpos($command, "git status --short 'foobar.php'")) {
 					return ' M foobar.php'; // note the leading space
 				}
-				if (false !== strpos($command, "git show HEAD:$(git ls-files --full-name 'foobar.php')")) {
+				if (false !== strpos($command, "git show :0:$(git ls-files --full-name 'foobar.php')")) {
 					return '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":99,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}';
 				}
 				if (false !== strpos($command, "cat 'foobar.php'")) {


### PR DESCRIPTION
Git mode has a few issues which this PR should improve.

- You'll be able to run `phpcs-changed --git` on a file when you are not in the git root directory.
- You'll be able to specify `--git-staged` or `--git-unstaged` to compare staged or unstaged changes, respectively.