### PR TITLE
git-base-object

### DIFF
--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -128,7 +128,8 @@ EOF;
 	printTwoColumns([
 		'--git-staged' => 'Compare the staged version to the HEAD version (this is the default).',
 		'--git-unstaged' => 'Compare the working copy version to the staged (or HEAD) version.',
-		'--git-branch <BRANCH>' => 'Compare the HEAD version to the HEAD of a different branch.',
+		'--git-branch <BRANCH>' => 'Compare the HEAD version to the HEAD of a different branch (deprecated in favor of --git-base).',
+		'--git-base <OBJECT>' => 'Compare the HEAD version to version found in OBJECT which can be a branch, commit, or other git object.',
 	], "	");
 
 	echo <<<EOF

--- a/README.md
+++ b/README.md
@@ -83,11 +83,11 @@ phpcs-changed --git --git-unstaged file.php
 
 You should specify `--git-staged` or `--git-unstaged` to tell `phpcs-changed` if you want to compare the current staged changes or the current working copy changes, respectively. The default is `--git-staged`.
 
-Alternatively, if you want to compare the current committed HEAD changes to another branch, you can use the `--git-branch` option followed by a branch name:
+Alternatively, if you want to compare the current committed HEAD changes to another object (which can be a branch, a commit, or another object), you can use the `--git-base` option followed by an object name:
 
 ```
 git checkout add-new-feature
-phpcs-changed --git --git-branch master file.php
+phpcs-changed --git --git-base master file.php
 ```
 
 ### CLI Options

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -36,6 +36,7 @@ $options = getopt(
 		'git-unstaged',
 		'git-staged',
 		'git-branch:',
+		'git-base:',
 		'standard:',
 		'report:',
 		'debug',
@@ -79,6 +80,12 @@ if (isset($options['version'])) {
 
 if (isset($options['i'])) {
 	printInstalledCodingStandards();
+}
+
+// --git-branch exists for compatibility, --git-bases supports branches
+if (isset($options['git-branch'])) {
+	$options['git-base'] = $options['git-branch'];
+	unset($options['git-branch']);
 }
 
 $debug = getDebug(isset($options['debug']));

--- a/tests/GitWorkflowTest.php
+++ b/tests/GitWorkflowTest.php
@@ -349,7 +349,7 @@ EOF;
 		$shell->registerCommand("git cat-file -e 'master':'bin/foobar.php'", '');
 		$shell->registerCommand("git show 'master':$(git ls-files --full-name 'bin/foobar.php') | phpcs --report=json -q --stdin-path='bin/foobar.php' -", '{"totals":{"errors":0,"warnings":1,"fixable":0},"files":{"\/srv\/www\/wordpress-default\/public_html\/test\/bin\/foobar.php":{"errors":0,"warnings":1,"messages":[{"message":"Found unused symbol Emergent.","source":"ImportDetection.Imports.RequireImports.Import","severity":5,"fixable":false,"type":"WARNING","line":6,"column":5}]}}}');
 		$shell->registerCommand("git show HEAD:$(git ls-files --full-name 'bin/foobar.php') | phpcs --report=json -q --stdin-path='bin/foobar.php' -", '{"totals":{"errors":0,"warnings":2,"fixable":0},"files":{"\/srv\/www\/wordpress-default\/public_html\/test\/bin\/foobar.php":{"errors":0,"warnings":2,"messages":[{"message":"Found unused symbol Foobar.","source":"ImportDetection.Imports.RequireImports.Import","severity":5,"fixable":false,"type":"WARNING","line":6,"column":5},{"message":"Found unused symbol Emergent.","source":"ImportDetection.Imports.RequireImports.Import","severity":5,"fixable":false,"type":"WARNING","line":7,"column":5}]}}}');
-		$options = [ 'git-branch' => 'master' ];
+		$options = [ 'git-base' => 'master' ];
 		$expected = PhpcsMessages::fromArrays([
 			[
 				'type' => 'WARNING',
@@ -383,7 +383,7 @@ EOF;
 		$shell->registerCommand("git diff 'master'... --no-prefix 'test.php'", $fixture);
 		$shell->registerCommand("git cat-file -e 'master':'test.php'", '', 128);
 		$shell->registerCommand("git show HEAD:$(git ls-files --full-name 'test.php') | phpcs --report=json -q --stdin-path='test.php' -", '{"totals":{"errors":0,"warnings":3,"fixable":0},"files":{"\/srv\/www\/wordpress-default\/public_html\/test\/test.php":{"errors":0,"warnings":3,"messages":[{"message":"Found unused symbol ' . "'Foobar'" . '.","source":"ImportDetection.Imports.RequireImports.Import","severity":5,"fixable":false,"type":"WARNING","line":6,"column":5},{"message":"Found unused symbol ' . "'Foobar'" . '.","source":"ImportDetection.Imports.RequireImports.Import","severity":5,"fixable":false,"type":"WARNING","line":7,"column":5},{"message":"Found unused symbol ' . "'Billing\\\\Emergent'" . '.","source":"ImportDetection.Imports.RequireImports.Import","severity":5,"fixable":false,"type":"WARNING","line":8,"column":5}]}}}');
-		$options = [ 'git-branch' => 'master' ];
+		$options = [ 'git-base' => 'master' ];
 		$expected = PhpcsMessages::fromArrays([
 			[
 				'type' => 'WARNING',


### PR DESCRIPTION
Introduces `--git-base-object`, which is accidentally compatible with the
current `--git-branch` implementation. Merge them as to make the behavior
official