### PR TITLE
Fix the filenames expasions

### DIFF
--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -40,12 +40,19 @@ $options = getopt(
 );
 
 $fileNames = array_slice($argv, $optind);
-$fileNamesExpanded = array_reduce($fileNames, function(array $expandedNames, string $file): array {
-	if (is_dir($file)) {
-		return array_merge($expandedNames, glob("{$file}/**/*.php"));
+$fileNamesExpanded = [];
+foreach( $fileNames as $file ) {
+	if ( is_dir($file) ) {
+		$iterator = new RecursiveIteratorIterator(new RecursiveCallbackFilterIterator(new RecursiveDirectoryIterator($file, (RecursiveDirectoryIterator::SKIP_DOTS | FilesystemIterator::FOLLOW_SYMLINKS)), function($file, $key, $iterator){
+			return $iterator->hasChildren() || ( $file->isFile() && '.php' === substr($file->getFilename(),-4) ) ? true : false;
+		}));
+		foreach( $iterator as $file ) {
+			$fileNamesExpanded[] = $file->getPathName();
+		}
+	} else {
+		$fileNamesExpanded[] = $file;
 	}
-	return array_merge($expandedNames, [$file]);
-}, []);
+}
 
 if (isset($options['h']) || isset($options['help'])) {
 	printHelp();


### PR DESCRIPTION
The current implementation via glob ignores .php files in current dir in case `.` is passed as file list, and also ignores nested directories.

To fix the issue, this commit introduces a more solid implementation via `RecursiveDirectoryIterator` with appropriate filtering.

The issue can be demonstrated when running the phpcs-changed eg.: for the [liveblog](https://github.com/Automattic/liveblog) plugin from within the root directory of the plugin. In such case, the following files are ignored:

```
./liveblog.php
./templates/amp/feed.ph
./templates/amp/pagination.ph
./templates/amp/entry.php
./templates/amp/author.php
```