### PR TITLE
Add/xml reporter

### DIFF
--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -10,6 +10,7 @@ use PhpcsChanged\FullReporter;
 use PhpcsChanged\PhpcsMessages;
 use PhpcsChanged\DiffLineMap;
 use PhpcsChanged\ShellOperator;
+use PhpcsChanged\XmlReporter;
 use function PhpcsChanged\{getNewPhpcsMessages, getNewPhpcsMessagesFromFiles, getVersion};
 use function PhpcsChanged\SvnWorkflow\{getSvnUnifiedDiff, isNewSvnFile, getSvnBasePhpcsOutput, getSvnNewPhpcsOutput, validateSvnFileExists};
 use function PhpcsChanged\GitWorkflow\{getGitUnifiedDiff, isNewGitFile, getGitBasePhpcsOutput, getGitNewPhpcsOutput, validateGitFileExists};
@@ -145,6 +146,8 @@ function getReporter(string $reportType): Reporter {
 			return new FullReporter();
 		case 'json':
 			return new JsonReporter();
+		case 'xml':
+			return new XmlReporter();
 	}
 	printErrorAndExit("Unknown Reporter '{$reportType}'");
 }
@@ -381,6 +384,6 @@ function shouldIgnorePath(string $path, string $patternOption = null): bool {
 			return true;
 		}
 	}
-	
+
 	return false;
 }

--- a/PhpcsChanged/PhpcsMessage.php
+++ b/PhpcsChanged/PhpcsMessage.php
@@ -40,6 +40,18 @@ class PhpcsMessage {
 		return $this->otherProperties['source'] ?? '';
 	}
 
