### PR TITLE
Add show sniff codes option

### DIFF
--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -244,8 +244,8 @@ function runGitWorkflowForFile(string $gitFile, array $options, ShellOperator $s
 	return getNewPhpcsMessages($unifiedDiff, PhpcsMessages::fromPhpcsJson($oldFilePhpcsOutput, $fileName), PhpcsMessages::fromPhpcsJson($newFilePhpcsOutput, $fileName));
 }
 
-function reportMessagesAndExit(PhpcsMessages $messages, string $reportType): void {
+function reportMessagesAndExit(PhpcsMessages $messages, string $reportType, array $options): void {
 	$reporter = getReporter($reportType);
-	echo $reporter->getFormattedMessages($messages);
+	echo $reporter->getFormattedMessages($messages, $options);
 	exit($reporter->getExitCode($messages));
 }

--- a/PhpcsChanged/FullReporter.php
+++ b/PhpcsChanged/FullReporter.php
@@ -9,7 +9,7 @@ use PhpcsChanged\PhpcsMessage;
 use function PhpcsChanged\Cli\getLongestString;
 
 class FullReporter implements Reporter {
-	public function getFormattedMessages(PhpcsMessages $messages): string {
+	public function getFormattedMessages(PhpcsMessages $messages, array $options): string {
 		$files = array_unique(array_map(function(PhpcsMessage $message): string {
 			return $message->getFile() ?? 'STDIN';
 		}, $messages->getMessages()));
@@ -22,15 +22,15 @@ class FullReporter implements Reporter {
 			return '';
 		}
 
-		return implode("\n", array_filter(array_map(function(string $file) use ($messages): ?string {
+		return implode("\n", array_filter(array_map(function(string $file) use ($messages, $options): ?string {
 			$messagesForFile = array_values(array_filter($messages->getMessages(), function(PhpcsMessage $message) use ($file): bool {
 				return ($message->getFile() ?? 'STDIN') === $file;
 			}));
-			return $this->getFormattedMessagesForFile($messagesForFile, $file);
+			return $this->getFormattedMessagesForFile($messagesForFile, $file, $options);
 		}, $files)));
 	}
 
-	private function getFormattedMessagesForFile(array $messages, string $file): ?string {
+	private function getFormattedMessagesForFile(array $messages, string $file, array $options): ?string {
 		$lineCount = count($messages);
 		if ($lineCount < 1) {
 			return null;

--- a/PhpcsChanged/FullReporter.php
+++ b/PhpcsChanged/FullReporter.php
@@ -50,8 +50,10 @@ class FullReporter implements Reporter {
 			return $message->getLineNumber();
 		}, $messages));
 
-		$formattedLines = implode("\n", array_map(function(PhpcsMessage $message) use ($longestNumber): string {
-			return sprintf(" %{$longestNumber}d | %s | %s", $message->getLineNumber(), $message->getType(), $message->getMessage());
+		$formattedLines = implode("\n", array_map(function(PhpcsMessage $message) use ($longestNumber, $options): string {
+			$source = $message->getSource() ?: 'Unknown';
+			$sourceString = isset($options['s']) ? " ({$source})" : '';
+			return sprintf(" %{$longestNumber}d | %s | %s%s", $message->getLineNumber(), $message->getType(), $message->getMessage(), $sourceString);
 		}, $messages));
 
 		return <<<EOF

--- a/PhpcsChanged/JsonReporter.php
+++ b/PhpcsChanged/JsonReporter.php
@@ -8,7 +8,7 @@ use PhpcsChanged\PhpcsMessages;
 use PhpcsChanged\PhpcsMessage;
 
 class JsonReporter implements Reporter {
-	public function getFormattedMessages(PhpcsMessages $messages): string {
+	public function getFormattedMessages(PhpcsMessages $messages, array $options): string {
 		$files = array_unique(array_map(function(PhpcsMessage $message): string {
 			return $message->getFile() ?? 'STDIN';
 		}, $messages->getMessages()));

--- a/PhpcsChanged/PhpcsMessage.php
+++ b/PhpcsChanged/PhpcsMessage.php
@@ -36,6 +36,10 @@ class PhpcsMessage {
 		return $this->otherProperties['message'] ?? '';
 	}
 
+	public function getSource(): string {
+		return $this->otherProperties['source'] ?? '';
+	}
+
 	public function toPhpcsArray(): array {
 		return array_merge([
 			'line' => $this->line,

--- a/PhpcsChanged/PhpcsMessages.php
+++ b/PhpcsChanged/PhpcsMessages.php
@@ -78,6 +78,6 @@ class PhpcsMessages {
 
 	public function toPhpcsJson(): string {
 		$reporter = new JsonReporter();
-		return $reporter->getFormattedMessages($this);
+		return $reporter->getFormattedMessages($this, []);
 	}
 }

--- a/PhpcsChanged/Reporter.php
+++ b/PhpcsChanged/Reporter.php
@@ -6,6 +6,6 @@ namespace PhpcsChanged;
 use PhpcsChanged\PhpcsMessages;
 
 interface Reporter {
-	public function getFormattedMessages(PhpcsMessages $messages): string;
+	public function getFormattedMessages(PhpcsMessages $messages, array $options): string;
 	public function getExitCode(PhpcsMessages $messages): int;
 }

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ You can use `--report` to customize the output type. `full` (the default) is hum
 
 You can use `--standard` to specify a specific phpcs standard to run. This matches the phpcs option of the same name.
 
+You can also use the `-s` option to Always show sniff codes after each error in the full reporter. This matches the phpcs option of the same name.
+
 ## PHP Library
 
 🐘🐘🐘

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -21,7 +21,7 @@ use PhpcsChanged\UnixShell;
 
 $optind = 0;
 $options = getopt(
-	'h',
+	'hs',
 	[
 		'help',
 		'version',

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -68,7 +68,8 @@ function run(array $options, array $fileNamesExpanded, callable $debug): void {
 	if ($diffFile && $phpcsOldFile && $phpcsNewFile) {
 		reportMessagesAndExit(
 			runManualWorkflow($diffFile, $phpcsOldFile, $phpcsNewFile),
-			$reportType
+			$reportType,
+			$options
 		);
 		return;
 	}
@@ -82,7 +83,8 @@ function run(array $options, array $fileNamesExpanded, callable $debug): void {
 		$shell = new UnixShell();
 		reportMessagesAndExit(
 			runSvnWorkflow($fileNamesExpanded, $options, $shell, $debug),
-			$reportType
+			$reportType,
+			$options
 		);
 		return;
 	}
@@ -91,7 +93,8 @@ function run(array $options, array $fileNamesExpanded, callable $debug): void {
 		$shell = new UnixShell();
 		reportMessagesAndExit(
 			runGitWorkflow($fileNamesExpanded, $options, $shell, $debug),
-			$reportType
+			$reportType,
+			$options
 		);
 		return;
 	}


### PR DESCRIPTION
This adds the `-s` option available on phpcs to phpcs-changed.