### PR TITLE
Add the ignore option and tests

### DIFF
--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -306,8 +306,8 @@ function fileHasValidExtension(\SplFileInfo $file): bool {
 	return true;
 }
 
-function shouldIgnorePath(string $path, string $patterns = null): bool {
-	if (null===$patterns) {
+function shouldIgnorePath(string $path, string $patternOption = null): bool {
+	if (null===$patternOption) {
 		return false;
 	}
 
@@ -316,7 +316,7 @@ function shouldIgnorePath(string $path, string $patterns = null): bool {
 	// using 1 or 3 slashes (\, or \\\,).
 	$patterns = preg_split(
 		'/(?<=(?<!\\\\)\\\\\\\\),|(?<!\\\\),/',
-		$patterns
+		$patternOption
 	);
 
 	$ignorePatterns = [];
@@ -347,8 +347,6 @@ function shouldIgnorePath(string $path, string $patterns = null): bool {
 		}
 	}
 
-	$relativePath = $path;
-
 	if (is_dir($path) === true) {
 		$ignorePatterns = $ignoreDirPatterns;
 	} else {
@@ -370,11 +368,7 @@ function shouldIgnorePath(string $path, string $patterns = null): bool {
 
 		$pattern = strtr($pattern, $replacements);
 
-		if ($type === 'relative') {
-			$testPath = $relativePath;
-		} else {
-			$testPath = $path;
-		}
+		$testPath = $path;
 
 		$pattern = '`'.$pattern.'`i';
 		if (preg_match($pattern, $testPath) === 1) {

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -122,6 +122,7 @@ EOF;
 		'--standard <STANDARD>' => 'The phpcs standard to use.',
 		'--report <REPORTER>' => 'The phpcs reporter to use. One of "full" (default) or "json".',
 		'-s' => 'Show sniff codes for each error when the reporter is "full".',
+		'--ignore <PATTERNS>' => 'A comma separated list of patterns to ignore files and directories.',
 		'--debug' => 'Enable debug output.',
 		'--help' => 'Print this help.',
 		'--version' => 'Print the current version.',

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -306,7 +306,11 @@ function fileHasValidExtension(\SplFileInfo $file): bool {
 	return true;
 }
 
-function shouldIgnorePath(string $path, $patterns = null): bool {
+function shouldIgnorePath(string $path, array $patterns = null): bool {
+	if ( null === $paterns ) {
+		return false;
+	}
+
 	/* Follows the logic in https://github.com/squizlabs/PHP_CodeSniffer/blob/1802f6b3827b66dc392219fdba27dadd2cd7d057/src/Config.php#L1156 */
 	// Split the ignore string on commas, unless the comma is escaped
 	// using 1 or 3 slashes (\, or \\\,).
@@ -352,13 +356,6 @@ function shouldIgnorePath(string $path, $patterns = null): bool {
 	}
 
 	foreach ($ignorePatterns as $pattern => $type) {
-		// Maintains backwards compatibility in case the ignore pattern does
-		// not have a relative/absolute value.
-		if (is_int($pattern) === true) {
-			$pattern = $type;
-			$type = 'absolute';
-		}
-
 		$replacements = [
 			'\\,' => ',',
 			'*'   => '.*',

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -319,6 +319,10 @@ function shouldIgnorePath(string $path, string $patternOption = null): bool {
 		$patternOption
 	);
 
+	if (!$patterns) {
+		return false;
+	}
+
 	$ignorePatterns = [];
 	foreach ($patterns as $pattern) {
 		$pattern = trim($pattern);

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -305,3 +305,85 @@ function fileHasValidExtension(\SplFileInfo $file): bool {
 
 	return true;
 }
+
+function shouldIgnorePath(string $path, $patterns = null): bool {
+	/* Follows the logic in https://github.com/squizlabs/PHP_CodeSniffer/blob/1802f6b3827b66dc392219fdba27dadd2cd7d057/src/Config.php#L1156 */
+	// Split the ignore string on commas, unless the comma is escaped
+	// using 1 or 3 slashes (\, or \\\,).
+	$patterns = preg_split(
+		'/(?<=(?<!\\\\)\\\\\\\\),|(?<!\\\\),/',
+		$patterns
+	);
+
+	$ignorePatterns = [];
+	foreach ($patterns as $pattern) {
+		$pattern = trim($pattern);
+		if ($pattern === '') {
+			continue;
+		}
+
+		$ignorePatterns[$pattern] = 'absolute';
+	}
+
+	/* Follows the logic in https://github.com/squizlabs/PHP_CodeSniffer/blob/2ecd8dc15364cdd6e5089e82ffef2b205c98c412/src/Filters/Filter.php#L198 */
+	$ignoreFilePatterns = [];
+	$ignoreDirPatterns = [];
+	foreach ($ignorePatterns as $pattern => $type) {
+		// If the ignore pattern ends with /* then it is ignoring an entire directory.
+		if (substr($pattern, -2) === '/*') {
+			// Need to check this pattern for dirs as well as individual file paths.
+			$ignoreFilePatterns[$pattern] = $type;
+
+			$pattern = substr($pattern, 0, -2);
+			$ignoreDirPatterns[$pattern] = $type;
+		} else {
+			// This is a file-specific pattern, so only need to check this
+			// for individual file paths.
+			$ignoreFilePatterns[$pattern] = $type;
+		}
+	}
+
+	$relativePath = $path;
+
+	if (is_dir($path) === true) {
+		$ignorePatterns = $ignoreDirPatterns;
+	} else {
+		$ignorePatterns = $ignoreFilePatterns;
+	}
+
+	foreach ($ignorePatterns as $pattern => $type) {
+		// Maintains backwards compatibility in case the ignore pattern does
+		// not have a relative/absolute value.
+		if (is_int($pattern) === true) {
+			$pattern = $type;
+			$type = 'absolute';
+		}
+
+		$replacements = [
+			'\\,' => ',',
+			'*'   => '.*',
+		];
+
+		// We assume a / directory separator, as do the exclude rules
+		// most developers write, so we need a special case for any system
+		// that is different.
+		if (DIRECTORY_SEPARATOR === '\\') {
+			$replacements['/'] = '\\\\';
+		}
+
+		$pattern = strtr($pattern, $replacements);
+
+		if ($type === 'relative') {
+			$testPath = $relativePath;
+		} else {
+			$testPath = $path;
+		}
+
+		$pattern = '`'.$pattern.'`i';
+		if (preg_match($pattern, $testPath) === 1) {
+			return true;
+		}
+	}
+	
+	return false;
+}

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -306,8 +306,8 @@ function fileHasValidExtension(\SplFileInfo $file): bool {
 	return true;
 }
 
-function shouldIgnorePath(string $path, array $patterns = null): bool {
-	if ( null === $paterns ) {
+function shouldIgnorePath(string $path, string $patterns = null): bool {
+	if (null===$paterns) {
 		return false;
 	}
 

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -307,7 +307,7 @@ function fileHasValidExtension(\SplFileInfo $file): bool {
 }
 
 function shouldIgnorePath(string $path, string $patterns = null): bool {
-	if (null===$paterns) {
+	if (null===$patterns) {
 		return false;
 	}
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ phpcs-changed --git --git-branch master file.php
 
 More than one file can be specified after a version control option, including globs and directories. If any file is a directory, phpcs-changed will scan the directory for all files ending in `.php` and process them. For example: `phpcs-changed --git src/lib test/**/*.php` will operate on all the php files in the `src/lib/` and `test/` directories.
 
+You can use `--ignore` to ignore any directory, file, or paths matching provided pattern(s). For example.: `--ignore=bin/*,vendor/*` would ignore any files in bin directory, as well as in vendor.
+
 You can use `--report` to customize the output type. `full` (the default) is human-readable and `json` prints a JSON object as shown above. These match the phpcs reporters of the same names.
 
 You can use `--standard` to specify a specific phpcs standard to run. This matches the phpcs option of the same name.

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -16,7 +16,8 @@ use function PhpcsChanged\Cli\{
 	runSvnWorkflow,
 	runGitWorkflow,
 	reportMessagesAndExit,
-	fileHasValidExtension
+	fileHasValidExtension,
+	shouldIgnorePath,
 };
 use PhpcsChanged\UnixShell;
 
@@ -36,7 +37,8 @@ $options = getopt(
 		'git-branch:',
 		'standard:',
 		'report:',
-		'debug'
+		'debug',
+		'ignore:',
 	],
 	$optind
 );
@@ -45,6 +47,9 @@ $fileNames = array_slice($argv, $optind);
 $fileNamesExpanded = [];
 foreach( $fileNames as $file ) {
 	if (is_dir($file)) {
+		if ( shouldIgnorePath($file, $options['ignore'] ?? null, '') ) {
+			continue;
+		}
 		$iterator = new RecursiveIteratorIterator(new RecursiveCallbackFilterIterator(new RecursiveDirectoryIterator($file, (RecursiveDirectoryIterator::SKIP_DOTS | FilesystemIterator::FOLLOW_SYMLINKS)), function($file, $key, $iterator){
 			
 			if ($file->isFile() && !fileHasValidExtension($file)) {
@@ -53,9 +58,12 @@ foreach( $fileNames as $file ) {
 			return $iterator->hasChildren() || $file->isFile() ? true : false;
 		}));
 		foreach ($iterator as $file) {
+			if (shouldIgnorePath($file->getPathName(), $options['ignore'] ?? null,'')) {
+				continue;
+			}
 			$fileNamesExpanded[] = $file->getPathName();
 		}
-	} else {
+	} elseif (!shouldIgnorePath($file,$options['ignore'] ?? null,'')) {
 		$fileNamesExpanded[] = $file;
 	}
 }

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -63,7 +63,7 @@ foreach( $fileNames as $file ) {
 			}
 			$fileNamesExpanded[] = $file->getPathName();
 		}
-	} elseif (!shouldIgnorePath($file,$options['ignore'] ?? null,'')) {
+	} elseif (!shouldIgnorePath($file, $options['ignore'] ?? null, '')) {
 		$fileNamesExpanded[] = $file;
 	}
 }

--- a/tests/CliTest.php
+++ b/tests/CliTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 require_once dirname(__DIR__) . '/index.php';
 
 use PHPUnit\Framework\TestCase;
-use function PhpcsChanged\Cli\fileHasValidExtension;
+use function PhpcsChanged\Cli\{fileHasValidExtension,shouldIgnorePath};
 
 class MockSplFileInfo extends SplFileInfo {
 	private $isFile = false;
@@ -37,5 +37,25 @@ final class CliTest extends TestCase {
 		$file = new MockSplFileInfo($fileName);
 		$file->setIsFile($isFile);
 		$this->assertEquals(fileHasValidExtension($file), $hasValidExtension);
+	}
+
+	public function ignoreProvider(): array {
+		return [
+			['bin/*', 'bin', true],
+			['*.php', 'bin/foobar.php', true],
+			['.php', 'bin/foobar.php', true],
+			['foobar.php', 'bin/foobar.php', true],
+			['.inc', 'bin/foobar.php', false],
+			['bar.php', 'foo.php', false],
+			['bar.phpfoo.php', 'bin/foobar.php', false],
+			['foobar.php,bin/', 'bin/foo.php', true],
+		];
+	}
+	
+	/**
+	 * @dataProvider ignoreProvider
+	 */
+	public function testShouldIgnorePath(string $pattern, string $path, bool $expected): void {
+		$this->assertEquals($expected, shouldIgnorePath($path, $pattern));
 	}
 }


### PR DESCRIPTION
PHPCS has an ignore option which allows developers to skip certain directories or files, specified via patterns.

In order to be able to use phpcs-changed as a drop-in replacement for phpcs, phpcs-changed should have the `--ignore` options which works similarly to the one in phpcs.

This PR introduces a `shouldIgnorePath` function, which follows the same logic the phpcs does when it's filtering the files (the function body is mostly a copy-paste of the original).

Part of the #26 .