+	public function getFixable(): bool {
+		return $this->otherProperties['fixable'] ?? false;
+	}
+
+	public function getColumn(): int {
+		return $this->otherProperties['column'] ?? 0;
+	}
+
+	public function getSeverity(): int {
+		return $this->otherProperties['severity'] ?? 5;
+	}
+
 	public function toPhpcsArray(): array {
 		return array_merge([
 			'line' => $this->line,

--- a/PhpcsChanged/XmlReporter.php
+++ b/PhpcsChanged/XmlReporter.php
@@ -1,0 +1,65 @@
+<?php
+declare(strict_types=1);
+
+namespace PhpcsChanged;
+
+use PhpcsChanged\Reporter;
+use PhpcsChanged\PhpcsMessages;
+use PhpcsChanged\PhpcsMessage;
+
+class XmlReporter implements Reporter {
+	public function getFormattedMessages(PhpcsMessages $messages, array $options): string {
+		$files = array_unique(array_map(function(PhpcsMessage $message): string {
+			return $message->getFile() ?? 'STDIN';
+		}, $messages->getMessages()));
+		if (empty($files)) {
+			$files = ['STDIN'];
+		}
+
+		$outputByFile = array_reduce($files,function(string $output, string $file) use ($messages): string {
+			$messagesForFile = array_values(array_filter($messages->getMessages(), static function(PhpcsMessage $message) use ($file): bool {
+				return ($message->getFile() ?? 'STDIN') === $file;
+			}));
+			$output .= $this->getFormattedMessagesForFile($messagesForFile, $file);
+			return $output;
+		}, '');
+
+		$output =  "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
+		$output .= "<phpcs version=\"3.5.6\">\n";
+		$output .= $outputByFile;
+		$output .= "</phpcs>\n";
+
+		return $output;
+	}
+
+	private function getFormattedMessagesForFile(array $messages, string $file): string {
+		$errorCount = count( array_values(array_filter($messages, function($message) {
+			return $message->getType() === 'ERROR';
+		})));
+		$warningCount = count(array_values(array_filter($messages, function($message) {
+			return $message->getType() === 'WARNING';
+		})));
+		$fixableCount = count(array_values(array_filter($messages, function($message) {
+			return $message->getFixable();
+		})));
+		$xmlOutputForFile = "\t<file name=\"{$file}\" errors=\"{$errorCount}\" warnings=\"{$warningCount}\" fixable=\"{$fixableCount}\">\n";
+		$xmlOutputForFile .= array_reduce($messages, function(string $output, PhpcsMessage  $message): string{
+			$type = strtolower( $message->getType() );
+			$line = $message->getLineNumber();
+			$column = $message->getColumn();
+			$source = $message->getSource();
+			$severity = $message->getSeverity();
+			$fixable = $message->getFixable() ? "1" : "0";
+			$messageString = $message->getMessage();
+			$output .= "\t\t<{$type} line=\"{$line}\" column=\"{$column}\" source=\"{$source}\" severity=\"{$severity}\" fixable=\"{$fixable}\">{$messageString}</{$type}>\n";
+			return $output;
+		},'');
+		$xmlOutputForFile .= "\t</file>\n";
+
+		return $xmlOutputForFile;
+	}
+
+	public function getExitCode(PhpcsMessages $messages): int {
+		return (count($messages->getMessages()) > 0) ? 1 : 0;
+	}
+}

--- a/PhpcsChanged/XmlReporter.php
+++ b/PhpcsChanged/XmlReporter.php
@@ -10,6 +10,8 @@ use PhpcsChanged\UnixShell;
 use PhpcsChanged\ShellException;
 
 class XmlReporter implements Reporter {
+	// We don't need the $options array here, but it is required by the Reporter Interface
+	// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 	public function getFormattedMessages(PhpcsMessages $messages, array $options): string {
 		$files = array_unique(array_map(function(PhpcsMessage $message): string {
 			return $message->getFile() ?? 'STDIN';
@@ -35,6 +37,7 @@ class XmlReporter implements Reporter {
 
 		return $output;
 	}
+	// phpcs:enable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 
 	private function getFormattedMessagesForFile(array $messages, string $file): string {
 		$errorCount = count( array_values(array_filter($messages, function($message) {
@@ -63,7 +66,7 @@ class XmlReporter implements Reporter {
 		return $xmlOutputForFile;
 	}
 
-	private function getPhpcsVersion(): string {
+	protected function getPhpcsVersion(): string {
 		$phpcs = getenv('PHPCS') ?: 'phpcs';
 		$shell = new UnixShell();
 

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -18,12 +18,13 @@ use function PhpcsChanged\Cli\{
 	reportMessagesAndExit,
 	fileHasValidExtension,
 	shouldIgnorePath,
+	printInstalledCodingStandards
 };
 use PhpcsChanged\UnixShell;
 
 $optind = 0;
 $options = getopt(
-	'hs',
+	'hsi',
 	[
 		'help',
 		'version',
@@ -51,7 +52,6 @@ foreach( $fileNames as $file ) {
 			continue;
 		}
 		$iterator = new RecursiveIteratorIterator(new RecursiveCallbackFilterIterator(new RecursiveDirectoryIterator($file, (RecursiveDirectoryIterator::SKIP_DOTS | FilesystemIterator::FOLLOW_SYMLINKS)), function($file, $key, $iterator){
-
 			if ($file->isFile() && !fileHasValidExtension($file)) {
 				return false;
 			}
@@ -75,6 +75,10 @@ if (isset($options['h']) || isset($options['help'])) {
 
 if (isset($options['version'])) {
 	printVersion();
+}
+
+if (isset($options['i'])) {
+	printInstalledCodingStandards();
 }
 
 $debug = getDebug(isset($options['debug']));

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -51,7 +51,7 @@ foreach( $fileNames as $file ) {
 			continue;
 		}
 		$iterator = new RecursiveIteratorIterator(new RecursiveCallbackFilterIterator(new RecursiveDirectoryIterator($file, (RecursiveDirectoryIterator::SKIP_DOTS | FilesystemIterator::FOLLOW_SYMLINKS)), function($file, $key, $iterator){
-			
+
 			if ($file->isFile() && !fileHasValidExtension($file)) {
 				return false;
 			}

--- a/index.php
+++ b/index.php
@@ -12,6 +12,7 @@ require_once __DIR__ . '/PhpcsChanged/PhpcsMessages.php';
 require_once __DIR__ . '/PhpcsChanged/Reporter.php';
 require_once __DIR__ . '/PhpcsChanged/JsonReporter.php';
 require_once __DIR__ . '/PhpcsChanged/FullReporter.php';
+require_once __DIR__ . '/PhpcsChanged/XmlReporter.php';
 require_once __DIR__ . '/PhpcsChanged/NoChangesException.php';
 require_once __DIR__ . '/PhpcsChanged/ShellException.php';
 require_once __DIR__ . '/PhpcsChanged/ShellOperator.php';

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,7 +3,7 @@
         printerClass="LimeDeck\Testing\Printer"
         >
         <testsuites>
-                <testsuite>
+                <testsuite name="'all-tests">
                         <directory>tests</directory>
                 </testsuite>
         </testsuites>

--- a/tests/XmlReporterTest.php
+++ b/tests/XmlReporterTest.php
@@ -1,0 +1,258 @@
+<?php
+declare(strict_types=1);
+
+require_once dirname(__DIR__) . '/index.php';
+require_once __DIR__ . '/helpers/helpers.php';
+
+use PHPUnit\Framework\TestCase;
+use PhpcsChanged\PhpcsMessages;
+use PhpcsChangedTests\TestXmlReporter;
+
+final class XmlReporterTest extends TestCase {
+	public function testSingleWarning() {
+		$messages = PhpcsMessages::fromArrays([
+			[
+				'type' => 'WARNING',
+				'severity' => 5,
+				'fixable' => false,
+				'column' => 5,
+				'source' => 'ImportDetection.Imports.RequireImports.Import',
+				'line' => 15,
+				'message' => 'Found unused symbol Foo.',
+			],
+		], 'fileA.php');
+		$expected = <<<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<phpcs version="1.2.3">
+	<file name="fileA.php" errors="0" warnings="1" fixable="0">
+		<warning line="15" column="5" source="ImportDetection.Imports.RequireImports.Import" severity="5" fixable="0">Found unused symbol Foo.</warning>
+	</file>
+</phpcs>
+
+EOF;
+		$reporter = new TestXmlReporter();
+		$result = $reporter->getFormattedMessages($messages, []);
+		$this->assertEquals($expected, $result);
+	}
+
+	public function testSingleWarningWithShowCodeOption() {
+		$messages = PhpcsMessages::fromArrays([
+			[
+				'type' => 'WARNING',
+				'severity' => 5,
+				'fixable' => false,
+				'column' => 5,
+				'source' => 'ImportDetection.Imports.RequireImports.Import',
+				'line' => 15,
+				'message' => 'Found unused symbol Foo.',
+			],
+		], 'fileA.php');
+		$expected = <<<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<phpcs version="1.2.3">
+	<file name="fileA.php" errors="0" warnings="1" fixable="0">
+		<warning line="15" column="5" source="ImportDetection.Imports.RequireImports.Import" severity="5" fixable="0">Found unused symbol Foo.</warning>
+	</file>
+</phpcs>
+
+EOF;
+		$reporter = new TestXmlReporter();
+		$result = $reporter->getFormattedMessages($messages, ['s' => 1]);
+		$this->assertEquals($expected, $result);
+	}
+
+	public function testSingleWarningWithShowCodeOptionAndNoCode() {
+		$messages = PhpcsMessages::fromArrays([
+			[
+				'type' => 'WARNING',
+				'severity' => 5,
+				'fixable' => false,
+				'column' => 5,
+				'line' => 15,
+				'message' => 'Found unused symbol Foo.',
+			],
+		], 'fileA.php');
+		$expected = <<<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<phpcs version="1.2.3">
+	<file name="fileA.php" errors="0" warnings="1" fixable="0">
+		<warning line="15" column="5" source="" severity="5" fixable="0">Found unused symbol Foo.</warning>
+	</file>
+</phpcs>
+
+EOF;
+		$reporter = new TestXmlReporter();
+		$result = $reporter->getFormattedMessages($messages, ['s' => 1]);
+		$this->assertEquals($expected, $result);
+	}
+
+	public function testMultipleWarningsWithLongLineNumber() {
+		$messages = PhpcsMessages::fromArrays([
+			[
+				'type' => 'WARNING',
+				'severity' => 5,
+				'fixable' => false,
+				'column' => 5,
+				'source' => 'ImportDetection.Imports.RequireImports.Import',
+				'line' => 133825,
+				'message' => 'Found unused symbol Foo.',
+			],
+			[
+				'type' => 'WARNING',
+				'severity' => 5,
+				'fixable' => false,
+				'column' => 5,
+				'source' => 'ImportDetection.Imports.RequireImports.Import',
+				'line' => 15,
+				'message' => 'Found unused symbol Bar.',
+			],
+		], 'fileA.php');
+		$expected = <<<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<phpcs version="1.2.3">
+	<file name="fileA.php" errors="0" warnings="2" fixable="0">
+		<warning line="133825" column="5" source="ImportDetection.Imports.RequireImports.Import" severity="5" fixable="0">Found unused symbol Foo.</warning>
+		<warning line="15" column="5" source="ImportDetection.Imports.RequireImports.Import" severity="5" fixable="0">Found unused symbol Bar.</warning>
+	</file>
+</phpcs>
+
+EOF;
+		$reporter = new TestXmlReporter();
+		$result = $reporter->getFormattedMessages($messages, []);
+		$this->assertEquals($expected, $result);
+	}
+
+	public function testMultipleWarningsErrorsAndFiles() {
+		$messagesA = PhpcsMessages::fromArrays([
+			[
+				'type' => 'ERROR',
+				'severity' => 5,
+				'fixable' => true,
+				'column' => 2,
+				'source' => 'ImportDetection.Imports.RequireImports.Something',
+				'line' => 12,
+				'message' => 'Found unused symbol Faa.',
+			],
+			[
+				'type' => 'ERROR',
+				'severity' => 5,
+				'fixable' => false,
+				'column' => 5,
+				'source' => 'ImportDetection.Imports.RequireImports.Import',
+				'line' => 15,
+				'message' => 'Found unused symbol Foo.',
+			],
+			[
+				'type' => 'WARNING',
+				'severity' => 5,
+				'fixable' => false,
+				'column' => 8,
+				'source' => 'ImportDetection.Imports.RequireImports.Boom',
+				'line' => 18,
+				'message' => 'Found unused symbol Bar.',
+			],
+			[
+				'type' => 'WARNING',
+				'severity' => 5,
+				'fixable' => false,
+				'column' => 5,
+				'source' => 'ImportDetection.Imports.RequireImports.Import',
+				'line' => 22,
+				'message' => 'Found unused symbol Foo.',
+			],
+		], 'fileA.php');
+		$messagesB = PhpcsMessages::fromArrays([
+			[
+				'type' => 'WARNING',
+				'severity' => 5,
+				'fixable' => false,
+				'column' => 5,
+				'source' => 'ImportDetection.Imports.RequireImports.Zoop',
+				'line' => 30,
+				'message' => 'Found unused symbol Hi.',
+			],
+		], 'fileB.php');
+		$messages = PhpcsMessages::merge([$messagesA, $messagesB]);
+		$expected = <<<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<phpcs version="1.2.3">
+	<file name="fileA.php" errors="2" warnings="2" fixable="1">
+		<error line="12" column="2" source="ImportDetection.Imports.RequireImports.Something" severity="5" fixable="1">Found unused symbol Faa.</error>
+		<error line="15" column="5" source="ImportDetection.Imports.RequireImports.Import" severity="5" fixable="0">Found unused symbol Foo.</error>
+		<warning line="18" column="8" source="ImportDetection.Imports.RequireImports.Boom" severity="5" fixable="0">Found unused symbol Bar.</warning>
+		<warning line="22" column="5" source="ImportDetection.Imports.RequireImports.Import" severity="5" fixable="0">Found unused symbol Foo.</warning>
+	</file>
+	<file name="fileB.php" errors="0" warnings="1" fixable="0">
+		<warning line="30" column="5" source="ImportDetection.Imports.RequireImports.Zoop" severity="5" fixable="0">Found unused symbol Hi.</warning>
+	</file>
+</phpcs>
+
+EOF;
+		$reporter = new TestXmlReporter();
+		$result = $reporter->getFormattedMessages($messages, ['s' => 1]);
+		$this->assertEquals($expected, $result);
+	}
+
+	public function testNoWarnings() {
+		$messages = PhpcsMessages::fromArrays([]);
+		$expected = <<<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<phpcs version="1.2.3">
+	<file name="STDIN" errors="0" warnings="0" fixable="0">
+	</file>
+</phpcs>
+
+EOF;
+		$reporter = new TestXmlReporter();
+		$result = $reporter->getFormattedMessages($messages, []);
+		$this->assertEquals($expected, $result);
+	}
+
+	public function testSingleWarningWithNoFilename() {
+		$messages = PhpcsMessages::fromArrays([
+			[
+				'type' => 'WARNING',
+				'severity' => 5,
+				'fixable' => false,
+				'column' => 5,
+				'source' => 'ImportDetection.Imports.RequireImports.Import',
+				'line' => 15,
+				'message' => 'Found unused symbol Foo.',
+			],
+		]);
+		$expected = <<<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<phpcs version="1.2.3">
+	<file name="STDIN" errors="0" warnings="1" fixable="0">
+		<warning line="15" column="5" source="ImportDetection.Imports.RequireImports.Import" severity="5" fixable="0">Found unused symbol Foo.</warning>
+	</file>
+</phpcs>
+
+EOF;
+		$reporter = new TestXmlReporter();
+		$result = $reporter->getFormattedMessages($messages, []);
+		$this->assertEquals($expected, $result);
+	}
+
+	public function testGetExitCodeWithMessages() {
+		$messages = PhpcsMessages::fromArrays([
+			[
+				'type' => 'WARNING',
+				'severity' => 5,
+				'fixable' => false,
+				'column' => 5,
+				'source' => 'ImportDetection.Imports.RequireImports.Import',
+				'line' => 15,
+				'message' => 'Found unused symbol Foo.',
+			],
+		], 'fileA.php');
+		$reporter = new TestXmlReporter();
+		$this->assertEquals(1, $reporter->getExitCode($messages));
+	}
+
+	public function testGetExitCodeWithNoMessages() {
+		$messages = PhpcsMessages::fromArrays([], 'fileA.php');
+		$reporter = new TestXmlReporter();
+		$this->assertEquals(0, $reporter->getExitCode($messages));
+	}
+}

--- a/tests/helpers/TestXmlReporter.php
+++ b/tests/helpers/TestXmlReporter.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpcsChangedTests;
+
+use PhpcsChanged\XmlReporter;
+
+class TestXmlReporter extends XmlReporter {
+	protected function getPhpcsVersion(): string {
+		return '1.2.3';
+	}
+}

--- a/tests/helpers/helpers.php
+++ b/tests/helpers/helpers.php
@@ -5,3 +5,4 @@ namespace PhpcsChangedTests;
 
 require_once __DIR__ . '/TestShell.php';
 require_once __DIR__ . '/Functions.php';
+require_once __DIR__ . '/TestXmlReporter.php';


### PR DESCRIPTION
This pull request adds the XML report type and the `-i` (to show the list of installed coding standards) to mimic these features provided by `phpcs`. This is useful for users who want to use `phpcs-changed` with an IDE like PHPStorm which requires use of the XML report type.

In order to test the XML report, specify the option `--report=xml` when using `phpcs-changed`. Ex:

```
❯  phpcs-changed --report=xml --git myProject/foo.php
<?xml version="1.0" encoding="UTF-8"?>
<phpcs version="3.5.8">
	<file name="/home/delputnam/projects/myProject/foo.php" errors="0" warnings="1" fixable="0">
		<warning line="21" column="2" source="VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable" severity="5" fixable="0">Unused variable $x.</warning>
	</file>
</phpcs>
```

To view the installed coding standards:

```
❯  phpcs-changed -i
The installed coding standards are PEAR, Zend, PSR2, MySource, Squiz, PSR1, PSR12, ImportDetection and VariableAnalysis
```

This PR also includes unit tests for the new `XmlReporter` class.