### PR TITLE
Introduce TestShell for making it easier to introduce new tests

### DIFF
--- a/tests/helpers/Functions.php
+++ b/tests/helpers/Functions.php
@@ -1,0 +1,6 @@
+<?php
+declare(strict_types=1);
+
+namespace PhpcsChangedTests;
+
+function debug($message) {} //phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable

--- a/tests/helpers/TestShell.php
+++ b/tests/helpers/TestShell.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+
+namespace PhpcsChangedTests;
+
+use PhpcsChanged\ShellOperator;
+
+class TestShell implements ShellOperator {
+
+	private $readableFileNames = [];
+
+	private $commands = [];
+
+	public function __construct(array $readableFileNames) {
+		foreach ($readableFileNames as $fileName) {
+			$this->registerReadableFileName($fileName);
+		}
+	}
+
+	public function registerReadableFileName(string $fileName, bool $override = false): bool {
+		if (!isset($this->readableFileNames[$fileName]) || $override ) {
+			$this->readableFileNames[$fileName] = true;
+			return true;
+		}
+		throw new \Exception("Already registered file name: {$fileName}");
+	}
+
+	public function registerCommand(string $command, string $output, int $return_val = 0, bool $override = false): bool {
+		if (!isset($this->commands[$command]) || $override) {
+			$this->commands[$command] = [
+				'output' => $output,
+				'return_val' => $return_val,
+			];
+			return true;
+		}
+		throw new \Exception("Already registered command: {$command}");
+	}
+
+	public function isReadable(string $fileName): bool {
+		return isset($this->readableFileNames[$fileName]);
+	}
+
+	public function exitWithCode(int $code): void {} // phpcs:ignore VariableAnalysis
+
+	public function printError(string $message): void {} // phpcs:ignore VariableAnalysis
+
+	public function validateExecutableExists(string $name, string $command): void {} // phpcs:ignore VariableAnalysis
+
+	public function executeCommand(string $command, array &$output = null, int &$return_val = null): string {
+		foreach ($this->commands as $registeredCommand => $return) {
+			if ( false !== strpos($command, $registeredCommand) ) {
+				$return_val = $return['return_val'];
+				$output = $return['output'];
+				return $return['output'];
+			}
+		}
+
+		throw new \Exception("Unknown command: {$command}");
+	}
+}

--- a/tests/helpers/helpers.php
+++ b/tests/helpers/helpers.php
@@ -1,0 +1,7 @@
+<?php
+declare(strict_types=1);
+
+namespace PhpcsChangedTests;
+
+require_once __DIR__ . '/TestShell.php';
+require_once __DIR__ . '/Functions.php';


### PR DESCRIPTION
While working on the other PRs, I found it unnecessarily verbose to write an integration test.

Feels like it could be made easier and less error-prone (eg: having the class to throw an exception by default in case unknown command is run) in case the project would provide some helpers. Eg.: a TestShell class, which would do the heavy lifting, while letting the developer to only focus on registering the commands.

In the PR I'm also adding a test debug function implementation, which can be shared across the tests, again minimising the amount of code developer has to write (including the PHPCS exclusion comment).

Please, take this only as a proposal, and feel free to say "No" if you don't see the fit here :)