### PR TITLE
Fix filename detection

### DIFF
--- a/PhpcsChanged/DiffLineMap.php
+++ b/PhpcsChanged/DiffLineMap.php
@@ -81,7 +81,7 @@ class DiffLineMap {
 		$diffStringLines = preg_split("/\r\n|\n|\r/", $unifiedDiff) ?: [];
 		foreach ($diffStringLines as $diffStringLine) {
 			$matches = [];
-			if (1 === preg_match('/^\-\-\- (\S+)/', $diffStringLine, $matches)) {
+			if (1 === preg_match('/^\+\+\+ (\S+)/', $diffStringLine, $matches)) {
 				return $matches[1] ?? null;
 			}
 		}


### PR DESCRIPTION
In case the interbranch git diff is used, the diff provided by git contains /dev/null instead of a real filename on the --- line when the file does not exist in the other branch.

I don't think that there was any specific reason to use the --- filename, insteand of the +++.