### PR TITLE
Fetch correct old file versions

### DIFF
--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -15,7 +15,7 @@ use PhpcsChanged\UnixShell;
 use PhpcsChanged\XmlReporter;
 use function PhpcsChanged\{getNewPhpcsMessages, getNewPhpcsMessagesFromFiles, getVersion};
 use function PhpcsChanged\SvnWorkflow\{getSvnUnifiedDiff, isNewSvnFile, getSvnBasePhpcsOutput, getSvnNewPhpcsOutput, validateSvnFileExists};
-use function PhpcsChanged\GitWorkflow\{getGitUnifiedDiff, isNewGitFile, getGitBasePhpcsOutput, getGitNewPhpcsOutput, validateGitFileExists};
+use function PhpcsChanged\GitWorkflow\{getGitMergeBase, getGitUnifiedDiff, isNewGitFile, getGitBasePhpcsOutput, getGitNewPhpcsOutput, validateGitFileExists};
 
 function getDebug(bool $debugEnabled): callable {
 	return function(...$outputs) use ($debugEnabled) {
@@ -252,6 +252,9 @@ function runGitWorkflow(array $gitFiles, array $options, ShellOperator $shell, c
 		$shell->validateExecutableExists('phpcs', $phpcs);
 		$shell->validateExecutableExists('cat', $cat);
 		$debug('executables are valid');
+		if (isset($options['git-base']) && ! empty($options['git-base'])) {
+			$options['git-base'] = getGitMergeBase($git, [$shell, 'executeCommand'], $options, $debug);
+		}
 	} catch(\Exception $err) {
 		$shell->printError($err->getMessage());
 		$shell->exitWithCode(1);

--- a/PhpcsChanged/GitWorkflow.php
+++ b/PhpcsChanged/GitWorkflow.php
@@ -19,6 +19,21 @@ function validateGitFileExists(string $gitFile, string $git, callable $isReadabl
 	}
 }
 
+function getGitMergeBase(string $git, callable $executeCommand, array $options, callable $debug): string {
+	if ( empty($options['git-base']) ) {
+		return '';
+	}
+	$mergeBaseCommand = "{$git} merge-base " . escapeshellarg($options['git-base']) . ' HEAD';
+	$debug('running merge-base command:', $mergeBaseCommand);
+	$mergeBase = $executeCommand($mergeBaseCommand);
+	if (! $mergeBase) {
+		$debug('merge-base command produced no output');
+		return $options['git-base'];
+	}
+	$debug('merge-base command output:', $mergeBase);
+	return trim($mergeBase);
+}
+
 function getGitUnifiedDiff(string $gitFile, string $git, callable $executeCommand, array $options, callable $debug): string {
 	$objectOption = isset($options['git-base']) && ! empty($options['git-base']) ? ' ' . escapeshellarg($options['git-base']) . '...' : '';
 	$stagedOption = empty( $objectOption ) && ! isset($options['git-unstaged']) ? ' --staged' : '';

--- a/tests/GitWorkflowTest.php
+++ b/tests/GitWorkflowTest.php
@@ -344,10 +344,11 @@ index c012707..319ecf3 100644
  use Billing\Monetary_Amount;
  use Stripe\Error;
 EOF;
-		$shell->registerCommand("git diff 'master'... --no-prefix 'bin/foobar.php'", $fixture);
+		$shell->registerCommand("git merge-base 'master' HEAD", "0123456789abcdef0123456789abcdef01234567\n");
+		$shell->registerCommand("git diff '0123456789abcdef0123456789abcdef01234567'... --no-prefix 'bin/foobar.php'", $fixture);
 		$shell->registerCommand("git status --short 'bin/foobar.php'", '');
-		$shell->registerCommand("git cat-file -e 'master':'bin/foobar.php'", '');
-		$shell->registerCommand("git show 'master':$(git ls-files --full-name 'bin/foobar.php') | phpcs --report=json -q --stdin-path='bin/foobar.php' -", '{"totals":{"errors":0,"warnings":1,"fixable":0},"files":{"\/srv\/www\/wordpress-default\/public_html\/test\/bin\/foobar.php":{"errors":0,"warnings":1,"messages":[{"message":"Found unused symbol Emergent.","source":"ImportDetection.Imports.RequireImports.Import","severity":5,"fixable":false,"type":"WARNING","line":6,"column":5}]}}}');
+		$shell->registerCommand("git cat-file -e '0123456789abcdef0123456789abcdef01234567':'bin/foobar.php'", '');
+		$shell->registerCommand("git show '0123456789abcdef0123456789abcdef01234567':$(git ls-files --full-name 'bin/foobar.php') | phpcs --report=json -q --stdin-path='bin/foobar.php' -", '{"totals":{"errors":0,"warnings":1,"fixable":0},"files":{"\/srv\/www\/wordpress-default\/public_html\/test\/bin\/foobar.php":{"errors":0,"warnings":1,"messages":[{"message":"Found unused symbol Emergent.","source":"ImportDetection.Imports.RequireImports.Import","severity":5,"fixable":false,"type":"WARNING","line":6,"column":5}]}}}');
 		$shell->registerCommand("git show HEAD:$(git ls-files --full-name 'bin/foobar.php') | phpcs --report=json -q --stdin-path='bin/foobar.php' -", '{"totals":{"errors":0,"warnings":2,"fixable":0},"files":{"\/srv\/www\/wordpress-default\/public_html\/test\/bin\/foobar.php":{"errors":0,"warnings":2,"messages":[{"message":"Found unused symbol Foobar.","source":"ImportDetection.Imports.RequireImports.Import","severity":5,"fixable":false,"type":"WARNING","line":6,"column":5},{"message":"Found unused symbol Emergent.","source":"ImportDetection.Imports.RequireImports.Import","severity":5,"fixable":false,"type":"WARNING","line":7,"column":5}]}}}');
 		$options = [ 'git-base' => 'master' ];
 		$expected = PhpcsMessages::fromArrays([
@@ -380,8 +381,9 @@ index 0000000..b3d9bbc
 +<?php
 
 EOF;
-		$shell->registerCommand("git diff 'master'... --no-prefix 'test.php'", $fixture);
-		$shell->registerCommand("git cat-file -e 'master':'test.php'", '', 128);
+		$shell->registerCommand("git merge-base 'master' HEAD", "0123456789abcdef0123456789abcdef01234567\n");
+		$shell->registerCommand("git diff '0123456789abcdef0123456789abcdef01234567'... --no-prefix 'test.php'", $fixture);
+		$shell->registerCommand("git cat-file -e '0123456789abcdef0123456789abcdef01234567':'test.php'", '', 128);
 		$shell->registerCommand("git show HEAD:$(git ls-files --full-name 'test.php') | phpcs --report=json -q --stdin-path='test.php' -", '{"totals":{"errors":0,"warnings":3,"fixable":0},"files":{"\/srv\/www\/wordpress-default\/public_html\/test\/test.php":{"errors":0,"warnings":3,"messages":[{"message":"Found unused symbol ' . "'Foobar'" . '.","source":"ImportDetection.Imports.RequireImports.Import","severity":5,"fixable":false,"type":"WARNING","line":6,"column":5},{"message":"Found unused symbol ' . "'Foobar'" . '.","source":"ImportDetection.Imports.RequireImports.Import","severity":5,"fixable":false,"type":"WARNING","line":7,"column":5},{"message":"Found unused symbol ' . "'Billing\\\\Emergent'" . '.","source":"ImportDetection.Imports.RequireImports.Import","severity":5,"fixable":false,"type":"WARNING","line":8,"column":5}]}}}');
 		$options = [ 'git-base' => 'master' ];
 		$expected = PhpcsMessages::fromArrays([


### PR DESCRIPTION
When `--git-base` is used, we use `git diff $BASE...` to fetch the diff,
which will diff against the merge-base of $BASE and HEAD rather than
against $BASE itself.

When we run phpcs for the old file versions, we run it against the
version from $BASE itself rather than the merge-base version.

Since the diff does not match the versions of the files used to produce
the phpcs output, the line number correction may fail and unchanged
issues may be incorrectly reported.

This PR adds an initial step that replaces the passed --git-base with
the merge-base commit hash so later steps use the correct file versions.

Fixes #42