### PR TITLE
Make sure to only include one of each file in reporters

### DIFF
--- a/PhpcsChanged/FullReporter.php
+++ b/PhpcsChanged/FullReporter.php
@@ -10,9 +10,9 @@ use function PhpcsChanged\Cli\getLongestString;
 
 class FullReporter implements Reporter {
 	public function getFormattedMessages(PhpcsMessages $messages): string {
-		$files = array_map(function(PhpcsMessage $message): string {
+		$files = array_unique(array_map(function(PhpcsMessage $message): string {
 			return $message->getFile() ?? 'STDIN';
-		}, $messages->getMessages());
+		}, $messages->getMessages()));
 		if (empty($files)) {
 			$files = ['STDIN'];
 		}

--- a/PhpcsChanged/JsonReporter.php
+++ b/PhpcsChanged/JsonReporter.php
@@ -9,9 +9,9 @@ use PhpcsChanged\PhpcsMessage;
 
 class JsonReporter implements Reporter {
 	public function getFormattedMessages(PhpcsMessages $messages): string {
-		$files = array_map(function(PhpcsMessage $message): string {
+		$files = array_unique(array_map(function(PhpcsMessage $message): string {
 			return $message->getFile() ?? 'STDIN';
-		}, $messages->getMessages());
+		}, $messages->getMessages()));
 		if (empty($files)) {
 			$files = ['STDIN'];
 		}


### PR DESCRIPTION
This prevents the reporters displaying the output of a single file multiple times if there are multiple errors.