### PR TITLE
Add support for inter branch diffs

### DIFF
--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -248,7 +248,7 @@ function runGitWorkflowForFile(string $gitFile, array $options, ShellOperator $s
 	try {
 		validateGitFileExists($gitFile, $git, [$shell, 'isReadable'], [$shell, 'executeCommand'], $debug);
 		$unifiedDiff = getGitUnifiedDiff($gitFile, $git, [$shell, 'executeCommand'], $options, $debug);
-		$isNewFile = isNewGitFile($gitFile, $git, [$shell, 'executeCommand'], $debug);
+		$isNewFile = isNewGitFile($gitFile, $git, [$shell, 'executeCommand'], $options, $debug);
 		$oldFilePhpcsOutput = $isNewFile ? '' : getGitBasePhpcsOutput($gitFile, $git, $phpcs, $phpcsStandardOption, [$shell, 'executeCommand'], $options, $debug);
 		$newFilePhpcsOutput = getGitNewPhpcsOutput($gitFile, $phpcs, $cat, $phpcsStandardOption, [$shell, 'executeCommand'], $debug);
 	} catch( NoChangesException $err ) {

--- a/PhpcsChanged/GitWorkflow.php
+++ b/PhpcsChanged/GitWorkflow.php
@@ -43,9 +43,11 @@ function isNewGitFile(string $gitFile, string $git, callable $executeCommand, ar
 function isNewGitFileRemote(string $gitFile, string $git, callable $executeCommand, array $options, callable $debug): bool {
 	$gitStatusCommand = "${git} cat-file -e " . escapeshellarg($options['git-branch']) . ':' . escapeshellarg($gitFile);
 	$debug('checking status of file with command:', $gitStatusCommand);
-	$gitStatusOutput = $executeCommand($gitStatusCommand, $gitStatusOutput, $retVal);
+	$gitStatusOutput = array();
+	$return_val = 0;
+	$gitStatusOutput = $executeCommand($gitStatusCommand, $gitStatusOutput, $return_val);
 	$debug('status command output:', $gitStatusOutput);
-	$debug('status command return val:', $retVal);
+	$debug('status command return val:', $return_val);
 	return 0 !== $return_val;
 }
 

--- a/PhpcsChanged/GitWorkflow.php
+++ b/PhpcsChanged/GitWorkflow.php
@@ -64,7 +64,11 @@ function isNewGitFileLocal(string $gitFile, string $git, callable $executeComman
 }
 
 function getGitBasePhpcsOutput(string $gitFile, string $git, string $phpcs, string $phpcsStandardOption, callable $executeCommand, array $options, callable $debug): string {
-	$rev = isset($options['git-unstaged']) ? ':0' : 'HEAD';
+	if ( isset($options['git-branch']) && ! empty($options['git-branch']) ) {
+		$rev = escapeshellarg($options['git-branch']);
+	} else {
+		$rev = empty( $branchOption ) && isset($options['git-unstaged']) ? ':0' : 'HEAD';
+	}
 	$oldFilePhpcsOutputCommand = "${git} show {$rev}:$(${git} ls-files --full-name " . escapeshellarg($gitFile) . ") | {$phpcs} --report=json -q" . $phpcsStandardOption . ' --stdin-path=' .  escapeshellarg($gitFile) . ' -';
 	$debug('running orig phpcs command:', $oldFilePhpcsOutputCommand);
 	$oldFilePhpcsOutput = $executeCommand($oldFilePhpcsOutputCommand);

--- a/PhpcsChanged/GitWorkflow.php
+++ b/PhpcsChanged/GitWorkflow.php
@@ -43,7 +43,9 @@ function isNewGitFile(string $gitFile, string $git, callable $executeCommand, ar
 function isNewGitFileRemote(string $gitFile, string $git, callable $executeCommand, array $options, callable $debug): bool {
 	$gitStatusCommand = "${git} cat-file -e " . escapeshellarg($options['git-branch']) . ':' . escapeshellarg($gitFile);
 	$debug('checking status of file with command:', $gitStatusCommand);
-	$gitStatusOutput = $executeCommand($gitStatusCommand, $gitStatusOutput = array(), $return_val = 1);
+	$return_val = 1;
+	$gitStatusOutput = [];
+	$gitStatusOutput = $executeCommand($gitStatusCommand, $gitStatusOutput, $return_val);
 	$debug('status command output:', $gitStatusOutput);
 	$debug('status command return val:', $return_val);
 	return 0 !== $return_val;

--- a/PhpcsChanged/GitWorkflow.php
+++ b/PhpcsChanged/GitWorkflow.php
@@ -67,7 +67,7 @@ function getGitBasePhpcsOutput(string $gitFile, string $git, string $phpcs, stri
 	if ( isset($options['git-branch']) && ! empty($options['git-branch']) ) {
 		$rev = escapeshellarg($options['git-branch']);
 	} else {
-		$rev = empty( $branchOption ) && isset($options['git-unstaged']) ? ':0' : 'HEAD';
+		$rev = isset($options['git-unstaged']) ? ':0' : 'HEAD';
 	}
 	$oldFilePhpcsOutputCommand = "${git} show {$rev}:$(${git} ls-files --full-name " . escapeshellarg($gitFile) . ") | {$phpcs} --report=json -q" . $phpcsStandardOption . ' --stdin-path=' .  escapeshellarg($gitFile) . ' -';
 	$debug('running orig phpcs command:', $oldFilePhpcsOutputCommand);

--- a/PhpcsChanged/GitWorkflow.php
+++ b/PhpcsChanged/GitWorkflow.php
@@ -43,9 +43,7 @@ function isNewGitFile(string $gitFile, string $git, callable $executeCommand, ar
 function isNewGitFileRemote(string $gitFile, string $git, callable $executeCommand, array $options, callable $debug): bool {
 	$gitStatusCommand = "${git} cat-file -e " . escapeshellarg($options['git-branch']) . ':' . escapeshellarg($gitFile);
 	$debug('checking status of file with command:', $gitStatusCommand);
-	$gitStatusOutput = array();
-	$return_val = 0;
-	$gitStatusOutput = $executeCommand($gitStatusCommand, $gitStatusOutput, $return_val);
+	$gitStatusOutput = $executeCommand($gitStatusCommand, $gitStatusOutput = array(), $return_val = 1);
 	$debug('status command output:', $gitStatusOutput);
 	$debug('status command return val:', $return_val);
 	return 0 !== $return_val;

--- a/PhpcsChanged/GitWorkflow.php
+++ b/PhpcsChanged/GitWorkflow.php
@@ -12,7 +12,7 @@ function validateGitFileExists(string $gitFile, string $git, callable $isReadabl
 	}
 	$gitStatusCommand = "${git} status --short " . escapeshellarg($gitFile);
 	$debug('checking git existence of file with command:', $gitStatusCommand);
-	$gitStatusOutput = $executeCommand($gitStatusCommand);
+	$gitStatusOutput = $executeCommand($gitStatusCommand, $gitStatusOutput, $retVal);
 	$debug('git status output:', $gitStatusOutput);
 	if (isset($gitStatusOutput[0]) && $gitStatusOutput[0] === '?') {
 		throw new ShellException("File does not appear to be tracked by git: '{$gitFile}'");
@@ -24,7 +24,7 @@ function getGitUnifiedDiff(string $gitFile, string $git, callable $executeComman
 	$stagedOption = empty( $branchOption ) && ! isset($options['git-unstaged']) ? ' --staged' : '';
 	$unifiedDiffCommand = "{$git} diff{$stagedOption}{$branchOption} --no-prefix " . escapeshellarg($gitFile);
 	$debug('running diff command:', $unifiedDiffCommand);
-	$unifiedDiff = $executeCommand($unifiedDiffCommand);
+	$unifiedDiff = $executeCommand($unifiedDiffCommand, $unifiedDiff, $retVal);
 	if (! $unifiedDiff) {
 		throw new NoChangesException("Cannot get git diff for file '{$gitFile}'; skipping");
 	}
@@ -43,16 +43,16 @@ function isNewGitFile(string $gitFile, string $git, callable $executeCommand, ar
 function isNewGitFileRemote(string $gitFile, string $git, callable $executeCommand, array $options, callable $debug): bool {
 	$gitStatusCommand = "${git} cat-file -e " . escapeshellarg($options['git-branch']) . ':' . escapeshellarg($gitFile);
 	$debug('checking status of file with command:', $gitStatusCommand);
-	$gitStatusOutput = $executeCommand($gitStatusCommand,$output,$return_val);
+	$gitStatusOutput = $executeCommand($gitStatusCommand, $gitStatusOutput, $retVal);
 	$debug('status command output:', $gitStatusOutput);
-	$debug('status command return val:', $return_val);
+	$debug('status command return val:', $retVal);
 	return 0 !== $return_val;
 }
 
 function isNewGitFileLocal(string $gitFile, string $git, callable $executeCommand, array $options, callable $debug): bool {
 	$gitStatusCommand = "${git} status --short " . escapeshellarg($gitFile);
 	$debug('checking git status of file with command:', $gitStatusCommand);
-	$gitStatusOutput = $executeCommand($gitStatusCommand);
+	$gitStatusOutput = $executeCommand($gitStatusCommand, $gitStatusOutput, $retVal);
 	$debug('git status output:', $gitStatusOutput);
 	if (! $gitStatusOutput || false === strpos($gitStatusOutput, $gitFile)) {
 		throw new ShellException("Cannot get git status for file '{$gitFile}'");
@@ -71,7 +71,7 @@ function getGitBasePhpcsOutput(string $gitFile, string $git, string $phpcs, stri
 	}
 	$oldFilePhpcsOutputCommand = "${git} show {$rev}:$(${git} ls-files --full-name " . escapeshellarg($gitFile) . ") | {$phpcs} --report=json -q" . $phpcsStandardOption . ' --stdin-path=' .  escapeshellarg($gitFile) . ' -';
 	$debug('running orig phpcs command:', $oldFilePhpcsOutputCommand);
-	$oldFilePhpcsOutput = $executeCommand($oldFilePhpcsOutputCommand);
+	$oldFilePhpcsOutput = $executeCommand($oldFilePhpcsOutputCommand, $oldFilePhpcsOutput, $retVal);
 	if (! $oldFilePhpcsOutput) {
 		throw new ShellException("Cannot get old phpcs output for file '{$gitFile}'");
 	}
@@ -82,7 +82,7 @@ function getGitBasePhpcsOutput(string $gitFile, string $git, string $phpcs, stri
 function getGitNewPhpcsOutput(string $gitFile, string $phpcs, string $cat, string $phpcsStandardOption, callable $executeCommand, callable $debug): string {
 	$newFilePhpcsOutputCommand = "{$cat} " . escapeshellarg($gitFile) . " | {$phpcs} --report=json -q" . $phpcsStandardOption . ' --stdin-path=' .  escapeshellarg($gitFile) .' -';
 	$debug('running new phpcs command:', $newFilePhpcsOutputCommand);
-	$newFilePhpcsOutput = $executeCommand($newFilePhpcsOutputCommand);
+	$newFilePhpcsOutput = $executeCommand($newFilePhpcsOutputCommand, $newFilePhpcsOutput, $retVal);
 	if (! $newFilePhpcsOutput) {
 		throw new ShellException("Cannot get new phpcs output for file '{$gitFile}'");
 	}

--- a/PhpcsChanged/GitWorkflow.php
+++ b/PhpcsChanged/GitWorkflow.php
@@ -12,7 +12,7 @@ function validateGitFileExists(string $gitFile, string $git, callable $isReadabl
 	}
 	$gitStatusCommand = "${git} status --short " . escapeshellarg($gitFile);
 	$debug('checking git existence of file with command:', $gitStatusCommand);
-	$gitStatusOutput = $executeCommand($gitStatusCommand, $gitStatusOutput, $retVal);
+	$gitStatusOutput = $executeCommand($gitStatusCommand);
 	$debug('git status output:', $gitStatusOutput);
 	if (isset($gitStatusOutput[0]) && $gitStatusOutput[0] === '?') {
 		throw new ShellException("File does not appear to be tracked by git: '{$gitFile}'");
@@ -24,7 +24,7 @@ function getGitUnifiedDiff(string $gitFile, string $git, callable $executeComman
 	$stagedOption = empty( $branchOption ) && ! isset($options['git-unstaged']) ? ' --staged' : '';
 	$unifiedDiffCommand = "{$git} diff{$stagedOption}{$branchOption} --no-prefix " . escapeshellarg($gitFile);
 	$debug('running diff command:', $unifiedDiffCommand);
-	$unifiedDiff = $executeCommand($unifiedDiffCommand, $unifiedDiff, $retVal);
+	$unifiedDiff = $executeCommand($unifiedDiffCommand);
 	if (! $unifiedDiff) {
 		throw new NoChangesException("Cannot get git diff for file '{$gitFile}'; skipping");
 	}
@@ -52,7 +52,7 @@ function isNewGitFileRemote(string $gitFile, string $git, callable $executeComma
 function isNewGitFileLocal(string $gitFile, string $git, callable $executeCommand, array $options, callable $debug): bool {
 	$gitStatusCommand = "${git} status --short " . escapeshellarg($gitFile);
 	$debug('checking git status of file with command:', $gitStatusCommand);
-	$gitStatusOutput = $executeCommand($gitStatusCommand, $gitStatusOutput, $retVal);
+	$gitStatusOutput = $executeCommand($gitStatusCommand);
 	$debug('git status output:', $gitStatusOutput);
 	if (! $gitStatusOutput || false === strpos($gitStatusOutput, $gitFile)) {
 		throw new ShellException("Cannot get git status for file '{$gitFile}'");
@@ -71,7 +71,7 @@ function getGitBasePhpcsOutput(string $gitFile, string $git, string $phpcs, stri
 	}
 	$oldFilePhpcsOutputCommand = "${git} show {$rev}:$(${git} ls-files --full-name " . escapeshellarg($gitFile) . ") | {$phpcs} --report=json -q" . $phpcsStandardOption . ' --stdin-path=' .  escapeshellarg($gitFile) . ' -';
 	$debug('running orig phpcs command:', $oldFilePhpcsOutputCommand);
-	$oldFilePhpcsOutput = $executeCommand($oldFilePhpcsOutputCommand, $oldFilePhpcsOutput, $retVal);
+	$oldFilePhpcsOutput = $executeCommand($oldFilePhpcsOutputCommand);
 	if (! $oldFilePhpcsOutput) {
 		throw new ShellException("Cannot get old phpcs output for file '{$gitFile}'");
 	}
@@ -82,7 +82,7 @@ function getGitBasePhpcsOutput(string $gitFile, string $git, string $phpcs, stri
 function getGitNewPhpcsOutput(string $gitFile, string $phpcs, string $cat, string $phpcsStandardOption, callable $executeCommand, callable $debug): string {
 	$newFilePhpcsOutputCommand = "{$cat} " . escapeshellarg($gitFile) . " | {$phpcs} --report=json -q" . $phpcsStandardOption . ' --stdin-path=' .  escapeshellarg($gitFile) .' -';
 	$debug('running new phpcs command:', $newFilePhpcsOutputCommand);
-	$newFilePhpcsOutput = $executeCommand($newFilePhpcsOutputCommand, $newFilePhpcsOutput, $retVal);
+	$newFilePhpcsOutput = $executeCommand($newFilePhpcsOutputCommand);
 	if (! $newFilePhpcsOutput) {
 		throw new ShellException("Cannot get new phpcs output for file '{$gitFile}'");
 	}

--- a/PhpcsChanged/ShellOperator.php
+++ b/PhpcsChanged/ShellOperator.php
@@ -9,7 +9,7 @@ namespace PhpcsChanged;
 interface ShellOperator {
 	public function validateExecutableExists(string $name, string $command): void;
 
-	public function executeCommand(string $command, ?array &$output, ?array &$return_val): string;
+	public function executeCommand(string $command, array &$output = null, array &$return_val = null): string;
 
 	public function isReadable(string $fileName): bool;
 

--- a/PhpcsChanged/ShellOperator.php
+++ b/PhpcsChanged/ShellOperator.php
@@ -9,7 +9,7 @@ namespace PhpcsChanged;
 interface ShellOperator {
 	public function validateExecutableExists(string $name, string $command): void;
 
-	public function executeCommand(string $command, array &$output, array &$return_val): string;
+	public function executeCommand(string $command, ?array &$output, ?array &$return_val): string;
 
 	public function isReadable(string $fileName): bool;
 

--- a/PhpcsChanged/ShellOperator.php
+++ b/PhpcsChanged/ShellOperator.php
@@ -9,7 +9,7 @@ namespace PhpcsChanged;
 interface ShellOperator {
 	public function validateExecutableExists(string $name, string $command): void;
 
-	public function executeCommand(string $command, array &$output = null, array &$return_val = null): string;
+	public function executeCommand(string $command, array &$output = null, int &$return_val = null): string;
 
 	public function isReadable(string $fileName): bool;
 

--- a/PhpcsChanged/ShellOperator.php
+++ b/PhpcsChanged/ShellOperator.php
@@ -9,7 +9,7 @@ namespace PhpcsChanged;
 interface ShellOperator {
 	public function validateExecutableExists(string $name, string $command): void;
 
-	public function executeCommand(string $command): string;
+	public function executeCommand(string $command, array &$output, array &$return_val): string;
 
 	public function isReadable(string $fileName): bool;
 

--- a/PhpcsChanged/SvnWorkflow.php
+++ b/PhpcsChanged/SvnWorkflow.php
@@ -12,7 +12,7 @@ function validateSvnFileExists(string $svnFile, string $svn, callable $isReadabl
 	}
 	$svnStatusCommand = "${svn} info " . escapeshellarg($svnFile);
 	$debug('checking svn existence of file with command:', $svnStatusCommand);
-	$svnStatusOutput = $executeCommand($svnStatusCommand, $svnStatusOutput, $retVal);
+	$svnStatusOutput = $executeCommand($svnStatusCommand);
 	$debug('svn status output:', $svnStatusOutput);
 	if (! $svnStatusOutput || false === strpos($svnStatusOutput, 'Schedule:')) {
 		throw new ShellException("Cannot get svn existence info for file '{$svnFile}'");
@@ -22,7 +22,7 @@ function validateSvnFileExists(string $svnFile, string $svn, callable $isReadabl
 function getSvnUnifiedDiff(string $svnFile, string $svn, callable $executeCommand, callable $debug): string {
 	$unifiedDiffCommand = "{$svn} diff " . escapeshellarg($svnFile);
 	$debug('running diff command:', $unifiedDiffCommand);
-	$unifiedDiff = $executeCommand($unifiedDiffCommand, $unifiedDiff, $retVal);
+	$unifiedDiff = $executeCommand($unifiedDiffCommand);
 	if (! $unifiedDiff) {
 		throw new NoChangesException("Cannot get svn diff for file '{$svnFile}'; skipping");
 	}
@@ -33,7 +33,7 @@ function getSvnUnifiedDiff(string $svnFile, string $svn, callable $executeComman
 function isNewSvnFile(string $svnFile, string $svn, callable $executeCommand, callable $debug): bool {
 	$svnStatusCommand = "${svn} info " . escapeshellarg($svnFile);
 	$debug('checking svn status of file with command:', $svnStatusCommand);
-	$svnStatusOutput = $executeCommand($svnStatusCommand, $svnStatusOutput, $retVal);
+	$svnStatusOutput = $executeCommand($svnStatusCommand);
 	$debug('svn status output:', $svnStatusOutput);
 	if (! $svnStatusOutput || false === strpos($svnStatusOutput, 'Schedule:')) {
 		throw new ShellException("Cannot get svn info for file '{$svnFile}'");
@@ -44,7 +44,7 @@ function isNewSvnFile(string $svnFile, string $svn, callable $executeCommand, ca
 function getSvnBasePhpcsOutput(string $svnFile, string $svn, string $phpcs, string $phpcsStandardOption, callable $executeCommand, callable $debug): string {
 	$oldFilePhpcsOutputCommand = "${svn} cat " . escapeshellarg($svnFile) . " | {$phpcs} --report=json -q" . $phpcsStandardOption . ' --stdin-path=' .  escapeshellarg($svnFile) . ' -';
 	$debug('running orig phpcs command:', $oldFilePhpcsOutputCommand);
-	$oldFilePhpcsOutput = $executeCommand($oldFilePhpcsOutputCommand, $oldFilePhpcsOutput, $retVal);
+	$oldFilePhpcsOutput = $executeCommand($oldFilePhpcsOutputCommand);
 	if (! $oldFilePhpcsOutput) {
 		throw new ShellException("Cannot get old phpcs output for file '{$svnFile}'");
 	}
@@ -55,7 +55,7 @@ function getSvnBasePhpcsOutput(string $svnFile, string $svn, string $phpcs, stri
 function getSvnNewPhpcsOutput(string $svnFile, string $phpcs, string $cat, string $phpcsStandardOption, callable $executeCommand, callable $debug): string {
 	$newFilePhpcsOutputCommand = "{$cat} " . escapeshellarg($svnFile) . " | {$phpcs} --report=json -q" . $phpcsStandardOption . ' --stdin-path=' .  escapeshellarg($svnFile) . ' -';
 	$debug('running new phpcs command:', $newFilePhpcsOutputCommand);
-	$newFilePhpcsOutput = $executeCommand($newFilePhpcsOutputCommand, $newFilePhpcsOutput, $retVal);
+	$newFilePhpcsOutput = $executeCommand($newFilePhpcsOutputCommand;
 	if (! $newFilePhpcsOutput) {
 		throw new ShellException("Cannot get new phpcs output for file '{$svnFile}'");
 	}

--- a/PhpcsChanged/SvnWorkflow.php
+++ b/PhpcsChanged/SvnWorkflow.php
@@ -12,7 +12,7 @@ function validateSvnFileExists(string $svnFile, string $svn, callable $isReadabl
 	}
 	$svnStatusCommand = "${svn} info " . escapeshellarg($svnFile);
 	$debug('checking svn existence of file with command:', $svnStatusCommand);
-	$svnStatusOutput = $executeCommand($svnStatusCommand);
+	$svnStatusOutput = $executeCommand($svnStatusCommand, $svnStatusOutput, $retVal);
 	$debug('svn status output:', $svnStatusOutput);
 	if (! $svnStatusOutput || false === strpos($svnStatusOutput, 'Schedule:')) {
 		throw new ShellException("Cannot get svn existence info for file '{$svnFile}'");
@@ -22,7 +22,7 @@ function validateSvnFileExists(string $svnFile, string $svn, callable $isReadabl
 function getSvnUnifiedDiff(string $svnFile, string $svn, callable $executeCommand, callable $debug): string {
 	$unifiedDiffCommand = "{$svn} diff " . escapeshellarg($svnFile);
 	$debug('running diff command:', $unifiedDiffCommand);
-	$unifiedDiff = $executeCommand($unifiedDiffCommand);
+	$unifiedDiff = $executeCommand($unifiedDiffCommand, $unifiedDiff, $retVal);
 	if (! $unifiedDiff) {
 		throw new NoChangesException("Cannot get svn diff for file '{$svnFile}'; skipping");
 	}
@@ -33,7 +33,7 @@ function getSvnUnifiedDiff(string $svnFile, string $svn, callable $executeComman
 function isNewSvnFile(string $svnFile, string $svn, callable $executeCommand, callable $debug): bool {
 	$svnStatusCommand = "${svn} info " . escapeshellarg($svnFile);
 	$debug('checking svn status of file with command:', $svnStatusCommand);
-	$svnStatusOutput = $executeCommand($svnStatusCommand);
+	$svnStatusOutput = $executeCommand($svnStatusCommand, $svnStatusOutput, $retVal);
 	$debug('svn status output:', $svnStatusOutput);
 	if (! $svnStatusOutput || false === strpos($svnStatusOutput, 'Schedule:')) {
 		throw new ShellException("Cannot get svn info for file '{$svnFile}'");
@@ -44,7 +44,7 @@ function isNewSvnFile(string $svnFile, string $svn, callable $executeCommand, ca
 function getSvnBasePhpcsOutput(string $svnFile, string $svn, string $phpcs, string $phpcsStandardOption, callable $executeCommand, callable $debug): string {
 	$oldFilePhpcsOutputCommand = "${svn} cat " . escapeshellarg($svnFile) . " | {$phpcs} --report=json -q" . $phpcsStandardOption . ' --stdin-path=' .  escapeshellarg($svnFile) . ' -';
 	$debug('running orig phpcs command:', $oldFilePhpcsOutputCommand);
-	$oldFilePhpcsOutput = $executeCommand($oldFilePhpcsOutputCommand);
+	$oldFilePhpcsOutput = $executeCommand($oldFilePhpcsOutputCommand, $oldFilePhpcsOutput, $retVal);
 	if (! $oldFilePhpcsOutput) {
 		throw new ShellException("Cannot get old phpcs output for file '{$svnFile}'");
 	}
@@ -55,7 +55,7 @@ function getSvnBasePhpcsOutput(string $svnFile, string $svn, string $phpcs, stri
 function getSvnNewPhpcsOutput(string $svnFile, string $phpcs, string $cat, string $phpcsStandardOption, callable $executeCommand, callable $debug): string {
 	$newFilePhpcsOutputCommand = "{$cat} " . escapeshellarg($svnFile) . " | {$phpcs} --report=json -q" . $phpcsStandardOption . ' --stdin-path=' .  escapeshellarg($svnFile) . ' -';
 	$debug('running new phpcs command:', $newFilePhpcsOutputCommand);
-	$newFilePhpcsOutput = $executeCommand($newFilePhpcsOutputCommand);
+	$newFilePhpcsOutput = $executeCommand($newFilePhpcsOutputCommand, $newFilePhpcsOutput, $retVal);
 	if (! $newFilePhpcsOutput) {
 		throw new ShellException("Cannot get new phpcs output for file '{$svnFile}'");
 	}

--- a/PhpcsChanged/SvnWorkflow.php
+++ b/PhpcsChanged/SvnWorkflow.php
@@ -55,7 +55,7 @@ function getSvnBasePhpcsOutput(string $svnFile, string $svn, string $phpcs, stri
 function getSvnNewPhpcsOutput(string $svnFile, string $phpcs, string $cat, string $phpcsStandardOption, callable $executeCommand, callable $debug): string {
 	$newFilePhpcsOutputCommand = "{$cat} " . escapeshellarg($svnFile) . " | {$phpcs} --report=json -q" . $phpcsStandardOption . ' --stdin-path=' .  escapeshellarg($svnFile) . ' -';
 	$debug('running new phpcs command:', $newFilePhpcsOutputCommand);
-	$newFilePhpcsOutput = $executeCommand($newFilePhpcsOutputCommand;
+	$newFilePhpcsOutput = $executeCommand($newFilePhpcsOutputCommand);
 	if (! $newFilePhpcsOutput) {
 		throw new ShellException("Cannot get new phpcs output for file '{$svnFile}'");
 	}

--- a/PhpcsChanged/UnixShell.php
+++ b/PhpcsChanged/UnixShell.php
@@ -17,7 +17,7 @@ class UnixShell implements ShellOperator {
 		}
 	}
 
-	public function executeCommand(string $command, ?array &$output, ?array &$return_val ): string {
+	public function executeCommand(string $command, array &$output = null, array &$return_val = null ): string {
 		exec($command,$output,$return_val) ?? '';
 		return join(PHP_EOL, $output) . PHP_EOL;
 	}

--- a/PhpcsChanged/UnixShell.php
+++ b/PhpcsChanged/UnixShell.php
@@ -17,7 +17,7 @@ class UnixShell implements ShellOperator {
 		}
 	}
 
-	public function executeCommand(string $command, array &$output = null, array &$return_val = null): string {
+	public function executeCommand(string $command, array &$output = null, int &$return_val = null): string {
 		exec($command, $output, $return_val) ?? '';
 		return join(PHP_EOL, $output) . PHP_EOL;
 	}

--- a/PhpcsChanged/UnixShell.php
+++ b/PhpcsChanged/UnixShell.php
@@ -17,8 +17,9 @@ class UnixShell implements ShellOperator {
 		}
 	}
 
-	public function executeCommand(string $command): string {
-		return shell_exec($command) ?? '';
+	public function executeCommand(string $command, array &$output = null, array &$return_val = null ): string {
+		exec($command,$output,$return_val) ?? '';
+		return join(PHP_EOL, $output) . PHP_EOL;
 	}
 
 	public function isReadable(string $fileName): bool {

--- a/PhpcsChanged/UnixShell.php
+++ b/PhpcsChanged/UnixShell.php
@@ -17,7 +17,7 @@ class UnixShell implements ShellOperator {
 		}
 	}
 
-	public function executeCommand(string $command, array &$output = null, array &$return_val = null ): string {
+	public function executeCommand(string $command, ?array &$output, ?array &$return_val ): string {
 		exec($command,$output,$return_val) ?? '';
 		return join(PHP_EOL, $output) . PHP_EOL;
 	}

--- a/PhpcsChanged/UnixShell.php
+++ b/PhpcsChanged/UnixShell.php
@@ -17,8 +17,8 @@ class UnixShell implements ShellOperator {
 		}
 	}
 
-	public function executeCommand(string $command, array &$output = null, array &$return_val = null ): string {
-		exec($command,$output,$return_val) ?? '';
+	public function executeCommand(string $command, array &$output = null, array &$return_val = null): string {
+		exec($command, $output, $return_val) ?? '';
 		return join(PHP_EOL, $output) . PHP_EOL;
 	}
 

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -32,6 +32,7 @@ $options = getopt(
 		'git',
 		'git-unstaged',
 		'git-staged',
+		'git-branch:',
 		'standard:',
 		'report:',
 		'debug'

--- a/tests/GitWorkflowTest.php
+++ b/tests/GitWorkflowTest.php
@@ -76,7 +76,7 @@ EOF;
 
 			public function validateExecutableExists(string $name, string $command): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command): string {
+			public function executeCommand(string $command, array &$output, array &$return_val): string {
 				if (false !== strpos($command, "git diff --staged --no-prefix 'foobar.php'")) {
 					return <<<EOF
 diff --git bin/foobar.php bin/foobar.php

--- a/tests/GitWorkflowTest.php
+++ b/tests/GitWorkflowTest.php
@@ -552,8 +552,8 @@ EOF;
 				if ( false !== strpos($command, "cat 'bin/foobar.php' | phpcs --report=json -q --stdin-path='bin/foobar.php' -")) {
 					return '{"totals":{"errors":0,"warnings":2,"fixable":0},"files":{"\/srv\/www\/wordpress-default\/public_html\/test\/bin\/foobar.php":{"errors":0,"warnings":2,"messages":[{"message":"Found unused symbol '."'Foobar'".'.","source":"ImportDetection.Imports.RequireImports.Import","severity":5,"fixable":false,"type":"WARNING","line":6,"column":5},{"message":"Found unused symbol '."'Billing\\\\Emergent'".'.","source":"ImportDetection.Imports.RequireImports.Import","severity":5,"fixable":false,"type":"WARNING","line":7,"column":5}]}}}';
 				}
-				
-				return '';
+			
+				throw new \Exception("Unknown command: {$command}");	
 			}
 		};
 		$options = [ 'git-branch' => 'master' ];

--- a/tests/GitWorkflowTest.php
+++ b/tests/GitWorkflowTest.php
@@ -76,7 +76,7 @@ EOF;
 
 			public function validateExecutableExists(string $name, string $command): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command, array &$output, array &$return_val): string {
+			public function executeCommand(string $command, ?array &$output, ?array &$return_val): string {
 				if (false !== strpos($command, "git diff --staged --no-prefix 'foobar.php'")) {
 					return <<<EOF
 diff --git bin/foobar.php bin/foobar.php
@@ -135,7 +135,7 @@ EOF;
 
 			public function validateExecutableExists(string $name, string $command): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command, array &$output, array &$return_val): string {
+			public function executeCommand(string $command, ?array &$output, ?array &$return_val): string {
 				if (false !== strpos($command, "git diff --no-prefix 'foobar.php'")) {
 					return <<<EOF
 diff --git bin/foobar.php bin/foobar.php
@@ -194,7 +194,7 @@ EOF;
 
 			public function validateExecutableExists(string $name, string $command): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command, array &$output, array &$return_val): string {
+			public function executeCommand(string $command, ?array &$output, ?array &$return_val): string {
 				if (false !== strpos($command, "git diff --staged --no-prefix 'foobar.php'")) {
 					return <<<EOF
 diff --git bin/foobar.php bin/foobar.php
@@ -291,7 +291,7 @@ EOF;
 
 			public function printError(string $message): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command, array &$output, array &$return_val): string {
+			public function executeCommand(string $command, ?array &$output, ?array &$return_val): string {
 				if (false !== strpos($command, "git diff --staged --no-prefix 'foobar.php'")) {
 					return <<<EOF
 EOF;
@@ -328,7 +328,7 @@ EOF;
 
 			public function printError(string $message): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command, array &$output, array &$return_val): string {
+			public function executeCommand(string $command, ?array &$output, ?array &$return_val): string {
 				if (false !== strpos($command, "git diff --staged --no-prefix 'foobar.php'")) {
 					return <<<EOF
 EOF;
@@ -366,7 +366,7 @@ EOF;
 
 			public function printError(string $message): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command, array &$output, array &$return_val): string {
+			public function executeCommand(string $command, ?array &$output, ?array &$return_val): string {
 				if (false !== strpos($command, "git diff --staged --no-prefix 'foobar.php'")) {
 					return <<<EOF
 EOF;
@@ -401,7 +401,7 @@ EOF;
 
 			public function printError(string $message): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command, array &$output, array &$return_val): string {
+			public function executeCommand(string $command, ?array &$output, ?array &$return_val): string {
 				if (false !== strpos($command, "git diff --staged --no-prefix 'foobar.php'")) {
 					return <<<EOF
 diff --git bin/foobar.php bin/foobar.php
@@ -468,7 +468,7 @@ EOF;
 
 			public function printError(string $message): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command, array &$output, array &$return_val): string {
+			public function executeCommand(string $command, ?array &$output, ?array &$return_val): string {
 				if (false !== strpos($command, "git diff --staged --no-prefix 'foobar.php'")) {
 					return <<<EOF
 diff --git bin/foobar.php bin/foobar.php

--- a/tests/GitWorkflowTest.php
+++ b/tests/GitWorkflowTest.php
@@ -135,7 +135,7 @@ EOF;
 
 			public function validateExecutableExists(string $name, string $command): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command): string {
+			public function executeCommand(string $command, array &$output, array &$return_val): string {
 				if (false !== strpos($command, "git diff --no-prefix 'foobar.php'")) {
 					return <<<EOF
 diff --git bin/foobar.php bin/foobar.php
@@ -194,7 +194,7 @@ EOF;
 
 			public function validateExecutableExists(string $name, string $command): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command): string {
+			public function executeCommand(string $command, array &$output, array &$return_val): string {
 				if (false !== strpos($command, "git diff --staged --no-prefix 'foobar.php'")) {
 					return <<<EOF
 diff --git bin/foobar.php bin/foobar.php
@@ -291,7 +291,7 @@ EOF;
 
 			public function printError(string $message): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command): string {
+			public function executeCommand(string $command, array &$output, array &$return_val): string {
 				if (false !== strpos($command, "git diff --staged --no-prefix 'foobar.php'")) {
 					return <<<EOF
 EOF;
@@ -328,7 +328,7 @@ EOF;
 
 			public function printError(string $message): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command): string {
+			public function executeCommand(string $command, array &$output, array &$return_val): string {
 				if (false !== strpos($command, "git diff --staged --no-prefix 'foobar.php'")) {
 					return <<<EOF
 EOF;
@@ -366,7 +366,7 @@ EOF;
 
 			public function printError(string $message): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command): string {
+			public function executeCommand(string $command, array &$output, array &$return_val): string {
 				if (false !== strpos($command, "git diff --staged --no-prefix 'foobar.php'")) {
 					return <<<EOF
 EOF;
@@ -401,7 +401,7 @@ EOF;
 
 			public function printError(string $message): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command): string {
+			public function executeCommand(string $command, array &$output, array &$return_val): string {
 				if (false !== strpos($command, "git diff --staged --no-prefix 'foobar.php'")) {
 					return <<<EOF
 diff --git bin/foobar.php bin/foobar.php
@@ -468,7 +468,7 @@ EOF;
 
 			public function printError(string $message): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command): string {
+			public function executeCommand(string $command, array &$output, array &$return_val): string {
 				if (false !== strpos($command, "git diff --staged --no-prefix 'foobar.php'")) {
 					return <<<EOF
 diff --git bin/foobar.php bin/foobar.php

--- a/tests/GitWorkflowTest.php
+++ b/tests/GitWorkflowTest.php
@@ -76,7 +76,7 @@ EOF;
 
 			public function validateExecutableExists(string $name, string $command): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command, array &$output = null, array &$return_val = null): string {
+			public function executeCommand(string $command, array &$output = null, int &$return_val = null): string {
 				if (false !== strpos($command, "git diff --staged --no-prefix 'foobar.php'")) {
 					return <<<EOF
 diff --git bin/foobar.php bin/foobar.php
@@ -135,7 +135,7 @@ EOF;
 
 			public function validateExecutableExists(string $name, string $command): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command, array &$output = null, array &$return_val = null): string {
+			public function executeCommand(string $command, array &$output = null, int &$return_val = null): string {
 				if (false !== strpos($command, "git diff --no-prefix 'foobar.php'")) {
 					return <<<EOF
 diff --git bin/foobar.php bin/foobar.php
@@ -194,7 +194,7 @@ EOF;
 
 			public function validateExecutableExists(string $name, string $command): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command, array &$output = null, array &$return_val = null): string {
+			public function executeCommand(string $command, array &$output = null, int &$return_val = null): string {
 				if (false !== strpos($command, "git diff --staged --no-prefix 'foobar.php'")) {
 					return <<<EOF
 diff --git bin/foobar.php bin/foobar.php
@@ -291,7 +291,7 @@ EOF;
 
 			public function printError(string $message): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command, array &$output = null, array &$return_val = null): string {
+			public function executeCommand(string $command, array &$output = null, int &$return_val = null): string {
 				if (false !== strpos($command, "git diff --staged --no-prefix 'foobar.php'")) {
 					return <<<EOF
 EOF;
@@ -328,7 +328,7 @@ EOF;
 
 			public function printError(string $message): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command, array &$output = null, array &$return_val = null): string {
+			public function executeCommand(string $command, array &$output = null, int &$return_val = null): string {
 				if (false !== strpos($command, "git diff --staged --no-prefix 'foobar.php'")) {
 					return <<<EOF
 EOF;
@@ -366,7 +366,7 @@ EOF;
 
 			public function printError(string $message): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command, array &$output = null, array &$return_val = null): string {
+			public function executeCommand(string $command, array &$output = null, int &$return_val = null): string {
 				if (false !== strpos($command, "git diff --staged --no-prefix 'foobar.php'")) {
 					return <<<EOF
 EOF;
@@ -401,7 +401,7 @@ EOF;
 
 			public function printError(string $message): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command, array &$output = null, array &$return_val = null): string {
+			public function executeCommand(string $command, array &$output = null, int &$return_val = null): string {
 				if (false !== strpos($command, "git diff --staged --no-prefix 'foobar.php'")) {
 					return <<<EOF
 diff --git bin/foobar.php bin/foobar.php
@@ -468,7 +468,7 @@ EOF;
 
 			public function printError(string $message): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command, array &$output = null, array &$return_val = null): string {
+			public function executeCommand(string $command, array &$output = null, int &$return_val = null): string {
 				if (false !== strpos($command, "git diff --staged --no-prefix 'foobar.php'")) {
 					return <<<EOF
 diff --git bin/foobar.php bin/foobar.php

--- a/tests/GitWorkflowTest.php
+++ b/tests/GitWorkflowTest.php
@@ -20,7 +20,7 @@ final class GitWorkflowTest extends TestCase {
 			}
 		};
 		$debug = function($message) {}; //phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		$this->assertTrue(isNewGitFile($gitFile, $git, $executeCommand, $debug));
+		$this->assertTrue(isNewGitFile($gitFile, $git, $executeCommand, array(), $debug));
 	}
 
 	public function testIsNewGitFileReturnsFalseForOldFile() {
@@ -32,7 +32,7 @@ final class GitWorkflowTest extends TestCase {
 			}
 		};
 		$debug = function($message) {}; //phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		$this->assertFalse(isNewGitFile($gitFile, $git, $executeCommand, $debug));
+		$this->assertFalse(isNewGitFile($gitFile, $git, $executeCommand, array(), $debug));
 	}
 
 	public function testGetGitUnifiedDiff() {

--- a/tests/GitWorkflowTest.php
+++ b/tests/GitWorkflowTest.php
@@ -504,4 +504,70 @@ Run "phpcs --help" for usage information
 		$messages = runGitWorkflow([$gitFile], $options, $shell, $debug);
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
+	function testFullGitWorkflowForInterBranchDiff() {
+		$gitFile = 'bin/foobar.php';
+		$debug = function($message) { var_dump( $message ); }; //phpcs:ignore VariableAnalysis
+		$shell = new class() implements ShellOperator {
+			public function isReadable(string $fileName): bool {
+				return ($fileName === 'bin/foobar.php');
+			}
+
+			public function exitWithCode(int $code): void {} // phpcs:ignore VariableAnalysis
+
+			public function printError(string $message): void {} // phpcs:ignore VariableAnalysis
+
+			public function validateExecutableExists(string $name, string $command): void {} // phpcs:ignore VariableAnalysis
+
+			public function executeCommand(string $command, array &$output = null, int &$return_val = null): string {
+				var_dump( $command );
+				if (false !== strpos($command, "git diff 'master'... --no-prefix 'bin/foobar.php'")) {
+					$return_val = 0;
+					return <<<EOF
+diff --git bin/foobar.php bin/foobar.php
+index c012707..319ecf3 100644
+--- bin/foobar.php
++++ bin/foobar.php
+@@ -3,6 +3,7 @@
+ use Billing\Purchases\Order;
+ use Billing\Services;
+ use Billing\Ebanx;
++use Foobar;
+ use Billing\Emergent;
+ use Billing\Monetary_Amount;
+ use Stripe\Error;
+EOF;
+				}
+				if (false !== strpos($command, "git status --short 'bin/foobar.php'")) {
+					$return_val = 0;
+					return ''; // the file is not modified, as this runs on fresh checkout.
+				}
+				if ( false !== strpos($command, "git cat-file -e 'master':'bin/foobar.php'")) {
+					$return_val = 0;
+					return '';
+				}
+				if ( false !== strpos($command, "git show 'master':$(git ls-files --full-name 'bin/foobar.php') | phpcs --report=json -q --stdin-path='bin/foobar.php' -") ){
+					return '{"totals":{"errors":0,"warnings":1,"fixable":0},"files":{"\/srv\/www\/wordpress-default\/public_html\/test\/bin\/foobar.php":{"errors":0,"warnings":1,"messages":[{"message":"Found unused symbol '."'Billing\\\\Emergent'".'","source":"ImportDetection.Imports.RequireImports.Import","severity":5,"fixable":false,"type":"WARNING","line":6,"column":5}]}}}';
+				}
+				if ( false !== strpos($command, "cat 'bin/foobar.php' | phpcs --report=json -q --stdin-path='bin/foobar.php' -")) {
+					return '{"totals":{"errors":0,"warnings":2,"fixable":0},"files":{"\/srv\/www\/wordpress-default\/public_html\/test\/bin\/foobar.php":{"errors":0,"warnings":2,"messages":[{"message":"Found unused symbol '."'Foobar'".'.","source":"ImportDetection.Imports.RequireImports.Import","severity":5,"fixable":false,"type":"WARNING","line":6,"column":5},{"message":"Found unused symbol '."'Billing\\\\Emergent'".'.","source":"ImportDetection.Imports.RequireImports.Import","severity":5,"fixable":false,"type":"WARNING","line":7,"column":5}]}}}';
+				}
+				
+				return '';
+			}
+		};
+		$options = [ 'git-branch' => 'master' ];
+		$expected = PhpcsMessages::fromArrays([
+			[
+				'type' => 'WARNING',
+				'severity' => 5,
+				'fixable' => false,
+				'column' => 5,
+				'source' => 'ImportDetection.Imports.RequireImports.Import',
+				'line' => 6,
+				'message' => "Found unused symbol 'Foobar'.",
+			],
+		], 'bin/foobar.php');
+		$messages = runGitWorkflow([$gitFile], $options, $shell, $debug);
+		$this->assertEquals($expected->getMessages(), $messages->getMessages());
+	}
 }

--- a/tests/GitWorkflowTest.php
+++ b/tests/GitWorkflowTest.php
@@ -76,7 +76,7 @@ EOF;
 
 			public function validateExecutableExists(string $name, string $command): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command, ?array &$output, ?array &$return_val): string {
+			public function executeCommand(string $command, array &$output = null, array &$return_val = null): string {
 				if (false !== strpos($command, "git diff --staged --no-prefix 'foobar.php'")) {
 					return <<<EOF
 diff --git bin/foobar.php bin/foobar.php
@@ -135,7 +135,7 @@ EOF;
 
 			public function validateExecutableExists(string $name, string $command): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command, ?array &$output, ?array &$return_val): string {
+			public function executeCommand(string $command, array &$output = null, array &$return_val = null): string {
 				if (false !== strpos($command, "git diff --no-prefix 'foobar.php'")) {
 					return <<<EOF
 diff --git bin/foobar.php bin/foobar.php
@@ -194,7 +194,7 @@ EOF;
 
 			public function validateExecutableExists(string $name, string $command): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command, ?array &$output, ?array &$return_val): string {
+			public function executeCommand(string $command, array &$output = null, array &$return_val = null): string {
 				if (false !== strpos($command, "git diff --staged --no-prefix 'foobar.php'")) {
 					return <<<EOF
 diff --git bin/foobar.php bin/foobar.php
@@ -291,7 +291,7 @@ EOF;
 
 			public function printError(string $message): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command, ?array &$output, ?array &$return_val): string {
+			public function executeCommand(string $command, array &$output = null, array &$return_val = null): string {
 				if (false !== strpos($command, "git diff --staged --no-prefix 'foobar.php'")) {
 					return <<<EOF
 EOF;
@@ -328,7 +328,7 @@ EOF;
 
 			public function printError(string $message): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command, ?array &$output, ?array &$return_val): string {
+			public function executeCommand(string $command, array &$output = null, array &$return_val = null): string {
 				if (false !== strpos($command, "git diff --staged --no-prefix 'foobar.php'")) {
 					return <<<EOF
 EOF;
@@ -366,7 +366,7 @@ EOF;
 
 			public function printError(string $message): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command, ?array &$output, ?array &$return_val): string {
+			public function executeCommand(string $command, array &$output = null, array &$return_val = null): string {
 				if (false !== strpos($command, "git diff --staged --no-prefix 'foobar.php'")) {
 					return <<<EOF
 EOF;
@@ -401,7 +401,7 @@ EOF;
 
 			public function printError(string $message): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command, ?array &$output, ?array &$return_val): string {
+			public function executeCommand(string $command, array &$output = null, array &$return_val = null): string {
 				if (false !== strpos($command, "git diff --staged --no-prefix 'foobar.php'")) {
 					return <<<EOF
 diff --git bin/foobar.php bin/foobar.php
@@ -468,7 +468,7 @@ EOF;
 
 			public function printError(string $message): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command, ?array &$output, ?array &$return_val): string {
+			public function executeCommand(string $command, array &$output = null, array &$return_val = null): string {
 				if (false !== strpos($command, "git diff --staged --no-prefix 'foobar.php'")) {
 					return <<<EOF
 diff --git bin/foobar.php bin/foobar.php

--- a/tests/GitWorkflowTest.php
+++ b/tests/GitWorkflowTest.php
@@ -507,7 +507,7 @@ Run "phpcs --help" for usage information
 
 	function testFullGitWorkflowForInterBranchDiff() {
 		$gitFile = 'bin/foobar.php';
-		$debug = function($message) { var_dump( $message ); }; //phpcs:ignore VariableAnalysis
+		$debug = function($message) {}; //phpcs:ignore VariableAnalysis
 		$shell = new class() implements ShellOperator {
 			public function isReadable(string $fileName): bool {
 				return ($fileName === 'bin/foobar.php');

--- a/tests/GitWorkflowTest.php
+++ b/tests/GitWorkflowTest.php
@@ -520,7 +520,6 @@ Run "phpcs --help" for usage information
 			public function validateExecutableExists(string $name, string $command): void {} // phpcs:ignore VariableAnalysis
 
 			public function executeCommand(string $command, array &$output = null, int &$return_val = null): string {
-				var_dump( $command );
 				if (false !== strpos($command, "git diff 'master'... --no-prefix 'bin/foobar.php'")) {
 					$return_val = 0;
 					return <<<EOF

--- a/tests/GitWorkflowTest.php
+++ b/tests/GitWorkflowTest.php
@@ -504,6 +504,7 @@ Run "phpcs --help" for usage information
 		$messages = runGitWorkflow([$gitFile], $options, $shell, $debug);
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
+
 	function testFullGitWorkflowForInterBranchDiff() {
 		$gitFile = 'bin/foobar.php';
 		$debug = function($message) { var_dump( $message ); }; //phpcs:ignore VariableAnalysis

--- a/tests/SvnWorkflowTest.php
+++ b/tests/SvnWorkflowTest.php
@@ -102,7 +102,7 @@ EOF;
 
 			public function exitWithCode(int $code): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command, array &$output = null, array &$return_val = null): string {
+			public function executeCommand(string $command, array &$output = null, int &$return_val = null): string {
 				if (false !== strpos($command, "svn diff 'foobar.php'")) {
 					return <<<EOF
 Index: foobar.php
@@ -177,7 +177,7 @@ EOF;
 
 			public function exitWithCode(int $code): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command, array &$output = null, array &$return_val = null): string {
+			public function executeCommand(string $command, array &$output = null, int &$return_val = null): string {
 				if (false !== strpos($command, "svn diff 'foobar.php'")) {
 					return <<<EOF
 Index: foobar.php
@@ -306,7 +306,7 @@ EOF;
 
 			public function printError(string $message): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command, array &$output = null, array &$return_val = null): string {
+			public function executeCommand(string $command, array &$output = null, int &$return_val = null): string {
 				if (false !== strpos($command, "svn diff 'foobar.php'")) {
 					return <<<EOF
 EOF;
@@ -359,7 +359,7 @@ EOF;
 
 			public function printError(string $message): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command, array &$output = null, array &$return_val = null): string {
+			public function executeCommand(string $command, array &$output = null, int &$return_val = null): string {
 				if (false !== strpos($command, "svn diff 'foobar.php'")) {
 					return <<<EOF
 EOF;
@@ -413,7 +413,7 @@ EOF;
 
 			public function printError(string $message): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command, array &$output = null, array &$return_val = null): string {
+			public function executeCommand(string $command, array &$output = null, int &$return_val = null): string {
 				if (false !== strpos($command, "svn diff 'foobar.php'")) {
 					return <<<EOF
 svn: E155010: The node 'foobar.php' was not found.
@@ -452,7 +452,7 @@ EOF;
 
 			public function exitWithCode(int $code): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command, array &$output = null, array &$return_val = null): string {
+			public function executeCommand(string $command, array &$output = null, int &$return_val = null): string {
 				if (false !== strpos($command, "svn diff 'foobar.php'")) {
 					return <<<EOF
 Index: foobar.php
@@ -524,7 +524,7 @@ EOF;
 
 			public function exitWithCode(int $code): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command, array &$output = null, array &$return_val = null): string {
+			public function executeCommand(string $command, array &$output = null, int &$return_val = null): string {
 				if (false !== strpos($command, "svn diff 'foobar.php'")) {
 					return <<<EOF
 Index: foobar.php

--- a/tests/SvnWorkflowTest.php
+++ b/tests/SvnWorkflowTest.php
@@ -102,7 +102,7 @@ EOF;
 
 			public function exitWithCode(int $code): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command, ?array &$output, ?array &$return_val): string {
+			public function executeCommand(string $command, array &$output = null, array &$return_val = null): string {
 				if (false !== strpos($command, "svn diff 'foobar.php'")) {
 					return <<<EOF
 Index: foobar.php
@@ -177,7 +177,7 @@ EOF;
 
 			public function exitWithCode(int $code): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command, ?array &$output, ?array &$return_val): string {
+			public function executeCommand(string $command, array &$output = null, array &$return_val = null): string {
 				if (false !== strpos($command, "svn diff 'foobar.php'")) {
 					return <<<EOF
 Index: foobar.php
@@ -306,7 +306,7 @@ EOF;
 
 			public function printError(string $message): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command, ?array &$output, ?array &$return_val): string {
+			public function executeCommand(string $command, array &$output = null, array &$return_val = null): string {
 				if (false !== strpos($command, "svn diff 'foobar.php'")) {
 					return <<<EOF
 EOF;
@@ -359,7 +359,7 @@ EOF;
 
 			public function printError(string $message): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command, ?array &$output, ?array &$return_val): string {
+			public function executeCommand(string $command, array &$output = null, array &$return_val = null): string {
 				if (false !== strpos($command, "svn diff 'foobar.php'")) {
 					return <<<EOF
 EOF;
@@ -413,7 +413,7 @@ EOF;
 
 			public function printError(string $message): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command, ?array &$output, ?array &$return_val): string {
+			public function executeCommand(string $command, array &$output = null, array &$return_val = null): string {
 				if (false !== strpos($command, "svn diff 'foobar.php'")) {
 					return <<<EOF
 svn: E155010: The node 'foobar.php' was not found.
@@ -452,7 +452,7 @@ EOF;
 
 			public function exitWithCode(int $code): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command, ?array &$output, ?array &$return_val): string {
+			public function executeCommand(string $command, array &$output = null, array &$return_val = null): string {
 				if (false !== strpos($command, "svn diff 'foobar.php'")) {
 					return <<<EOF
 Index: foobar.php
@@ -524,7 +524,7 @@ EOF;
 
 			public function exitWithCode(int $code): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command, ?array &$output, ?array &$return_val): string {
+			public function executeCommand(string $command, array &$output = null, array &$return_val = null): string {
 				if (false !== strpos($command, "svn diff 'foobar.php'")) {
 					return <<<EOF
 Index: foobar.php

--- a/tests/SvnWorkflowTest.php
+++ b/tests/SvnWorkflowTest.php
@@ -102,7 +102,7 @@ EOF;
 
 			public function exitWithCode(int $code): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command): string {
+			public function executeCommand(string $command, array &$output, array &$return_val): string {
 				if (false !== strpos($command, "svn diff 'foobar.php'")) {
 					return <<<EOF
 Index: foobar.php
@@ -177,7 +177,7 @@ EOF;
 
 			public function exitWithCode(int $code): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command): string {
+			public function executeCommand(string $command, array &$output, array &$return_val): string {
 				if (false !== strpos($command, "svn diff 'foobar.php'")) {
 					return <<<EOF
 Index: foobar.php
@@ -306,7 +306,7 @@ EOF;
 
 			public function printError(string $message): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command): string {
+			public function executeCommand(string $command, array &$output, array &$return_val): string {
 				if (false !== strpos($command, "svn diff 'foobar.php'")) {
 					return <<<EOF
 EOF;
@@ -359,7 +359,7 @@ EOF;
 
 			public function printError(string $message): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command): string {
+			public function executeCommand(string $command, array &$output, array &$return_val): string {
 				if (false !== strpos($command, "svn diff 'foobar.php'")) {
 					return <<<EOF
 EOF;
@@ -413,7 +413,7 @@ EOF;
 
 			public function printError(string $message): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command): string {
+			public function executeCommand(string $command, array &$output, array &$return_val): string {
 				if (false !== strpos($command, "svn diff 'foobar.php'")) {
 					return <<<EOF
 svn: E155010: The node 'foobar.php' was not found.
@@ -452,7 +452,7 @@ EOF;
 
 			public function exitWithCode(int $code): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command): string {
+			public function executeCommand(string $command, array &$output, array &$return_val): string {
 				if (false !== strpos($command, "svn diff 'foobar.php'")) {
 					return <<<EOF
 Index: foobar.php
@@ -524,7 +524,7 @@ EOF;
 
 			public function exitWithCode(int $code): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command): string {
+			public function executeCommand(string $command, array &$output, array &$return_val): string {
 				if (false !== strpos($command, "svn diff 'foobar.php'")) {
 					return <<<EOF
 Index: foobar.php

--- a/tests/SvnWorkflowTest.php
+++ b/tests/SvnWorkflowTest.php
@@ -102,7 +102,7 @@ EOF;
 
 			public function exitWithCode(int $code): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command, array &$output, array &$return_val): string {
+			public function executeCommand(string $command, ?array &$output, ?array &$return_val): string {
 				if (false !== strpos($command, "svn diff 'foobar.php'")) {
 					return <<<EOF
 Index: foobar.php
@@ -177,7 +177,7 @@ EOF;
 
 			public function exitWithCode(int $code): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command, array &$output, array &$return_val): string {
+			public function executeCommand(string $command, ?array &$output, ?array &$return_val): string {
 				if (false !== strpos($command, "svn diff 'foobar.php'")) {
 					return <<<EOF
 Index: foobar.php
@@ -306,7 +306,7 @@ EOF;
 
 			public function printError(string $message): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command, array &$output, array &$return_val): string {
+			public function executeCommand(string $command, ?array &$output, ?array &$return_val): string {
 				if (false !== strpos($command, "svn diff 'foobar.php'")) {
 					return <<<EOF
 EOF;
@@ -359,7 +359,7 @@ EOF;
 
 			public function printError(string $message): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command, array &$output, array &$return_val): string {
+			public function executeCommand(string $command, ?array &$output, ?array &$return_val): string {
 				if (false !== strpos($command, "svn diff 'foobar.php'")) {
 					return <<<EOF
 EOF;
@@ -413,7 +413,7 @@ EOF;
 
 			public function printError(string $message): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command, array &$output, array &$return_val): string {
+			public function executeCommand(string $command, ?array &$output, ?array &$return_val): string {
 				if (false !== strpos($command, "svn diff 'foobar.php'")) {
 					return <<<EOF
 svn: E155010: The node 'foobar.php' was not found.
@@ -452,7 +452,7 @@ EOF;
 
 			public function exitWithCode(int $code): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command, array &$output, array &$return_val): string {
+			public function executeCommand(string $command, ?array &$output, ?array &$return_val): string {
 				if (false !== strpos($command, "svn diff 'foobar.php'")) {
 					return <<<EOF
 Index: foobar.php
@@ -524,7 +524,7 @@ EOF;
 
 			public function exitWithCode(int $code): void {} // phpcs:ignore VariableAnalysis
 
-			public function executeCommand(string $command, array &$output, array &$return_val): string {
+			public function executeCommand(string $command, ?array &$output, ?array &$return_val): string {
 				if (false !== strpos($command, "svn diff 'foobar.php'")) {
 					return <<<EOF
 Index: foobar.php


### PR DESCRIPTION
When phpcs-changed is used in CI (eg.: Travis), there is no good way to determine the unified diff, since the working directory is clean.

In order to accommodate the situation when a branch or PR is being checked, a support for inter branch diff is helpful.

This PR adds a new param `git-branch:` which instructs the phpcs-changed to run a diff of the current working directory against specified branch (eg.: `master`).

A usage in Travis would be, for instance, as follows:

```
script:
  - if [[ "$SNIFF" == "1" ]] && [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then /tmp/phpcs-changed/bin/phpcs-changed --git --git-branch "$TRAVIS_BRANCH" --standard="WordPress-VIP-Go" .; fi
```

For the needs of checking whether a file is a new one, the `UnixShell::executeCommand` method had to be changed to use `exec` rather than `shell_exec`, as `exec` also provides support for reading the exit code. In order to make the `UnixShell::executeCommand` backward compatible, I'm joining the `$output` with `PHP_EOL` + appending one to the very end.

See #25 