### PR TITLE
Allow more files extensions to be checked

### DIFF
--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -272,3 +272,31 @@ function reportMessagesAndExit(PhpcsMessages $messages, string $reportType, arra
 	echo $reporter->getFormattedMessages($messages, $options);
 	exit($reporter->getExitCode($messages));
 }
+
+function fileHasValidExtension(\SplFileInfo $file): bool {
+	$extensions = [
+		'php',
+		'inc',
+		'js',
+		'css',
+	];
+	if ($file->isFile()) {
+		$fileName = basename($file->getFilename());
+		$fileParts = explode('.', $fileName);
+		if ($fileParts[0] === $fileName || $fileParts[0] === '') {
+			return false;
+		}
+
+		$fileExtensions = [];
+		array_shift($fileParts);
+		foreach ($fileParts as $part) {
+			$fileExtensions[] = implode('.', $fileParts);
+			array_shift($fileParts);
+		}
+		$matches = array_intersect($fileExtensions, $extensions);
+		if (empty($matches) === true) {
+			return false;
+		}
+	}
+	return true;
+}

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -281,23 +281,27 @@ function fileHasValidExtension(\SplFileInfo $file): bool {
 		'js',
 		'css',
 	];
-	if ($file->isFile()) {
-		$fileName = basename($file->getFilename());
-		$fileParts = explode('.', $fileName);
-		if ($fileParts[0] === $fileName || $fileParts[0] === '') {
-			return false;
-		}
-
-		$extensions = [];
-		array_shift($fileParts);
-		foreach ($fileParts as $part) {
-			$extensions[] = implode('.', $fileParts);
-			array_shift($fileParts);
-		}
-		$matches = array_intersect($extensions, $AllowedExtensions);
-		if (empty($matches) === true) {
-			return false;
-		}
+	// Extensions can only be checked for files.
+	if (!$file->isFile()) {
+		return false;
 	}
+
+	$fileName = basename($file->getFilename());
+	$fileParts = explode('.', $fileName);
+	if ($fileParts[0] === $fileName || $fileParts[0] === '') {
+		return false;
+	}
+
+	$extensions = [];
+	array_shift($fileParts);
+	foreach ($fileParts as $part) {
+		$extensions[] = implode('.', $fileParts);
+		array_shift($fileParts);
+	}
+	$matches = array_intersect($extensions, $AllowedExtensions);
+	if (empty($matches) === true) {
+		return false;
+	}
+
 	return true;
 }

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -274,7 +274,8 @@ function reportMessagesAndExit(PhpcsMessages $messages, string $reportType, arra
 }
 
 function fileHasValidExtension(\SplFileInfo $file): bool {
-	$extensions = [
+	// The followin logic follows the same in PHPCS. See https://github.com/squizlabs/PHP_CodeSniffer/blob/2ecd8dc15364cdd6e5089e82ffef2b205c98c412/src/Filters/Filter.php#L161
+	$AllowedExtensions = [
 		'php',
 		'inc',
 		'js',
@@ -287,13 +288,13 @@ function fileHasValidExtension(\SplFileInfo $file): bool {
 			return false;
 		}
 
-		$fileExtensions = [];
+		$extensions = [];
 		array_shift($fileParts);
 		foreach ($fileParts as $part) {
-			$fileExtensions[] = implode('.', $fileParts);
+			$extensions[] = implode('.', $fileParts);
 			array_shift($fileParts);
 		}
-		$matches = array_intersect($fileExtensions, $extensions);
+		$matches = array_intersect($extensions, $AllowedExtensions);
 		if (empty($matches) === true) {
 			return false;
 		}

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -43,9 +43,9 @@ $options = getopt(
 $fileNames = array_slice($argv, $optind);
 $fileNamesExpanded = [];
 foreach( $fileNames as $file ) {
-	if ( is_dir($file) ) {
+	if (is_dir($file)) {
 		$iterator = new RecursiveIteratorIterator(new RecursiveCallbackFilterIterator(new RecursiveDirectoryIterator($file, (RecursiveDirectoryIterator::SKIP_DOTS | FilesystemIterator::FOLLOW_SYMLINKS)), function($file, $key, $iterator){
-			if ( ! fileHasValidExtension( $file ) ) {
+			if (!fileHasValidExtension($file)) {
 				return false;
 			}
 			return $iterator->hasChildren() || $file->isFile() ? true : false;

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -44,9 +44,34 @@ $fileNamesExpanded = [];
 foreach( $fileNames as $file ) {
 	if ( is_dir($file) ) {
 		$iterator = new RecursiveIteratorIterator(new RecursiveCallbackFilterIterator(new RecursiveDirectoryIterator($file, (RecursiveDirectoryIterator::SKIP_DOTS | FilesystemIterator::FOLLOW_SYMLINKS)), function($file, $key, $iterator){
-			return $iterator->hasChildren() || ( $file->isFile() && '.php' === substr($file->getFilename(),-4) ) ? true : false;
+			$extensions = [
+				'php',
+				'inc',
+				'js',
+				'css',
+			];
+			if ($file->isFile()) {
+				$fileName = basename($file->getFilename());
+				$fileParts = explode('.', $fileName);
+				if ($fileParts[0] === $fileName || $fileParts[0] === '') {
+					return false;
+				}
+
+				$fileExtensions = [];
+				array_shift($fileParts);
+				foreach ($fileParts as $part) {
+					$fileExtensions[] = implode('.', $fileParts);
+					array_shift($fileParts);
+				}
+				$matches = array_intersect($fileExtensions, $extensions);
+				if (empty($matches) === true) {
+					return false;
+				}
+			}
+
+			return $iterator->hasChildren() || $file->isFile() ? true : false;
 		}));
-		foreach( $iterator as $file ) {
+		foreach ($iterator as $file) {
 			$fileNamesExpanded[] = $file->getPathName();
 		}
 	} else {

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -45,7 +45,8 @@ $fileNamesExpanded = [];
 foreach( $fileNames as $file ) {
 	if (is_dir($file)) {
 		$iterator = new RecursiveIteratorIterator(new RecursiveCallbackFilterIterator(new RecursiveDirectoryIterator($file, (RecursiveDirectoryIterator::SKIP_DOTS | FilesystemIterator::FOLLOW_SYMLINKS)), function($file, $key, $iterator){
-			if (!fileHasValidExtension($file)) {
+			
+			if ($file->isFile() && !fileHasValidExtension($file)) {
 				return false;
 			}
 			return $iterator->hasChildren() || $file->isFile() ? true : false;

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -15,7 +15,8 @@ use function PhpcsChanged\Cli\{
 	runManualWorkflow,
 	runSvnWorkflow,
 	runGitWorkflow,
-	reportMessagesAndExit
+	reportMessagesAndExit,
+	fileHasValidExtension
 };
 use PhpcsChanged\UnixShell;
 
@@ -44,31 +45,9 @@ $fileNamesExpanded = [];
 foreach( $fileNames as $file ) {
 	if ( is_dir($file) ) {
 		$iterator = new RecursiveIteratorIterator(new RecursiveCallbackFilterIterator(new RecursiveDirectoryIterator($file, (RecursiveDirectoryIterator::SKIP_DOTS | FilesystemIterator::FOLLOW_SYMLINKS)), function($file, $key, $iterator){
-			$extensions = [
-				'php',
-				'inc',
-				'js',
-				'css',
-			];
-			if ($file->isFile()) {
-				$fileName = basename($file->getFilename());
-				$fileParts = explode('.', $fileName);
-				if ($fileParts[0] === $fileName || $fileParts[0] === '') {
-					return false;
-				}
-
-				$fileExtensions = [];
-				array_shift($fileParts);
-				foreach ($fileParts as $part) {
-					$fileExtensions[] = implode('.', $fileParts);
-					array_shift($fileParts);
-				}
-				$matches = array_intersect($fileExtensions, $extensions);
-				if (empty($matches) === true) {
-					return false;
-				}
+			if ( ! fileHasValidExtension( $file ) ) {
+				return false;
 			}
-
 			return $iterator->hasChildren() || $file->isFile() ? true : false;
 		}));
 		foreach ($iterator as $file) {

--- a/tests/CliTest.php
+++ b/tests/CliTest.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+require_once dirname(__DIR__) . '/index.php';
+
+use PHPUnit\Framework\TestCase;
+use PhpcsChanged\PhpcsMessages;
+use function PhpcsChanged\{getNewPhpcsMessages, getNewPhpcsMessagesFromFiles};
+use function PhpcsChanged\Cli\fileHasValidExtension;
+
+class MockSplFileInfo extends SplFileInfo {
+	private $isFile = false;
+	public function setIsFile(bool $isFile): void {
+		$this->isFile = $isFile;
+	}
+
+	public function isFile(): bool {
+		return $this->isFile;
+	}
+}
+
+final class CliTest extends TestCase {
+	public function filesProvider() {
+		return [
+			'PHP File' => ['example.php', true, true],
+			'Dir' => ['example', false, false],
+			'JS File' => ['example.js', true, true],
+			'INC file' => ['example.inc', true, true],
+			'Dot File' => ['.example', true, false],
+			'Dot INC dot PHP' => ['example.inc.php', true, true],
+		];
+	}
+
+	/**
+	 * @dataProvider filesProvider
+	 */
+	public function testFileHasValidExtension( $fileName, $isFile, $hasValidExtension ) {
+
+		$file = new MockSplFileInfo($fileName);
+		$file->setIsFile($isFile);
+		$this->assertEquals(fileHasValidExtension($file), $hasValidExtension);
+	}
+}

--- a/tests/CliTest.php
+++ b/tests/CliTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 require_once dirname(__DIR__) . '/index.php';
 
 use PHPUnit\Framework\TestCase;
-use PhpcsChanged\PhpcsMessages;
-use function PhpcsChanged\{getNewPhpcsMessages, getNewPhpcsMessagesFromFiles};
 use function PhpcsChanged\Cli\fileHasValidExtension;
 
 class MockSplFileInfo extends SplFileInfo {


### PR DESCRIPTION
PHPCS which is internally used by the phpcs-changed allows more than .php files to be linted by default. This PR brings the default allowed extensions in phpcs-changed on par with phpcs.

The logic is a copy-paste from the phpcs, as it would validate the extensions using the very same logic again, so it should ideally work the same in both places.

Fixes #27 