### PR TITLE
Add caching of phpcs results

### DIFF
--- a/PhpcsChanged/CacheEntry.php
+++ b/PhpcsChanged/CacheEntry.php
@@ -12,7 +12,7 @@ class CacheEntry implements \JsonSerializable {
 	/**
 	 * @var string
 	 */
-	public $phpcsStandard;
+	public $cacheKey;
 
 	/**
 	 * @var string
@@ -22,7 +22,7 @@ class CacheEntry implements \JsonSerializable {
 	public function jsonSerialize(): array {
 		return [
 			'path' => $this->path,
-			'phpcsStandard' => $this->phpcsStandard,
+			'cacheKey' => $this->cacheKey,
 			'data' => $this->data,
 		];
 	}

--- a/PhpcsChanged/CacheEntry.php
+++ b/PhpcsChanged/CacheEntry.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace PhpcsChanged\Cache;
+namespace PhpcsChanged;
 
 class CacheEntry implements \JsonSerializable {
 	/**

--- a/PhpcsChanged/CacheEntry.php
+++ b/PhpcsChanged/CacheEntry.php
@@ -12,7 +12,12 @@ class CacheEntry implements \JsonSerializable {
 	/**
 	 * @var string
 	 */
-	public $cacheKey;
+	public $hash;
+
+	/**
+	 * @var string
+	 */
+	public $phpcsStandard;
 
 	/**
 	 * @var string
@@ -22,8 +27,18 @@ class CacheEntry implements \JsonSerializable {
 	public function jsonSerialize(): array {
 		return [
 			'path' => $this->path,
-			'cacheKey' => $this->cacheKey,
+			'hash' => $this->hash,
+			'phpcsStandard' => $this->phpcsStandard,
 			'data' => $this->data,
 		];
+	}
+
+	public static function fromJson(array $deserializedJson): self {
+		$entry = new CacheEntry();
+		$entry->path = $deserializedJson['path'];
+		$entry->hash = $deserializedJson['hash'];
+		$entry->phpcsStandard = $deserializedJson['phpcsStandard'];
+		$entry->data = $deserializedJson['data'];
+		return $entry;
 	}
 }

--- a/PhpcsChanged/CacheEntry.php
+++ b/PhpcsChanged/CacheEntry.php
@@ -12,6 +12,11 @@ class CacheEntry implements \JsonSerializable {
 	/**
 	 * @var string
 	 */
+	public $type;
+
+	/**
+	 * @var string
+	 */
 	public $hash;
 
 	/**
@@ -28,6 +33,7 @@ class CacheEntry implements \JsonSerializable {
 		return [
 			'path' => $this->path,
 			'hash' => $this->hash,
+			'type' => $this->type,
 			'phpcsStandard' => $this->phpcsStandard,
 			'data' => $this->data,
 		];
@@ -37,8 +43,13 @@ class CacheEntry implements \JsonSerializable {
 		$entry = new CacheEntry();
 		$entry->path = $deserializedJson['path'];
 		$entry->hash = $deserializedJson['hash'];
+		$entry->type = $deserializedJson['type'];
 		$entry->phpcsStandard = $deserializedJson['phpcsStandard'];
 		$entry->data = $deserializedJson['data'];
 		return $entry;
+	}
+
+	public function __toString(): string {
+		return "Cache entry for file '{$this->path}', type '{$this->type}', hash '{$this->hash}', standard '{$this->phpcsStandard}': {$this->data}";
 	}
 }

--- a/PhpcsChanged/CacheInterface.php
+++ b/PhpcsChanged/CacheInterface.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-namespace PhpcsChanged\Cache;
+namespace PhpcsChanged;
 
-use PhpcsChanged\Cache\CacheManager;
+use PhpcsChanged\CacheManager;
 
 interface CacheInterface {
 	public function load(CacheManager $manager): void;

--- a/PhpcsChanged/CacheManager.php
+++ b/PhpcsChanged/CacheManager.php
@@ -40,6 +40,11 @@ class CacheManager {
 
 	public function load(): void {
 		$this->cache->load($this);
+		// Don't try to use old cache versions
+		if ($this->cacheVersion !== getVersion()) {
+			$this->clearCache();
+			$this->cacheVersion = getVersion();
+		}
 		$this->hasBeenModified = false;
 	}
 

--- a/PhpcsChanged/CacheManager.php
+++ b/PhpcsChanged/CacheManager.php
@@ -5,6 +5,7 @@ namespace PhpcsChanged;
 
 use PhpcsChanged\CacheInterface;
 use PhpcsChanged\CacheEntry;
+use function PhpcsChanged\getVersion;
 
 class CacheManager {
 	/**
@@ -18,6 +19,11 @@ class CacheManager {
 	private $revisionId;
 
 	/**
+	 * @var string
+	 */
+	private $cacheVersion;
+
+	/**
 	 * @var bool
 	 */
 	private $hasBeenModified = false;
@@ -29,6 +35,7 @@ class CacheManager {
 
 	public function __construct(CacheInterface $cache) {
 		$this->cache = $cache;
+		$this->cacheVersion = getVersion();
 	}
 
 	public function load(): void {
@@ -48,6 +55,10 @@ class CacheManager {
 		return $this->revisionId;
 	}
 
+	public function getCacheVersion(): string {
+		return $this->cacheVersion;
+	}
+
 	/**
 	 * @return CacheEntry[]
 	 */
@@ -55,6 +66,15 @@ class CacheManager {
 		return array_reduce($this->fileDataByPath, function(array $entries, array $entriesByStandard): array {
 			return array_merge($entries, array_values($entriesByStandard));
 		}, []);
+	}
+
+	public function setCacheVersion(string $cacheVersion): void {
+		if ($this->cacheVersion === $cacheVersion) {
+			return;
+		}
+		$this->hasBeenModified = true;
+		$this->clearCache();
+		$this->cacheVersion = $cacheVersion;
 	}
 
 	public function setRevision(string $revisionId): void {

--- a/PhpcsChanged/CacheManager.php
+++ b/PhpcsChanged/CacheManager.php
@@ -53,19 +53,25 @@ class CacheManager {
 	}
 
 	public function load(): void {
+		($this->debug)("Loading cache...");
 		$this->cache->load($this);
 		// Don't try to use old cache versions
-		if ($this->cacheVersion !== getVersion()) {
+		$version = getVersion();
+		if ($this->cacheVersion !== $version) {
+			($this->debug)("Cache version has changed ({$this->cacheVersion} -> {$version}). Clearing cache.");
 			$this->clearCache();
-			$this->cacheVersion = getVersion();
+			$this->cacheVersion = $version;
 		}
 		$this->hasBeenModified = false;
+		($this->debug)("Cache loaded.");
 	}
 
 	public function save(): void {
 		if (! $this->hasBeenModified) {
+			($this->debug)("Not saving cache. It is unchanged.");
 			return;
 		}
+		($this->debug)("Saving cache.");
 		$this->cache->save($this);
 		$this->hasBeenModified = false;
 	}
@@ -108,7 +114,8 @@ class CacheManager {
 	}
 
 	public function setCacheVersion(string $cacheVersion): void {
-		if ($this->cacheVersion === $cacheVersion) {
+		if (! $this->cacheVersion || $this->cacheVersion === $cacheVersion) {
+			$this->cacheVersion = $cacheVersion;
 			return;
 		}
 		($this->debug)("Cache version has changed ('{$this->cacheVersion}' -> '{$cacheVersion}'). Clearing cache.");
@@ -118,7 +125,8 @@ class CacheManager {
 	}
 
 	public function setRevision(string $revisionId): void {
-		if ($this->revisionId === $revisionId) {
+		if (! $this->revisionId || $this->revisionId === $revisionId) {
+			$this->revisionId = $revisionId;
 			return;
 		}
 		($this->debug)("Revision has changed ('{$this->revisionId}' -> '{$revisionId}'). Clearing cache.");

--- a/PhpcsChanged/CacheManager.php
+++ b/PhpcsChanged/CacheManager.php
@@ -146,6 +146,9 @@ class CacheManager {
 
 	// Keep only one actual hash key (a new file) and one empty hash key (an old file) per file path
 	private function pruneOldEntriesForFile(CacheEntry $entry): void {
+		if ($entry->hash === '') {
+			return;
+		}
 		$hashKeysForFile = array_keys($this->fileDataByPath[$entry->path]);
 		foreach($hashKeysForFile as $hash) {
 			if ($hash === '' || $hash === $entry->hash) {

--- a/PhpcsChanged/CacheManager.php
+++ b/PhpcsChanged/CacheManager.php
@@ -141,6 +141,19 @@ class CacheManager {
 			$this->fileDataByPath[$entry->path][$entry->hash] = [];
 		}
 		$this->fileDataByPath[$entry->path][$entry->hash][$entry->phpcsStandard] = $entry;
+		$this->pruneOldEntriesForFile($entry);
+	}
+
+	// Keep only one actual hash key (a new file) and one empty hash key (an old file) per file path
+	private function pruneOldEntriesForFile(CacheEntry $entry): void {
+		$hashKeysForFile = array_keys($this->fileDataByPath[$entry->path]);
+		foreach($hashKeysForFile as $hash) {
+			if ($hash === '' || $hash === $entry->hash) {
+				continue;
+			}
+			$this->hasBeenModified = true;
+			unset($this->fileDataByPath[$entry->path][$hash]);
+		}
 	}
 
 	public function clearCache(): void {

--- a/PhpcsChanged/CacheManager.php
+++ b/PhpcsChanged/CacheManager.php
@@ -1,10 +1,10 @@
 <?php
 declare(strict_types=1);
 
-namespace PhpcsChanged\Cache;
+namespace PhpcsChanged;
 
-use PhpcsChanged\Cache\CacheInterface;
-use PhpcsChanged\Cache\CacheEntry;
+use PhpcsChanged\CacheInterface;
+use PhpcsChanged\CacheEntry;
 
 class CacheManager {
 	/**

--- a/PhpcsChanged/CacheManager.php
+++ b/PhpcsChanged/CacheManager.php
@@ -114,4 +114,3 @@ class CacheManager {
 		$this->fileDataByPath = [];
 	}
 }
-

--- a/PhpcsChanged/CacheManager.php
+++ b/PhpcsChanged/CacheManager.php
@@ -62,8 +62,8 @@ class CacheManager {
 			return;
 		}
 		$this->hasBeenModified = true;
-		$this->revisionId = $revisionId;
 		$this->clearCache();
+		$this->revisionId = $revisionId;
 	}
 
 	public function getCacheForFile(string $filePath, string $phpcsStandard): ?string {
@@ -85,6 +85,7 @@ class CacheManager {
 
 	public function clearCache(): void {
 		$this->hasBeenModified = true;
+		$this->revisionId = '';
 		$this->fileDataByPath = [];
 	}
 }

--- a/PhpcsChanged/CacheManager.php
+++ b/PhpcsChanged/CacheManager.php
@@ -66,21 +66,21 @@ class CacheManager {
 		$this->revisionId = $revisionId;
 	}
 
-	public function getCacheForFile(string $filePath, string $phpcsStandard): ?string {
-		$entry = $this->fileDataByPath[$filePath][$phpcsStandard] ?? null;
+	public function getCacheForFile(string $filePath, string $cacheKey): ?string {
+		$entry = $this->fileDataByPath[$filePath][$cacheKey] ?? null;
 		return $entry->data ?? null;
 	}
 
-	public function setCacheForFile(string $filePath, string $data, string $phpcsStandard): void {
+	public function setCacheForFile(string $filePath, string $data, string $cacheKey): void {
 		$this->hasBeenModified = true;
 		$entry = new CacheEntry();
-		$entry->phpcsStandard = $phpcsStandard;
+		$entry->cacheKey = $cacheKey;
 		$entry->data = $data;
 		$entry->path = $filePath;
 		if (! isset($this->fileDataByPath[$filePath])) {
 			$this->fileDataByPath[$filePath] = [];
 		}
-		$this->fileDataByPath[$filePath][$phpcsStandard] = $entry;
+		$this->fileDataByPath[$filePath][$cacheKey] = $entry;
 	}
 
 	public function clearCache(): void {

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -238,10 +238,10 @@ function runSvnWorkflowForFile(string $svnFile, array $options, ShellOperator $s
 			$cache->setRevision($revisionId);
 			$oldFilePhpcsOutput = $cache->getCacheForFile($svnFile, $phpcsStandard ?? '');
 			if ($oldFilePhpcsOutput) {
-				$debug("Using cache for '{$svnFile}'");
+				$debug("Using cache for '{$svnFile}' at revision '{$revisionId}' and standard '{$phpcsStandard}'");
 			}
 			if (! $oldFilePhpcsOutput) {
-				$debug("Not using cache for '{$svnFile}'");
+				$debug("Not using cache for '{$svnFile}' at revision '{$revisionId}' and standard '{$phpcsStandard}'");
 				$oldFilePhpcsOutput = getSvnBasePhpcsOutput($svnFile, $svn, $phpcs, $phpcsStandardOption, [$shell, 'executeCommand'], $debug);
 				$cache->setCacheForFile($svnFile, $oldFilePhpcsOutput, $phpcsStandard ?? '');
 			}

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -241,26 +241,26 @@ function runSvnWorkflowForFile(string $svnFile, array $options, ShellOperator $s
 		if ( ! $isNewFile ) {
 			$cache->setRevision($revisionId);
 
-			$oldFilePhpcsOutput = $cache->getCacheForFile($svnFile, '', $phpcsStandard ?? '');
+			$oldFilePhpcsOutput = $cache->getCacheForFile($svnFile, 'old', '', $phpcsStandard ?? '');
 			if ($oldFilePhpcsOutput) {
 				$debug("Using cache for old file '{$svnFile}' at revision '{$revisionId}' and standard '{$phpcsStandard}'");
 			}
 			if (! $oldFilePhpcsOutput) {
 				$debug("Not using cache for old file '{$svnFile}' at revision '{$revisionId}' and standard '{$phpcsStandard}'");
 				$oldFilePhpcsOutput = getSvnBasePhpcsOutput($svnFile, $svn, $phpcs, $phpcsStandardOption, [$shell, 'executeCommand'], $debug);
-				$cache->setCacheForFile($svnFile, '', $phpcsStandard ?? '', $oldFilePhpcsOutput);
+				$cache->setCacheForFile($svnFile, 'old', '', $phpcsStandard ?? '', $oldFilePhpcsOutput);
 			}
 		}
 
 		$newFileHash = $shell->getFileHash($svnFile);
-		$newFilePhpcsOutput = $cache->getCacheForFile($svnFile, $newFileHash, $phpcsStandard ?? '');
+		$newFilePhpcsOutput = $cache->getCacheForFile($svnFile, 'new', $newFileHash, $phpcsStandard ?? '');
 		if ($newFilePhpcsOutput) {
 			$debug("Using cache for new file '{$svnFile}' at revision '{$revisionId}', hash '{$newFileHash}', and standard '{$phpcsStandard}'");
 		}
 		if (! $newFilePhpcsOutput) {
 			$debug("Not using cache for new file '{$svnFile}' at revision '{$revisionId}', hash '{$newFileHash}', and standard '{$phpcsStandard}'");
 			$newFilePhpcsOutput = getSvnNewPhpcsOutput($svnFile, $phpcs, $cat, $phpcsStandardOption, [$shell, 'executeCommand'], $debug);
-			$cache->setCacheForFile($svnFile, $newFileHash, $phpcsStandard ?? '', $newFilePhpcsOutput);
+			$cache->setCacheForFile($svnFile, 'new', $newFileHash, $phpcsStandard ?? '', $newFilePhpcsOutput);
 		}
 	} catch( NoChangesException $err ) {
 		$debug($err->getMessage());
@@ -325,26 +325,26 @@ function runGitWorkflowForFile(string $gitFile, array $options, ShellOperator $s
 		if (! $isNewFile) {
 			$cache->setRevision(''); // git files are all protected by a hash key; there is no need to invalidate the cache if the version changes
 			$oldFileHash = getOldGitFileHash($gitFile, $git, $cat, [$shell, 'executeCommand'], $options, $debug);
-			$oldFilePhpcsOutput = $cache->getCacheForFile($gitFile, $oldFileHash, $phpcsStandard ?? '');
+			$oldFilePhpcsOutput = $cache->getCacheForFile($gitFile, 'old', $oldFileHash, $phpcsStandard ?? '');
 			if ($oldFilePhpcsOutput) {
-				$debug("Using cache for old file '{$gitFile}' with standard '{$phpcsStandard}'");
+				$debug("Using cache for old file '{$gitFile}' at hash '{$oldFileHash}' with standard '{$phpcsStandard}'");
 			}
 			if (! $oldFilePhpcsOutput) {
-				$debug("Not using cache for old file '{$gitFile}' with standard '{$phpcsStandard}'");
+				$debug("Not using cache for old file '{$gitFile}' at hash '{$oldFileHash}' with standard '{$phpcsStandard}'");
 				$oldFilePhpcsOutput = getGitBasePhpcsOutput($gitFile, $git, $phpcs, $phpcsStandardOption, [$shell, 'executeCommand'], $options, $debug);
-				$cache->setCacheForFile($gitFile, '', $phpcsStandard ?? '', $oldFilePhpcsOutput);
+				$cache->setCacheForFile($gitFile, 'old', $oldFileHash, $phpcsStandard ?? '', $oldFilePhpcsOutput);
 			}
 		}
 
 		$newFileHash = getNewGitFileHash($gitFile, $git, $cat, [$shell, 'executeCommand'], $options, $debug);
-		$newFilePhpcsOutput = $cache->getCacheForFile($gitFile, $newFileHash, $phpcsStandard ?? '');
+		$newFilePhpcsOutput = $cache->getCacheForFile($gitFile, 'new', $newFileHash, $phpcsStandard ?? '');
 		if ($newFilePhpcsOutput) {
 			$debug("Using cache for new file '{$gitFile}' at hash '{$newFileHash}', and standard '{$phpcsStandard}'");
 		}
 		if (! $newFilePhpcsOutput) {
 			$debug("Not using cache for new file '{$gitFile}' at hash '{$newFileHash}', and standard '{$phpcsStandard}'");
 			$newFilePhpcsOutput = getGitNewPhpcsOutput($gitFile, $git, $phpcs, $cat, $phpcsStandardOption, [$shell, 'executeCommand'], $options, $debug);
-			$cache->setCacheForFile($gitFile, $newFileHash, $phpcsStandard ?? '', $newFilePhpcsOutput);
+			$cache->setCacheForFile($gitFile, 'new', $newFileHash, $phpcsStandard ?? '', $newFilePhpcsOutput);
 		}
 	} catch( NoChangesException $err ) {
 		$debug($err->getMessage());

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -210,12 +210,24 @@ function runSvnWorkflow(array $svnFiles, array $options, ShellOperator $shell, C
 	}
 
 	if (isCachingEnabled($options)) {
-		$cache->load();
+		try {
+			$cache->load();
+		} catch( \Exception $err ) {
+			$shell->printError($err->getMessage());
+			$shell->exitWithCode(1);
+			throw $err; // Just in case we do not actually exit, like in tests
+		}
 	}
 
 	if (isset($options['clear-cache'])) {
 		$cache->clearCache();
-		$cache->save();
+		try {
+			$cache->save();
+		} catch( \Exception $err ) {
+			$shell->printError($err->getMessage());
+			$shell->exitWithCode(1);
+			throw $err; // Just in case we do not actually exit, like in tests
+		}
 	}
 
 	$phpcsMessages = array_map(function(string $svnFile) use ($options, $shell, $cache, $debug): PhpcsMessages {

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -262,27 +262,26 @@ function runSvnWorkflowForFile(string $svnFile, array $options, ShellOperator $s
 		if ( ! $isNewFile ) {
 			$cache->setRevision($revisionId);
 
-			$oldFilePhpcsOutput = $cache->getCacheForFile($svnFile, $phpcsStandard ?? '');
+			$oldFilePhpcsOutput = $cache->getCacheForFile($svnFile, '', $phpcsStandard ?? '');
 			if ($oldFilePhpcsOutput) {
 				$debug("Using cache for old file '{$svnFile}' at revision '{$revisionId}' and standard '{$phpcsStandard}'");
 			}
 			if (! $oldFilePhpcsOutput) {
 				$debug("Not using cache for old file '{$svnFile}' at revision '{$revisionId}' and standard '{$phpcsStandard}'");
 				$oldFilePhpcsOutput = getSvnBasePhpcsOutput($svnFile, $svn, $phpcs, $phpcsStandardOption, [$shell, 'executeCommand'], $debug);
-				$cache->setCacheForFile($svnFile, $oldFilePhpcsOutput, $phpcsStandard ?? '');
+				$cache->setCacheForFile($svnFile, '', $phpcsStandard ?? '', $oldFilePhpcsOutput);
 			}
 		}
 
 		$newFileHash = $shell->getFileHash($svnFile);
-		$newFileCacheKey = ($phpcsStandard ?? '') . $newFileHash;
-		$newFilePhpcsOutput = $cache->getCacheForFile($svnFile, $newFileCacheKey);
+		$newFilePhpcsOutput = $cache->getCacheForFile($svnFile, $newFileHash, $phpcsStandard ?? '');
 		if ($newFilePhpcsOutput) {
-			$debug("Using cache for new file '{$svnFile}' at revision '{$revisionId}' and key '{$newFileCacheKey}'");
+			$debug("Using cache for new file '{$svnFile}' at revision '{$revisionId}', hash '{$newFileHash}', and standard '{$phpcsStandard}'");
 		}
 		if (! $newFilePhpcsOutput) {
-			$debug("Not using cache for new file '{$svnFile}' at revision '{$revisionId}' and key '{$newFileCacheKey}'");
+			$debug("Not using cache for new file '{$svnFile}' at revision '{$revisionId}', hash '{$newFileHash}', and standard '{$phpcsStandard}'");
 			$newFilePhpcsOutput = getSvnNewPhpcsOutput($svnFile, $phpcs, $cat, $phpcsStandardOption, [$shell, 'executeCommand'], $debug);
-			$cache->setCacheForFile($svnFile, $newFilePhpcsOutput, $newFileCacheKey);
+			$cache->setCacheForFile($svnFile, $newFileHash, $phpcsStandard ?? '', $newFilePhpcsOutput);
 		}
 	} catch( NoChangesException $err ) {
 		$debug($err->getMessage());

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -213,8 +213,9 @@ function runSvnWorkflow(array $svnFiles, array $options, ShellOperator $shell, C
 		$cache->load();
 	}
 
-	if (isset($options['clear-cache'])) {
+	if (isset($options['clear-cache']) && $options['clear-cache']) {
 		$cache->clearCache();
+		$cache->save();
 	}
 
 	$phpcsMessages = array_map(function(string $svnFile) use ($options, $shell, $cache, $debug): PhpcsMessages {

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -13,7 +13,7 @@ use PhpcsChanged\ShellException;
 use PhpcsChanged\ShellOperator;
 use PhpcsChanged\UnixShell;
 use PhpcsChanged\XmlReporter;
-use PhpcsChanged\Cache\CacheManager;
+use PhpcsChanged\CacheManager;
 use function PhpcsChanged\{getNewPhpcsMessages, getNewPhpcsMessagesFromFiles, getVersion};
 use function PhpcsChanged\SvnWorkflow\{getSvnUnifiedDiff, getSvnFileInfo, isNewSvnFile, getSvnBasePhpcsOutput, getSvnNewPhpcsOutput, getSvnRevisionId};
 use function PhpcsChanged\GitWorkflow\{getGitMergeBase, getGitUnifiedDiff, isNewGitFile, getGitBasePhpcsOutput, getGitNewPhpcsOutput, validateGitFileExists};

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -250,7 +250,11 @@ function runSvnWorkflowForFile(string $svnFile, array $options, ShellOperator $s
 
 		$newFileHash = $shell->getFileHash($svnFile);
 		$newFilePhpcsOutput = $cache->getCacheForFile($svnFile, $newFileHash);
+		if ($newFilePhpcsOutput) {
+			$debug("Using cache for new file '{$svnFile}' at revision '{$revisionId}' and hash '{$newFileHash}'");
+		}
 		if (! $newFilePhpcsOutput) {
+			$debug("Not using cache for new file '{$svnFile}' at revision '{$revisionId}' and hash '{$newFileHash}'");
 			$newFilePhpcsOutput = getSvnNewPhpcsOutput($svnFile, $phpcs, $cat, $phpcsStandardOption, [$shell, 'executeCommand'], $debug);
 			$cache->setCacheForFile($svnFile, $newFilePhpcsOutput, $newFileHash);
 		}

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -275,7 +275,11 @@ function runSvnWorkflowForFile(string $svnFile, array $options, ShellOperator $s
 
 	$debug('processing data...');
 	$fileName = DiffLineMap::getFileNameFromDiff($unifiedDiff);
-	return getNewPhpcsMessages($unifiedDiff, PhpcsMessages::fromPhpcsJson($oldFilePhpcsOutput, $fileName), PhpcsMessages::fromPhpcsJson($newFilePhpcsOutput, $fileName));
+	return getNewPhpcsMessages(
+		$unifiedDiff,
+		PhpcsMessages::fromPhpcsJson($oldFilePhpcsOutput, $fileName),
+		PhpcsMessages::fromPhpcsJson($newFilePhpcsOutput, $fileName)
+	);
 }
 
 function runGitWorkflow(array $gitFiles, array $options, ShellOperator $shell, CacheManager $cache, callable $debug): PhpcsMessages {

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -239,28 +239,34 @@ function runSvnWorkflowForFile(string $svnFile, array $options, ShellOperator $s
 
 		$oldFilePhpcsOutput = '';
 		if ( ! $isNewFile ) {
-			$cache->setRevision($revisionId);
+			if (isCachingEnabled($options)) {
+				$cache->setRevision($revisionId);
+			}
 
-			$oldFilePhpcsOutput = $cache->getCacheForFile($svnFile, 'old', '', $phpcsStandard ?? '');
+			$oldFilePhpcsOutput = isCachingEnabled($options) ? $cache->getCacheForFile($svnFile, 'old', '', $phpcsStandard ?? '') : null;
 			if ($oldFilePhpcsOutput) {
 				$debug("Using cache for old file '{$svnFile}' at revision '{$revisionId}' and standard '{$phpcsStandard}'");
 			}
 			if (! $oldFilePhpcsOutput) {
 				$debug("Not using cache for old file '{$svnFile}' at revision '{$revisionId}' and standard '{$phpcsStandard}'");
 				$oldFilePhpcsOutput = getSvnBasePhpcsOutput($svnFile, $svn, $phpcs, $phpcsStandardOption, [$shell, 'executeCommand'], $debug);
-				$cache->setCacheForFile($svnFile, 'old', '', $phpcsStandard ?? '', $oldFilePhpcsOutput);
+				if (isCachingEnabled($options)) {
+					$cache->setCacheForFile($svnFile, 'old', '', $phpcsStandard ?? '', $oldFilePhpcsOutput);
+				}
 			}
 		}
 
 		$newFileHash = $shell->getFileHash($svnFile);
-		$newFilePhpcsOutput = $cache->getCacheForFile($svnFile, 'new', $newFileHash, $phpcsStandard ?? '');
+		$newFilePhpcsOutput = isCachingEnabled($options) ? $cache->getCacheForFile($svnFile, 'new', $newFileHash, $phpcsStandard ?? '') : null;
 		if ($newFilePhpcsOutput) {
 			$debug("Using cache for new file '{$svnFile}' at revision '{$revisionId}', hash '{$newFileHash}', and standard '{$phpcsStandard}'");
 		}
 		if (! $newFilePhpcsOutput) {
 			$debug("Not using cache for new file '{$svnFile}' at revision '{$revisionId}', hash '{$newFileHash}', and standard '{$phpcsStandard}'");
 			$newFilePhpcsOutput = getSvnNewPhpcsOutput($svnFile, $phpcs, $cat, $phpcsStandardOption, [$shell, 'executeCommand'], $debug);
-			$cache->setCacheForFile($svnFile, 'new', $newFileHash, $phpcsStandard ?? '', $newFilePhpcsOutput);
+			if (isCachingEnabled($options)) {
+				$cache->setCacheForFile($svnFile, 'new', $newFileHash, $phpcsStandard ?? '', $newFilePhpcsOutput);
+			}
 		}
 	} catch( NoChangesException $err ) {
 		$debug($err->getMessage());
@@ -327,28 +333,34 @@ function runGitWorkflowForFile(string $gitFile, array $options, ShellOperator $s
 		$isNewFile = isNewGitFile($gitFile, $git, [$shell, 'executeCommand'], $options, $debug);
 		$oldFilePhpcsOutput = '';
 		if (! $isNewFile) {
-			$cache->setRevision(''); // git files are all protected by a hash key; there is no need to invalidate the cache if the version changes
+			if (isCachingEnabled($options)) {
+				$cache->setRevision(''); // git files are all protected by a hash key; there is no need to invalidate the cache if the version changes
+			}
 			$oldFileHash = getOldGitFileHash($gitFile, $git, $cat, [$shell, 'executeCommand'], $options, $debug);
-			$oldFilePhpcsOutput = $cache->getCacheForFile($gitFile, 'old', $oldFileHash, $phpcsStandard ?? '');
+			$oldFilePhpcsOutput = isCachingEnabled($options) ? $cache->getCacheForFile($gitFile, 'old', $oldFileHash, $phpcsStandard ?? '') : null;
 			if ($oldFilePhpcsOutput) {
 				$debug("Using cache for old file '{$gitFile}' at hash '{$oldFileHash}' with standard '{$phpcsStandard}'");
 			}
 			if (! $oldFilePhpcsOutput) {
 				$debug("Not using cache for old file '{$gitFile}' at hash '{$oldFileHash}' with standard '{$phpcsStandard}'");
 				$oldFilePhpcsOutput = getGitBasePhpcsOutput($gitFile, $git, $phpcs, $phpcsStandardOption, [$shell, 'executeCommand'], $options, $debug);
-				$cache->setCacheForFile($gitFile, 'old', $oldFileHash, $phpcsStandard ?? '', $oldFilePhpcsOutput);
+				if (isCachingEnabled($options)) {
+					$cache->setCacheForFile($gitFile, 'old', $oldFileHash, $phpcsStandard ?? '', $oldFilePhpcsOutput);
+				}
 			}
 		}
 
 		$newFileHash = getNewGitFileHash($gitFile, $git, $cat, [$shell, 'executeCommand'], $options, $debug);
-		$newFilePhpcsOutput = $cache->getCacheForFile($gitFile, 'new', $newFileHash, $phpcsStandard ?? '');
+		$newFilePhpcsOutput = isCachingEnabled($options) ? $cache->getCacheForFile($gitFile, 'new', $newFileHash, $phpcsStandard ?? '') : null;
 		if ($newFilePhpcsOutput) {
 			$debug("Using cache for new file '{$gitFile}' at hash '{$newFileHash}', and standard '{$phpcsStandard}'");
 		}
 		if (! $newFilePhpcsOutput) {
 			$debug("Not using cache for new file '{$gitFile}' at hash '{$newFileHash}', and standard '{$phpcsStandard}'");
 			$newFilePhpcsOutput = getGitNewPhpcsOutput($gitFile, $git, $phpcs, $cat, $phpcsStandardOption, [$shell, 'executeCommand'], $options, $debug);
-			$cache->setCacheForFile($gitFile, 'new', $newFileHash, $phpcsStandard ?? '', $newFilePhpcsOutput);
+			if (isCachingEnabled($options)) {
+				$cache->setCacheForFile($gitFile, 'new', $newFileHash, $phpcsStandard ?? '', $newFilePhpcsOutput);
+			}
 		}
 	} catch( NoChangesException $err ) {
 		$debug($err->getMessage());

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -259,17 +259,18 @@ function runSvnWorkflowForFile(string $svnFile, array $options, ShellOperator $s
 		}
 
 		$newFileHash = $shell->getFileHash($svnFile);
+		$newFileCacheKey = ($phpcsStandard ?? '') . $newFileHash;
 		$newFilePhpcsOutput = null;
 		if (! isset($options['no-cache'])) {
-			$newFilePhpcsOutput = $cache->getCacheForFile($svnFile, $newFileHash);
+			$newFilePhpcsOutput = $cache->getCacheForFile($svnFile, $newFileCacheKey);
 		}
 		if ($newFilePhpcsOutput) {
-			$debug("Using cache for new file '{$svnFile}' at revision '{$revisionId}' and hash '{$newFileHash}'");
+			$debug("Using cache for new file '{$svnFile}' at revision '{$revisionId}' and key '{$newFileCacheKey}'");
 		}
 		if (! $newFilePhpcsOutput) {
-			$debug("Not using cache for new file '{$svnFile}' at revision '{$revisionId}' and hash '{$newFileHash}'");
+			$debug("Not using cache for new file '{$svnFile}' at revision '{$revisionId}' and key '{$newFileCacheKey}'");
 			$newFilePhpcsOutput = getSvnNewPhpcsOutput($svnFile, $phpcs, $cat, $phpcsStandardOption, [$shell, 'executeCommand'], $debug);
-			$cache->setCacheForFile($svnFile, $newFilePhpcsOutput, $newFileHash);
+			$cache->setCacheForFile($svnFile, $newFilePhpcsOutput, $newFileCacheKey);
 		}
 	} catch( NoChangesException $err ) {
 		$debug($err->getMessage());

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -252,10 +252,10 @@ function runSvnWorkflowForFile(string $svnFile, array $options, ShellOperator $s
 
 			$oldFilePhpcsOutput = $cache->getCacheForFile($svnFile, $phpcsStandard ?? '');
 			if ($oldFilePhpcsOutput) {
-				$debug("Using cache for '{$svnFile}' at revision '{$revisionId}' and standard '{$phpcsStandard}'");
+				$debug("Using cache for old file '{$svnFile}' at revision '{$revisionId}' and standard '{$phpcsStandard}'");
 			}
 			if (! $oldFilePhpcsOutput) {
-				$debug("Not using cache for '{$svnFile}' at revision '{$revisionId}' and standard '{$phpcsStandard}'");
+				$debug("Not using cache for old file '{$svnFile}' at revision '{$revisionId}' and standard '{$phpcsStandard}'");
 				$oldFilePhpcsOutput = getSvnBasePhpcsOutput($svnFile, $svn, $phpcs, $phpcsStandardOption, [$shell, 'executeCommand'], $debug);
 				$cache->setCacheForFile($svnFile, $oldFilePhpcsOutput, $phpcsStandard ?? '');
 			}

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -512,6 +512,10 @@ function loadCache(CacheManager $cache, ShellOperator $shell, array $options): v
 			$cache->load();
 		} catch( \Exception $err ) {
 			$shell->printError($err->getMessage());
+			// If there is an invalid cache, we should clear it to be safe
+			$shell->printError('An error occurred reading the cache so it will now be cleared. Try running your command again.');
+			$cache->clearCache();
+			saveCache($cache, $shell, $options);
 			$shell->exitWithCode(1);
 			throw $err; // Just in case we do not actually exit, like in tests
 		}
@@ -535,6 +539,7 @@ function saveCache(CacheManager $cache, ShellOperator $shell, array $options): v
 			$cache->save();
 		} catch( \Exception $err ) {
 			$shell->printError($err->getMessage());
+			$shell->printError('An error occurred saving the cache. Try running with caching disabled.');
 			$shell->exitWithCode(1);
 			throw $err; // Just in case we do not actually exit, like in tests
 		}

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -213,7 +213,7 @@ function runSvnWorkflow(array $svnFiles, array $options, ShellOperator $shell, C
 		$cache->load();
 	}
 
-	if (isset($options['clear-cache']) && $options['clear-cache']) {
+	if (isset($options['clear-cache'])) {
 		$cache->clearCache();
 		$cache->save();
 	}
@@ -463,10 +463,10 @@ function shouldIgnorePath(string $path, string $patternOption = null): bool {
 }
 
 function isCachingEnabled(array $options): bool {
-	if (isset($options['no-cache']) && $options['no-cache']) {
+	if (isset($options['no-cache'])) {
 		return false;
 	}
-	if (isset($options['cache']) && $options['cache']) {
+	if (isset($options['cache'])) {
 		return true;
 	}
 	return false;

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -209,34 +209,13 @@ function runSvnWorkflow(array $svnFiles, array $options, ShellOperator $shell, C
 		throw $err; // Just in case we do not actually exit, like in tests
 	}
 
-	if (isCachingEnabled($options)) {
-		try {
-			$cache->load();
-		} catch( \Exception $err ) {
-			$shell->printError($err->getMessage());
-			$shell->exitWithCode(1);
-			throw $err; // Just in case we do not actually exit, like in tests
-		}
-	}
-
-	if (isset($options['clear-cache'])) {
-		$cache->clearCache();
-		try {
-			$cache->save();
-		} catch( \Exception $err ) {
-			$shell->printError($err->getMessage());
-			$shell->exitWithCode(1);
-			throw $err; // Just in case we do not actually exit, like in tests
-		}
-	}
+	loadCache($cache, $shell, $options);
 
 	$phpcsMessages = array_map(function(string $svnFile) use ($options, $shell, $cache, $debug): PhpcsMessages {
 		return runSvnWorkflowForFile($svnFile, $options, $shell, $cache, $debug);
 	}, $svnFiles);
 
-	if (isCachingEnabled($options)) {
-		$cache->save();
-	}
+	saveCache($cache, $shell, $options);
 
 	return PhpcsMessages::merge($phpcsMessages);
 }
@@ -481,4 +460,39 @@ function isCachingEnabled(array $options): bool {
 		return true;
 	}
 	return false;
+}
+
+function loadCache(CacheManager $cache, ShellOperator $shell, array $options): void {
+	if (isCachingEnabled($options)) {
+		try {
+			$cache->load();
+		} catch( \Exception $err ) {
+			$shell->printError($err->getMessage());
+			$shell->exitWithCode(1);
+			throw $err; // Just in case we do not actually exit, like in tests
+		}
+	}
+
+	if (isset($options['clear-cache'])) {
+		$cache->clearCache();
+		try {
+			$cache->save();
+		} catch( \Exception $err ) {
+			$shell->printError($err->getMessage());
+			$shell->exitWithCode(1);
+			throw $err; // Just in case we do not actually exit, like in tests
+		}
+	}
+}
+
+function saveCache(CacheManager $cache, ShellOperator $shell, array $options): void {
+	if (isCachingEnabled($options)) {
+		try {
+			$cache->save();
+		} catch( \Exception $err ) {
+			$shell->printError($err->getMessage());
+			$shell->exitWithCode(1);
+			throw $err; // Just in case we do not actually exit, like in tests
+		}
+	}
 }

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -236,14 +236,14 @@ function runSvnWorkflowForFile(string $svnFile, array $options, ShellOperator $s
 		$oldFilePhpcsOutput = '';
 		if ( ! $isNewFile ) {
 			$cache->setRevision($revisionId);
-			$oldFilePhpcsOutput = $cache->getCacheForFile($svnFile, $phpcsStandard);
+			$oldFilePhpcsOutput = $cache->getCacheForFile($svnFile, $phpcsStandard ?? '');
 			if ($oldFilePhpcsOutput) {
 				$debug("Using cache for '{$svnFile}'");
 			}
 			if (! $oldFilePhpcsOutput) {
 				$debug("Not using cache for '{$svnFile}'");
 				$oldFilePhpcsOutput = getSvnBasePhpcsOutput($svnFile, $svn, $phpcs, $phpcsStandardOption, [$shell, 'executeCommand'], $debug);
-				$cache->setCacheForFile($svnFile, $oldFilePhpcsOutput, $phpcsStandard);
+				$cache->setCacheForFile($svnFile, $oldFilePhpcsOutput, $phpcsStandard ?? '');
 			}
 		}
 		$newFilePhpcsOutput = getSvnNewPhpcsOutput($svnFile, $phpcs, $cat, $phpcsStandardOption, [$shell, 'executeCommand'], $debug);

--- a/PhpcsChanged/FileCache.php
+++ b/PhpcsChanged/FileCache.php
@@ -5,6 +5,7 @@ namespace PhpcsChanged;
 
 use PhpcsChanged\CacheInterface;
 use PhpcsChanged\CacheManager;
+use PhpcsChanged\CacheEntry;
 
 define('DEFAULT_CACHE_FILE', '.phpcs-changed-cache');
 
@@ -32,7 +33,7 @@ class FileCache implements CacheInterface {
 			if (! $this->isDecodedEntryValid($entry)) {
 				throw new \Exception('Invalid cache file entry: ' . $entry);
 			}
-			$manager->setCacheForFile($entry['path'], $entry['data'], $entry['cacheKey']);
+			$manager->addCacheEntry(CacheEntry::fromJson($entry));
 		}
 	}
 

--- a/PhpcsChanged/FileCache.php
+++ b/PhpcsChanged/FileCache.php
@@ -22,7 +22,7 @@ class FileCache implements CacheInterface {
 		if ($contents === false) {
 			throw new \Exception('Failed to read cache file');
 		}
-		$decoded = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+		$decoded = json_decode($contents, true);
 		if (! is_array($decoded) || ! array_key_exists('revisionId', $decoded) || ! array_key_exists('entries', $decoded) || ! is_array($decoded['entries'])) {
 			throw new \Exception('Invalid cache file');
 		}
@@ -40,7 +40,7 @@ class FileCache implements CacheInterface {
 			'revisionId' => $manager->getRevision(),
 			'entries' => $manager->getEntries(),
 		];
-		$result = file_put_contents($this->cacheFilePath, json_encode($data, JSON_THROW_ON_ERROR));
+		$result = file_put_contents($this->cacheFilePath, json_encode($data));
 		if ($result === false) {
 			throw new \Exception('Failed to write cache file');
 		}

--- a/PhpcsChanged/FileCache.php
+++ b/PhpcsChanged/FileCache.php
@@ -23,12 +23,13 @@ class FileCache implements CacheInterface {
 			throw new \Exception('Failed to read cache file');
 		}
 		$decoded = json_decode($contents, true);
-		if (! is_array($decoded) || ! array_key_exists('revisionId', $decoded) || ! array_key_exists('entries', $decoded) || ! is_array($decoded['entries'])) {
+		if (! $this->isDecodedDataValid($decoded)) {
 			throw new \Exception('Invalid cache file');
 		}
+		$manager->setCacheVersion($decoded['cacheVersion']);
 		$manager->setRevision($decoded['revisionId']);
 		foreach($decoded['entries'] as $entry) {
-			if (! array_key_exists('path', $entry) || ! array_key_exists('data', $entry) || ! array_key_exists('cacheKey', $entry)) {
+			if (! $this->isDecodedEntryValid($entry)) {
 				throw new \Exception('Invalid cache file entry: ' . $entry);
 			}
 			$manager->setCacheForFile($entry['path'], $entry['data'], $entry['cacheKey']);
@@ -44,5 +45,35 @@ class FileCache implements CacheInterface {
 		if ($result === false) {
 			throw new \Exception('Failed to write cache file');
 		}
+	}
+
+	/**
+ 	 * @param mixed $decoded The json-decoded data
+	 */
+	private function isDecodedDataValid($decoded): bool {
+		if (! is_array($decoded) ||
+			! array_key_exists('cacheVersion', $decoded) ||
+			! array_key_exists('revisionId', $decoded) ||
+			! array_key_exists('entries', $decoded) ||
+			! is_array($decoded['entries'])
+		) {
+			return false;
+		}
+		if (! is_string($decoded['cacheVersion'])) {
+			return false;
+		}
+		if (! is_string($decoded['revisionId'])) {
+			return false;
+		}
+		// Note that this does not validate the entries to avoid iterating over
+		// them twice. That should be done by isDecodedEntryValid.
+		return true;
+	}
+
+	private function isDecodedEntryValid(array $entry): bool {
+		if (! array_key_exists('path', $entry) || ! array_key_exists('data', $entry) || ! array_key_exists('cacheKey', $entry)) {
+			return false;		
+		}
+		return true;
 	}
 }

--- a/PhpcsChanged/FileCache.php
+++ b/PhpcsChanged/FileCache.php
@@ -1,10 +1,10 @@
 <?php
 declare(strict_types=1);
 
-namespace PhpcsChanged\Cache;
+namespace PhpcsChanged;
 
-use PhpcsChanged\Cache\CacheInterface;
-use PhpcsChanged\Cache\CacheManager;
+use PhpcsChanged\CacheInterface;
+use PhpcsChanged\CacheManager;
 
 define('DEFAULT_CACHE_FILE', '.phpcs-changed-cache');
 

--- a/PhpcsChanged/FileCache.php
+++ b/PhpcsChanged/FileCache.php
@@ -73,7 +73,7 @@ class FileCache implements CacheInterface {
 	}
 
 	private function isDecodedEntryValid(array $entry): bool {
-		if (! array_key_exists('path', $entry) || ! array_key_exists('data', $entry) || ! array_key_exists('phpcsStandard', $entry) || ! array_key_exists('hash', $entry)) {
+		if (! array_key_exists('path', $entry) || ! array_key_exists('data', $entry) || ! array_key_exists('phpcsStandard', $entry) || ! array_key_exists('hash', $entry) || ! array_key_exists('type', $entry)) {
 			return false;		
 		}
 		return true;

--- a/PhpcsChanged/FileCache.php
+++ b/PhpcsChanged/FileCache.php
@@ -28,10 +28,10 @@ class FileCache implements CacheInterface {
 		}
 		$manager->setRevision($decoded['revisionId']);
 		foreach($decoded['entries'] as $entry) {
-			if (! array_key_exists('path', $entry) || ! array_key_exists('data', $entry) || ! array_key_exists('phpcsStandard', $entry)) {
+			if (! array_key_exists('path', $entry) || ! array_key_exists('data', $entry) || ! array_key_exists('cacheKey', $entry)) {
 				throw new \Exception('Invalid cache file entry: ' . $entry);
 			}
-			$manager->setCacheForFile($entry['path'], $entry['data'], $entry['phpcsStandard']);
+			$manager->setCacheForFile($entry['path'], $entry['data'], $entry['cacheKey']);
 		}
 	}
 

--- a/PhpcsChanged/FileCache.php
+++ b/PhpcsChanged/FileCache.php
@@ -38,6 +38,7 @@ class FileCache implements CacheInterface {
 
 	public function save(CacheManager $manager): void {
 		$data = [
+			'cacheVersion' => $manager->getCacheVersion(),
 			'revisionId' => $manager->getRevision(),
 			'entries' => $manager->getEntries(),
 		];

--- a/PhpcsChanged/FileCache.php
+++ b/PhpcsChanged/FileCache.php
@@ -73,7 +73,7 @@ class FileCache implements CacheInterface {
 	}
 
 	private function isDecodedEntryValid(array $entry): bool {
-		if (! array_key_exists('path', $entry) || ! array_key_exists('data', $entry) || ! array_key_exists('cacheKey', $entry)) {
+		if (! array_key_exists('path', $entry) || ! array_key_exists('data', $entry) || ! array_key_exists('phpcsStandard', $entry) || ! array_key_exists('hash', $entry)) {
 			return false;		
 		}
 		return true;

--- a/PhpcsChanged/GitWorkflow.php
+++ b/PhpcsChanged/GitWorkflow.php
@@ -112,7 +112,6 @@ function getGitNewPhpcsOutput(string $gitFile, string $git, string $phpcs, strin
 
 function getNewGitRevisionContentsCommand(string $gitFile, string $git, string $cat, array $options): string {
 	if (isset($options['git-base']) && ! empty($options['git-base'])) {
-		return 'HEAD';
 		// for git-base mode, we get the contents of the file from the HEAD version of the file in the current branch
 		return "{$git} show HEAD:$(${git} ls-files --full-name " . escapeshellarg($gitFile) . ')';
 	} else if (isset($options['git-unstaged'])) {

--- a/PhpcsChanged/GitWorkflow.php
+++ b/PhpcsChanged/GitWorkflow.php
@@ -47,14 +47,6 @@ function getGitUnifiedDiff(string $gitFile, string $git, callable $executeComman
 	return $unifiedDiff;
 }
 
-function getGitRevisionId(string $git, callable $executeCommand, callable $debug): string {
-	$gitStatusCommand = "${git} rev-parse HEAD"; // TODO: this should maybe query something else besides HEAD; maybe git-base?
-	$debug('checking revision id with command:', $gitStatusCommand);
-	$gitStatusOutput = $executeCommand($gitStatusCommand);
-	$debug('revision command output:', $gitStatusOutput);
-	return $gitStatusOutput;
-}
-
 function isNewGitFile(string $gitFile, string $git, callable $executeCommand, array $options, callable $debug): bool {
 	if ( isset($options['git-base']) && ! empty($options['git-base']) ) {
 		return isNewGitFileRemote( $gitFile, $git, $executeCommand, $options, $debug );

--- a/PhpcsChanged/GitWorkflow.php
+++ b/PhpcsChanged/GitWorkflow.php
@@ -81,18 +81,9 @@ function isNewGitFileLocal(string $gitFile, string $git, callable $executeComman
 }
 
 function getGitBasePhpcsOutput(string $gitFile, string $git, string $phpcs, string $phpcsStandardOption, callable $executeCommand, array $options, callable $debug): string {
-	if (isset($options['git-base']) && ! empty($options['git-base'])) {
-		// git-base
-		$rev = escapeshellarg($options['git-base']);
-	} else if (isset($options['git-unstaged'])) {
-		// git-unstaged
-		$rev = ':0'; // :0 in this case means "staged version or HEAD if there is no staged version"
-	} else {
-		// git-staged
-		$rev = 'HEAD';
-	}
+	$oldFileContents = getOldGitRevisionContentsCommand($gitFile, $git, $options);
 
-	$oldFilePhpcsOutputCommand = "${git} show {$rev}:$(${git} ls-files --full-name " . escapeshellarg($gitFile) . ") | {$phpcs} --report=json -q" . $phpcsStandardOption . ' --stdin-path=' .  escapeshellarg($gitFile) . ' -';
+	$oldFilePhpcsOutputCommand = "{$oldFileContents} | {$phpcs} --report=json -q" . $phpcsStandardOption . ' --stdin-path=' .  escapeshellarg($gitFile) . ' -';
 	$debug('running orig phpcs command:', $oldFilePhpcsOutputCommand);
 	$oldFilePhpcsOutput = $executeCommand($oldFilePhpcsOutputCommand);
 	if (! $oldFilePhpcsOutput) {
@@ -103,16 +94,7 @@ function getGitBasePhpcsOutput(string $gitFile, string $git, string $phpcs, stri
 }
 
 function getGitNewPhpcsOutput(string $gitFile, string $git, string $phpcs, string $cat, string $phpcsStandardOption, callable $executeCommand, array $options, callable $debug): string {
-	if (isset($options['git-base']) && ! empty($options['git-base'])) {
-		// for git-base mode, we get the contents of the file from the HEAD version of the file in the current branch
-		$newFileContents = "{$git} show HEAD:$(${git} ls-files --full-name " . escapeshellarg($gitFile) . ')';
-	} else if (isset($options['git-unstaged'])) {
-		// for git-unstaged mode, we get the contents of the file from the current working copy
-		$newFileContents = "{$cat} " . escapeshellarg($gitFile);
-	} else {
-		// default mode is git-staged, so we get the contents from the staged version of the file
-		$newFileContents = "{$git} show :0:$(${git} ls-files --full-name " . escapeshellarg($gitFile) . ')';
-	}
+	$newFileContents = getNewGitRevisionContentsCommand($gitFile, $git, $cat, $options);
 
 	$newFilePhpcsOutputCommand = "{$newFileContents} | {$phpcs} --report=json -q" . $phpcsStandardOption . ' --stdin-path=' .  escapeshellarg($gitFile) .' -';
 	$debug('running new phpcs command:', $newFilePhpcsOutputCommand);
@@ -126,4 +108,55 @@ function getGitNewPhpcsOutput(string $gitFile, string $git, string $phpcs, strin
 		return '';
 	}
 	return $newFilePhpcsOutput;
+}
+
+function getNewGitRevisionContentsCommand(string $gitFile, string $git, string $cat, array $options): string {
+	if (isset($options['git-base']) && ! empty($options['git-base'])) {
+		return 'HEAD';
+		// for git-base mode, we get the contents of the file from the HEAD version of the file in the current branch
+		return "{$git} show HEAD:$(${git} ls-files --full-name " . escapeshellarg($gitFile) . ')';
+	} else if (isset($options['git-unstaged'])) {
+		// for git-unstaged mode, we get the contents of the file from the current working copy
+		return "{$cat} " . escapeshellarg($gitFile);
+	}
+	// default mode is git-staged, so we get the contents from the staged version of the file
+	return "{$git} show :0:$(${git} ls-files --full-name " . escapeshellarg($gitFile) . ')';
+}
+
+function getOldGitRevisionContentsCommand(string $gitFile, string $git, array $options): string {
+	if (isset($options['git-base']) && ! empty($options['git-base'])) {
+		// git-base
+		$rev = escapeshellarg($options['git-base']);
+	} else if (isset($options['git-unstaged'])) {
+		// git-unstaged
+		$rev = ':0'; // :0 in this case means "staged version or HEAD if there is no staged version"
+	} else {
+		// git-staged
+		$rev = 'HEAD';
+	}
+	return "${git} show {$rev}:$(${git} ls-files --full-name " . escapeshellarg($gitFile) . ")";
+}
+
+function getNewGitFileHash(string $gitFile, string $git, string $cat, callable $executeCommand, array $options, callable $debug): string {
+	$fileContents = getNewGitRevisionContentsCommand($gitFile, $git, $cat, $options);
+	$command = "{$fileContents} | {$git} hash-object --stdin";
+	$debug('running new file git hash command:', $command);
+	$hash = $executeCommand($command);
+	if (! $hash) {
+		throw new ShellException("Cannot get new file hash for file '{$gitFile}'");
+	}
+	$debug('new file git hash command output:', $hash);
+	return $hash;
+}
+
+function getOldGitFileHash(string $gitFile, string $git, string $cat, callable $executeCommand, array $options, callable $debug): string {
+	$fileContents = getOldGitRevisionContentsCommand($gitFile, $git, $options);
+	$command = "{$fileContents} | {$git} hash-object --stdin";
+	$debug('running old file git hash command:', $command);
+	$hash = $executeCommand($command);
+	if (! $hash) {
+		throw new ShellException("Cannot get old file hash for file '{$gitFile}'");
+	}
+	$debug('old file git hash command output:', $hash);
+	return $hash;
 }

--- a/PhpcsChanged/GitWorkflow.php
+++ b/PhpcsChanged/GitWorkflow.php
@@ -47,6 +47,14 @@ function getGitUnifiedDiff(string $gitFile, string $git, callable $executeComman
 	return $unifiedDiff;
 }
 
+function getGitRevisionId(string $git, callable $executeCommand, callable $debug): string {
+	$gitStatusCommand = "${git} rev-parse HEAD"; // TODO: this should maybe query something else besides HEAD; maybe git-base?
+	$debug('checking revision id with command:', $gitStatusCommand);
+	$gitStatusOutput = $executeCommand($gitStatusCommand);
+	$debug('revision command output:', $gitStatusOutput);
+	return $gitStatusOutput;
+}
+
 function isNewGitFile(string $gitFile, string $git, callable $executeCommand, array $options, callable $debug): bool {
 	if ( isset($options['git-base']) && ! empty($options['git-base']) ) {
 		return isNewGitFileRemote( $gitFile, $git, $executeCommand, $options, $debug );

--- a/PhpcsChanged/PhpcsMessages.php
+++ b/PhpcsChanged/PhpcsMessages.php
@@ -54,7 +54,7 @@ class PhpcsMessages {
 			return $fileName;
 		}, array_keys($parsed['files']));
 		if (count($fileNames) < 1) {
-			throw new \Exception('Failed to find file names in phpcs JSON: ' . var_export($messages, true));
+			return self::fromArrays([]);
 		}
 		$fileName = $fileNames[0];
 		if (! isset($parsed['files'][$fileName]['messages'])) {

--- a/PhpcsChanged/ShellOperator.php
+++ b/PhpcsChanged/ShellOperator.php
@@ -13,6 +13,8 @@ interface ShellOperator {
 
 	public function isReadable(string $fileName): bool;
 
+	public function getFileHash(string $fileName): string;
+
 	public function exitWithCode(int $code): void;
 
 	public function printError(string $message): void;

--- a/PhpcsChanged/UnixShell.php
+++ b/PhpcsChanged/UnixShell.php
@@ -26,6 +26,14 @@ class UnixShell implements ShellOperator {
 		return is_readable($fileName);
 	}
 
+	public function getFileHash(string $fileName): string {
+		$result = md5_file($fileName);
+		if ($result === false) {
+			throw new \Exception("Cannot get hash for file '{$fileName}'.");
+		}
+		return $result;
+	}
+
 	public function exitWithCode(int $code): void {
 		exit($code);
 	}

--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ You can use `--standard` to specify a specific phpcs standard to run. This match
 
 You can also use the `-s` option to Always show sniff codes after each error in the full reporter. This matches the phpcs option of the same name.
 
+The `--cache` option will enable caching of phpcs output and can significantly improve performance for slow phpcs standards or when running with high frequency. There are actually two caches: one for the phpcs scan of the previous version of the file and one for the phpcs scan of the new version. The previous version phpcs output cache is invalidated when the version control revision changes or when the phpcs standard changes. The new version phpcs output cache is invalidated when the file hash changes or when the phpcs standard changes.
+
+The `--no-cache` option will disable the cache if it's been enabled. (This may also be useful in the future if caching is made the default.)
+
+The `--clear-cache` option will clear the cache before running. This works with or without caching enabled.
+
 ## PHP Library
 
 🐘🐘🐘

--- a/README.md
+++ b/README.md
@@ -81,9 +81,13 @@ If the file was versioned by git, we can do the same with the `--git` option:
 phpcs-changed --git --git-unstaged file.php
 ```
 
-You should specify `--git-staged` or `--git-unstaged` to tell `phpcs-changed` if you want to compare the current staged changes or the current working copy changes, respectively. The default is `--git-staged`.
+When using `--git`, you should also specify `--git-staged`, `--git-unstaged`, or `--git-base`.
 
-Alternatively, if you want to compare the current committed HEAD changes to another object (which can be a branch, a commit, or another object), you can use the `--git-base` option followed by an object name:
+`--git-staged` compares the currently staged changes (as the new version of the files) to the current HEAD (as the previous version of the files). This is the default.
+
+`--git-unstaged` compares the current (unstaged) working copy changes (as the new version of the files) to the either the currently staged changes, or if there are none, the current HEAD (as the previous version of the files).
+
+`--git-base`, followed by a git object, compares the current HEAD (as the new version of the files) to the specified [git object](https://git-scm.com/book/en/v2/Git-Internals-Git-Objects) (as the previous version of the file) which can be a branch name, a commit, or some other valid git object.
 
 ```
 git checkout add-new-feature

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -43,6 +43,8 @@ $options = getopt(
 		'report:',
 		'debug',
 		'ignore:',
+		'no-cache',
+		'clear-cache',
 	],
 	$optind
 );

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -43,6 +43,7 @@ $options = getopt(
 		'report:',
 		'debug',
 		'ignore:',
+		'cache',
 		'no-cache',
 		'clear-cache',
 	],

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -98,6 +98,7 @@ run($options, $fileNamesExpanded, $debug);
 
 function run(array $options, array $fileNamesExpanded, callable $debug): void {
 	$debug('Running on filenames: ' . implode(', ', $fileNamesExpanded));
+	$debug('Options: ' . json_encode($options));
 	$reportType = $options['report'] ?? 'full';
 	$diffFile = $options['diff'] ?? null;
 	$phpcsOldFile = $options['phpcs-orig'] ?? null;

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -21,8 +21,8 @@ use function PhpcsChanged\Cli\{
 	printInstalledCodingStandards
 };
 use PhpcsChanged\UnixShell;
-use PhpcsChanged\Cache\CacheManager;
-use PhpcsChanged\Cache\FileCache;
+use PhpcsChanged\CacheManager;
+use PhpcsChanged\FileCache;
 
 $optind = 0;
 $options = getopt(

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -21,6 +21,7 @@ use function PhpcsChanged\Cli\{
 	printInstalledCodingStandards
 };
 use PhpcsChanged\UnixShell;
+use PhpcsChanged\Cache\CacheManager;
 use PhpcsChanged\Cache\FileCache;
 
 $optind = 0;
@@ -116,7 +117,7 @@ function run(array $options, array $fileNamesExpanded, callable $debug): void {
 	if (isset($options['svn'])) {
 		$shell = new UnixShell();
 		reportMessagesAndExit(
-			runSvnWorkflow($fileNamesExpanded, $options, $shell, new FileCache(), $debug),
+			runSvnWorkflow($fileNamesExpanded, $options, $shell, new CacheManager(new FileCache()), $debug),
 			$reportType,
 			$options
 		);

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -121,7 +121,7 @@ function run(array $options, array $fileNamesExpanded, callable $debug): void {
 	if (isset($options['svn'])) {
 		$shell = new UnixShell();
 		reportMessagesAndExit(
-			runSvnWorkflow($fileNamesExpanded, $options, $shell, new CacheManager(new FileCache()), $debug),
+			runSvnWorkflow($fileNamesExpanded, $options, $shell, new CacheManager(new FileCache(), $debug), $debug),
 			$reportType,
 			$options
 		);
@@ -131,7 +131,7 @@ function run(array $options, array $fileNamesExpanded, callable $debug): void {
 	if (isset($options['git'])) {
 		$shell = new UnixShell();
 		reportMessagesAndExit(
-			runGitWorkflow($fileNamesExpanded, $options, $shell, $debug),
+			runGitWorkflow($fileNamesExpanded, $options, $shell, new CacheManager(new FileCache(), $debug), $debug),
 			$reportType,
 			$options
 		);

--- a/index.php
+++ b/index.php
@@ -17,7 +17,9 @@ require_once __DIR__ . '/PhpcsChanged/NoChangesException.php';
 require_once __DIR__ . '/PhpcsChanged/ShellException.php';
 require_once __DIR__ . '/PhpcsChanged/ShellOperator.php';
 require_once __DIR__ . '/PhpcsChanged/UnixShell.php';
+require_once __DIR__ . '/PhpcsChanged/CacheEntry.php';
 require_once __DIR__ . '/PhpcsChanged/CacheInterface.php';
+require_once __DIR__ . '/PhpcsChanged/CacheManager.php';
 require_once __DIR__ . '/PhpcsChanged/FileCache.php';
 
 // Function-only files

--- a/tests/GitWorkflowTest.php
+++ b/tests/GitWorkflowTest.php
@@ -101,7 +101,7 @@ final class GitWorkflowTest extends TestCase {
 			'git-unstaged' => '1',
 			'cache' => false, // getopt is weird and sets options to false
 		];
-		$cache = new CacheManager( new TestCache() );
+		$cache = new CacheManager( new TestCache(), '\PhpcsChangedTests\Debug' );
 		$expected = $this->phpcs->getResults('bin/foobar.php', [20], 'Found unused symbol Foobar.');
 
 		runGitWorkflow([$gitFile], $options, $shell, $cache, '\PhpcsChangedTests\Debug');

--- a/tests/GitWorkflowTest.php
+++ b/tests/GitWorkflowTest.php
@@ -61,8 +61,8 @@ final class GitWorkflowTest extends TestCase {
 		$fixture = $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;');
 		$shell->registerCommand("git diff --staged --no-prefix 'foobar.php'", $fixture);
 		$shell->registerCommand("git status --short 'foobar.php'", $this->fixture->getModifiedFileInfo('foobar.php'));
-		$shell->registerCommand("git show HEAD:$(git ls-files --full-name 'foobar.php')", '{"totals":{"errors":1,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"Variables.Defined.RequiredDefined.Unused","message":"Found unused symbol Emergent."}]}}}');
-		$shell->registerCommand("git show :0:$(git ls-files --full-name 'foobar.php')", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"Variables.Defined.RequiredDefined.Unused","message":"Found unused symbol Foobar."},{"line":21,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"Variables.Defined.RequiredDefined.Unused","message":"Found unused symbol Emergent."}]}}}');
+		$shell->registerCommand("git show HEAD:$(git ls-files --full-name 'foobar.php')", $this->phpcs->getResults('STDIN', [20])->toPhpcsJson());
+		$shell->registerCommand("git show :0:$(git ls-files --full-name 'foobar.php')", $this->phpcs->getResults('STDIN', [20, 21], 'Found unused symbol Foobar.')->toPhpcsJson());
 		$options = [];
 		$expected = $this->phpcs->getResults('bin/foobar.php', [20], 'Found unused symbol Foobar.');
 		$messages = runGitWorkflow([$gitFile], $options, $shell, '\PhpcsChangedTests\Debug');
@@ -75,8 +75,8 @@ final class GitWorkflowTest extends TestCase {
 		$fixture = $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;');
 		$shell->registerCommand("git diff --no-prefix 'foobar.php'", $fixture);
 		$shell->registerCommand("git status --short 'foobar.php'", $this->fixture->getModifiedFileInfo('foobar.php'));
-		$shell->registerCommand("git show :0:$(git ls-files --full-name 'foobar.php')", '{"totals":{"errors":1,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"Variables.Defined.RequiredDefined.Unused","message":"Found unused symbol Emergent."}]}}}');
-		$shell->registerCommand("cat 'foobar.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":21,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"Variables.Defined.RequiredDefined.Unused","message":"Found unused symbol Emergent."},{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"Variables.Defined.RequiredDefined.Unused","message":"Found unused symbol Foobar."}]}}}');
+		$shell->registerCommand("git show :0:$(git ls-files --full-name 'foobar.php')", $this->phpcs->getResults('STDIN', [20], 'Found unused symbol Foobar.')->toPhpcsJson());
+		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getResults('STDIN', [21, 20], 'Found unused symbol Foobar.')->toPhpcsJson());
 		$options = ['git-unstaged' => '1'];
 		$expected = $this->phpcs->getResults('bin/foobar.php', [20], 'Found unused symbol Foobar.');
 		$messages = runGitWorkflow([$gitFile], $options, $shell, '\PhpcsChangedTests\Debug');
@@ -92,10 +92,10 @@ final class GitWorkflowTest extends TestCase {
 		$shell->registerCommand("git diff --staged --no-prefix 'baz.php'", $fixture);
 		$shell->registerCommand("git status --short 'foobar.php'", $this->fixture->getModifiedFileInfo('foobar.php'));
 		$shell->registerCommand("git status --short 'baz.php'", $this->fixture->getModifiedFileInfo('baz.php'));
-		$shell->registerCommand("git show HEAD:$(git ls-files --full-name 'foobar.php')", '{"totals":{"errors":1,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"Variables.Defined.RequiredDefined.Unused","message":"Found unused symbol Emergent."}]}}}');
-		$shell->registerCommand("git show HEAD:$(git ls-files --full-name 'baz.php')", '{"totals":{"errors":1,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"Variables.Defined.RequiredDefined.Unused","message":"Found unused symbol Emergent."}]}}}');
-		$shell->registerCommand("git show :0:$(git ls-files --full-name 'foobar.php')", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"Variables.Defined.RequiredDefined.Unused","message":"Found unused symbol Foobar."},{"line":21,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"Variables.Defined.RequiredDefined.Unused","message":"Found unused symbol Emergent."}]}}}');
-		$shell->registerCommand("git show :0:$(git ls-files --full-name 'baz.php')", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"Variables.Defined.RequiredDefined.Unused","message":"Found unused symbol Baz."},{"line":21,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"Variables.Defined.RequiredDefined.Unused","message":"Found unused symbol Baz."}]}}}');
+		$shell->registerCommand("git show HEAD:$(git ls-files --full-name 'foobar.php')", $this->phpcs->getResults('STDIN', [20])->toPhpcsJson());
+		$shell->registerCommand("git show HEAD:$(git ls-files --full-name 'baz.php')", $this->phpcs->getResults('STDIN', [20])->toPhpcsJson());
+		$shell->registerCommand("git show :0:$(git ls-files --full-name 'foobar.php')", $this->phpcs->getResults('STDIN', [20, 21], 'Found unused symbol Foobar.')->toPhpcsJson());
+		$shell->registerCommand("git show :0:$(git ls-files --full-name 'baz.php')", $this->phpcs->getResults('STDIN', [20, 21], 'Found unused symbol Baz.')->toPhpcsJson());
 		$options = [];
 		$expected = PhpcsMessages::merge([
 			$this->phpcs->getResults('bin/foobar.php', [20], 'Found unused symbol Foobar.'),
@@ -111,8 +111,8 @@ final class GitWorkflowTest extends TestCase {
 		$fixture = $this->fixture->getEmptyFileDiff();
 		$shell->registerCommand("git diff --staged --no-prefix 'foobar.php'", $fixture);
 		$shell->registerCommand("git status --short 'foobar.php'", '');
-		$shell->registerCommand("git show HEAD:$(git ls-files --full-name 'foobar.php')", '{"totals":{"errors":1,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"Variables.Defined.RequiredDefined.Unused","message":"Found unused symbol Emergent."}]}}}');
-		$shell->registerCommand("git show :0:$(git ls-files --full-name 'foobar.php')", '{"totals":{"errors":1,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"Variables.Defined.RequiredDefined.Unused","message":"Found unused symbol Emergent."}]}}}');
+		$shell->registerCommand("git show HEAD:$(git ls-files --full-name 'foobar.php')", $this->phpcs->getResults('STDIN', [20])->toPhpcsJson());
+		$shell->registerCommand("git show :0:$(git ls-files --full-name 'foobar.php')", $this->phpcs->getResults('STDIN', [20])->toPhpcsJson());
 		$options = [];
 		$expected = PhpcsMessages::fromArrays([], '/dev/null');
 		$messages = runGitWorkflow([$gitFile], $options, $shell, '\PhpcsChangedTests\Debug');
@@ -125,8 +125,8 @@ final class GitWorkflowTest extends TestCase {
 		$fixture = $this->fixture->getEmptyFileDiff();
 		$shell->registerCommand("git diff --staged --no-prefix 'foobar.php'", $fixture);
 		$shell->registerCommand("git status --short 'foobar.php'", '');
-		$shell->registerCommand("git show HEAD:$(git ls-files --full-name 'foobar.php')", '{"totals":{"errors":0,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":0,"warnings":0,"messages":[]}}}');
-		$shell->registerCommand("git show :0:$(git ls-files --full-name 'foobar.php')", '{"totals":{"errors":0,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":0,"warnings":0,"messages":[]}}}');
+		$shell->registerCommand("git show HEAD:$(git ls-files --full-name 'foobar.php')", $this->phpcs->getResults('STDIN', [])->toPhpcsJson());
+		$shell->registerCommand("git show :0:$(git ls-files --full-name 'foobar.php')", $this->phpcs->getResults('STDIN', [])->toPhpcsJson());
 		$options = [];
 		$expected = PhpcsMessages::fromArrays([], '/dev/null');
 		$messages = runGitWorkflow([$gitFile], $options, $shell, '\PhpcsChangedTests\Debug');
@@ -140,8 +140,8 @@ final class GitWorkflowTest extends TestCase {
 		$fixture = $this->fixture->getEmptyFileDiff();
 		$shell->registerCommand("git diff --staged --no-prefix 'foobar.php'", $fixture);
 		$shell->registerCommand("git status --short 'foobar.php'", "?? foobar.php" );
-		$shell->registerCommand("git show HEAD:$(git ls-files --full-name 'foobar.php')", "fatal: Path 'foobar.php' exists on disk, but not in 'HEAD'.", 128);
-		$shell->registerCommand("git show :0:$(git ls-files --full-name 'foobar.php')", '{"totals":{"errors":1,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"Variables.Defined.RequiredDefined.Unused","message":"Found unused symbol Foobar."}]}}}');
+		$shell->registerCommand("git show HEAD:$(git ls-files --full-name 'foobar.php')", $this->fixture->getNonGitFileShow('foobar.php'), 128);
+		$shell->registerCommand("git show :0:$(git ls-files --full-name 'foobar.php')", $this->phpcs->getResults('STDIN', [20], 'Found unused symbol Foobar.')->toPhpcsJson());
 		$options = [];
 		runGitWorkflow([$gitFile], $options, $shell, '\PhpcsChangedTests\Debug');
 	}
@@ -152,7 +152,7 @@ final class GitWorkflowTest extends TestCase {
 		$fixture = $this->fixture->getNewFileDiff('foobar.php');
 		$shell->registerCommand("git diff --staged --no-prefix 'foobar.php'", $fixture);
 		$shell->registerCommand("git status --short 'foobar.php'", $this->fixture->getNewFileInfo('foobar.php'));
-		$shell->registerCommand("git show :0:$(git ls-files --full-name 'foobar.php')", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":5,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"Variables.Defined.RequiredDefined.Unused","message":"Found unused symbol Foobar."},{"line":6,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"Variables.Defined.RequiredDefined.Unused","message":"Found unused symbol Foobar."}]}}}');
+		$shell->registerCommand("git show :0:$(git ls-files --full-name 'foobar.php')", $this->phpcs->getResults('STDIN', [5, 6], 'Found unused symbol Foobar.')->toPhpcsJson());
 		$options = [];
 		$expected = $this->phpcs->getResults('bin/foobar.php', [5, 6], 'Found unused symbol Foobar.');
 		$messages = runGitWorkflow([$gitFile], $options, $shell, '\PhpcsChangedTests\Debug');
@@ -185,8 +185,8 @@ Run "phpcs --help" for usage information
 		$shell->registerCommand("git diff '0123456789abcdef0123456789abcdef01234567'... --no-prefix 'bin/foobar.php'", $fixture);
 		$shell->registerCommand("git status --short 'bin/foobar.php'", '');
 		$shell->registerCommand("git cat-file -e '0123456789abcdef0123456789abcdef01234567':'bin/foobar.php'", '');
-		$shell->registerCommand("git show '0123456789abcdef0123456789abcdef01234567':$(git ls-files --full-name 'bin/foobar.php') | phpcs --report=json -q --stdin-path='bin/foobar.php' -", '{"totals":{"errors":0,"warnings":1,"fixable":0},"files":{"\/srv\/www\/wordpress-default\/public_html\/test\/bin\/foobar.php":{"errors":0,"warnings":1,"messages":[{"message":"Found unused symbol Emergent.","source":"Variables.Defined.RequiredDefined.Unused","severity":5,"fixable":false,"type":"ERROR","line":6,"column":5}]}}}');
-		$shell->registerCommand("git show HEAD:$(git ls-files --full-name 'bin/foobar.php') | phpcs --report=json -q --stdin-path='bin/foobar.php' -", '{"totals":{"errors":0,"warnings":2,"fixable":0},"files":{"\/srv\/www\/wordpress-default\/public_html\/test\/bin\/foobar.php":{"errors":0,"warnings":2,"messages":[{"message":"Found unused symbol Foobar.","source":"Variables.Defined.RequiredDefined.Unused","severity":5,"fixable":false,"type":"ERROR","line":6,"column":5},{"message":"Found unused symbol Emergent.","source":"Variables.Defined.RequiredDefined.Unused","severity":5,"fixable":false,"type":"ERROR","line":7,"column":5}]}}}');
+		$shell->registerCommand("git show '0123456789abcdef0123456789abcdef01234567':$(git ls-files --full-name 'bin/foobar.php') | phpcs --report=json -q --stdin-path='bin/foobar.php' -", $this->phpcs->getResults('\/srv\/www\/wordpress-default\/public_html\/test\/bin\/foobar.php', [6], 'Found unused symbol Foobar.')->toPhpcsJson());
+		$shell->registerCommand("git show HEAD:$(git ls-files --full-name 'bin/foobar.php') | phpcs --report=json -q --stdin-path='bin/foobar.php' -", $this->phpcs->getResults('\/srv\/www\/wordpress-default\/public_html\/test\/bin\/foobar.php', [6, 7], 'Found unused symbol Foobar.')->toPhpcsJson());
 		$options = [ 'git-base' => 'master' ];
 		$expected = $this->phpcs->getResults('bin/foobar.php', [6], 'Found unused symbol Foobar.');
 		$messages = runGitWorkflow([$gitFile], $options, $shell, '\PhpcsChangedTests\Debug');
@@ -202,12 +202,12 @@ Run "phpcs --help" for usage information
 		$shell->registerCommand("git merge-base 'master' HEAD", "0123456789abcdef0123456789abcdef01234567\n");
 		$shell->registerCommand("git diff '0123456789abcdef0123456789abcdef01234567'... --no-prefix 'test.php'", $fixture);
 		$shell->registerCommand("git cat-file -e '0123456789abcdef0123456789abcdef01234567':'test.php'", '', 128);
-		$shell->registerCommand("git show HEAD:$(git ls-files --full-name 'test.php') | phpcs --report=json -q --stdin-path='test.php' -", '{"totals":{"errors":0,"warnings":3,"fixable":0},"files":{"\/srv\/www\/wordpress-default\/public_html\/test\/test.php":{"errors":0,"warnings":3,"messages":[{"message":"Found unused symbol ' . "'Foobar'" . '.","source":"Variables.Defined.RequiredDefined.Unused","severity":5,"fixable":false,"type":"ERROR","line":6,"column":5},{"message":"Found unused symbol ' . "'Foobar'" . '.","source":"Variables.Defined.RequiredDefined.Unused","severity":5,"fixable":false,"type":"ERROR","line":7,"column":5},{"message":"Found unused symbol ' . "'Billing\\\\Emergent'" . '.","source":"Variables.Defined.RequiredDefined.Unused","severity":5,"fixable":false,"type":"ERROR","line":8,"column":5}]}}}');
+		$shell->registerCommand("git show HEAD:$(git ls-files --full-name 'test.php') | phpcs --report=json -q --stdin-path='test.php' -", $this->phpcs->getResults('\/srv\/www\/wordpress-default\/public_html\/test\/test.php', [6, 7, 8], "Found unused symbol 'Foobar'.")->toPhpcsJson());
 		$options = [ 'git-base' => 'master' ];
 		$expected = PhpcsMessages::merge([
 			$this->phpcs->getResults('test.php', [6], "Found unused symbol 'Foobar'."),
 			$this->phpcs->getResults('test.php', [7], "Found unused symbol 'Foobar'."),
-			$this->phpcs->getResults('test.php', [8], "Found unused symbol 'Billing\Emergent'."),
+			$this->phpcs->getResults('test.php', [8], "Found unused symbol 'Foobar'."),
 		]);
 		$messages = runGitWorkflow([$gitFile], $options, $shell, '\PhpcsChangedTests\Debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());

--- a/tests/GitWorkflowTest.php
+++ b/tests/GitWorkflowTest.php
@@ -9,6 +9,7 @@ use PhpcsChanged\PhpcsMessages;
 use PhpcsChanged\ShellException;
 use PhpcsChangedTests\TestShell;
 use PhpcsChangedTests\GitFixture;
+use PhpcsChangedTests\PhpcsFixture;
 use function PhpcsChanged\Cli\runGitWorkflow;
 use function PhpcsChanged\GitWorkflow\{isNewGitFile, getGitUnifiedDiff};
 
@@ -16,6 +17,7 @@ final class GitWorkflowTest extends TestCase {
 	public function setUp(): void {
 		parent::setUp();
 		$this->fixture = new GitFixture();
+		$this->phpcs = new PhpcsFixture();
 	}
 
 	public function testIsNewGitFileReturnsTrueForNewFile() {
@@ -59,20 +61,10 @@ final class GitWorkflowTest extends TestCase {
 		$fixture = $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;');
 		$shell->registerCommand("git diff --staged --no-prefix 'foobar.php'", $fixture);
 		$shell->registerCommand("git status --short 'foobar.php'", ' M foobar.php'); // note the leading space
-		$shell->registerCommand("git show HEAD:$(git ls-files --full-name 'foobar.php')", '{"totals":{"errors":1,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
-		$shell->registerCommand("git show :0:$(git ls-files --full-name 'foobar.php')", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Foobar."},{"line":21,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
+		$shell->registerCommand("git show HEAD:$(git ls-files --full-name 'foobar.php')", '{"totals":{"errors":1,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"Variables.Defined.RequiredDefined.Unused","message":"Found unused symbol Emergent."}]}}}');
+		$shell->registerCommand("git show :0:$(git ls-files --full-name 'foobar.php')", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"Variables.Defined.RequiredDefined.Unused","message":"Found unused symbol Foobar."},{"line":21,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"Variables.Defined.RequiredDefined.Unused","message":"Found unused symbol Emergent."}]}}}');
 		$options = [];
-		$expected = PhpcsMessages::fromArrays([
-			[
-				'type' => 'ERROR',
-				'severity' => 5,
-				'fixable' => false,
-				'column' => 5,
-				'source' => 'ImportDetection.Imports.RequireImports.Import',
-				'line' => 20,
-				'message' => 'Found unused symbol Foobar.',
-			],
-		], 'bin/foobar.php');
+		$expected = $this->phpcs->getResults('bin/foobar.php', [20], 'Found unused symbol Foobar.');
 		$messages = runGitWorkflow([$gitFile], $options, $shell, '\PhpcsChangedTests\Debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
@@ -83,20 +75,10 @@ final class GitWorkflowTest extends TestCase {
 		$fixture = $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;');
 		$shell->registerCommand("git diff --no-prefix 'foobar.php'", $fixture);
 		$shell->registerCommand("git status --short 'foobar.php'", ' M foobar.php'); // note the leading space
-		$shell->registerCommand("git show :0:$(git ls-files --full-name 'foobar.php')", '{"totals":{"errors":1,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
-		$shell->registerCommand("cat 'foobar.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":21,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Foobar."}]}}}');
+		$shell->registerCommand("git show :0:$(git ls-files --full-name 'foobar.php')", '{"totals":{"errors":1,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"Variables.Defined.RequiredDefined.Unused","message":"Found unused symbol Emergent."}]}}}');
+		$shell->registerCommand("cat 'foobar.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":21,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"Variables.Defined.RequiredDefined.Unused","message":"Found unused symbol Emergent."},{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"Variables.Defined.RequiredDefined.Unused","message":"Found unused symbol Foobar."}]}}}');
 		$options = ['git-unstaged' => '1'];
-		$expected = PhpcsMessages::fromArrays([
-			[
-				'type' => 'ERROR',
-				'severity' => 5,
-				'fixable' => false,
-				'column' => 5,
-				'source' => 'ImportDetection.Imports.RequireImports.Import',
-				'line' => 20,
-				'message' => 'Found unused symbol Foobar.',
-			],
-		], 'bin/foobar.php');
+		$expected = $this->phpcs->getResults('bin/foobar.php', [20], 'Found unused symbol Foobar.');
 		$messages = runGitWorkflow([$gitFile], $options, $shell, '\PhpcsChangedTests\Debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
@@ -110,34 +92,14 @@ final class GitWorkflowTest extends TestCase {
 		$shell->registerCommand("git diff --staged --no-prefix 'baz.php'", $fixture);
 		$shell->registerCommand("git status --short 'foobar.php'", ' M foobar.php'); // note the leading space
 		$shell->registerCommand("git status --short 'baz.php'", ' M baz.php'); // note the leading space
-		$shell->registerCommand("git show HEAD:$(git ls-files --full-name 'foobar.php')", '{"totals":{"errors":1,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
-		$shell->registerCommand("git show HEAD:$(git ls-files --full-name 'baz.php')", '{"totals":{"errors":1,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
-		$shell->registerCommand("git show :0:$(git ls-files --full-name 'foobar.php')", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Foobar."},{"line":21,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
-		$shell->registerCommand("git show :0:$(git ls-files --full-name 'baz.php')", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Baz."},{"line":21,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Baz."}]}}}');
+		$shell->registerCommand("git show HEAD:$(git ls-files --full-name 'foobar.php')", '{"totals":{"errors":1,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"Variables.Defined.RequiredDefined.Unused","message":"Found unused symbol Emergent."}]}}}');
+		$shell->registerCommand("git show HEAD:$(git ls-files --full-name 'baz.php')", '{"totals":{"errors":1,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"Variables.Defined.RequiredDefined.Unused","message":"Found unused symbol Emergent."}]}}}');
+		$shell->registerCommand("git show :0:$(git ls-files --full-name 'foobar.php')", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"Variables.Defined.RequiredDefined.Unused","message":"Found unused symbol Foobar."},{"line":21,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"Variables.Defined.RequiredDefined.Unused","message":"Found unused symbol Emergent."}]}}}');
+		$shell->registerCommand("git show :0:$(git ls-files --full-name 'baz.php')", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"Variables.Defined.RequiredDefined.Unused","message":"Found unused symbol Baz."},{"line":21,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"Variables.Defined.RequiredDefined.Unused","message":"Found unused symbol Baz."}]}}}');
 		$options = [];
 		$expected = PhpcsMessages::merge([
-			PhpcsMessages::fromArrays([
-				[
-					'type' => 'ERROR',
-					'severity' => 5,
-					'fixable' => false,
-					'column' => 5,
-					'source' => 'ImportDetection.Imports.RequireImports.Import',
-					'line' => 20,
-					'message' => 'Found unused symbol Foobar.',
-				],
-			], 'bin/foobar.php'),
-			PhpcsMessages::fromArrays([
-				[
-					'type' => 'ERROR',
-					'severity' => 5,
-					'fixable' => false,
-					'column' => 5,
-					'source' => 'ImportDetection.Imports.RequireImports.Import',
-					'line' => 20,
-					'message' => 'Found unused symbol Baz.',
-				],
-			], 'bin/baz.php'),
+			$this->phpcs->getResults('bin/foobar.php', [20], 'Found unused symbol Foobar.'),
+			$this->phpcs->getResults('bin/baz.php', [20], 'Found unused symbol Baz.'),
 		]);
 		$messages = runGitWorkflow($gitFiles, $options, $shell, '\PhpcsChangedTests\Debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
@@ -149,8 +111,8 @@ final class GitWorkflowTest extends TestCase {
 		$fixture = $this->fixture->getEmptyFileDiff();
 		$shell->registerCommand("git diff --staged --no-prefix 'foobar.php'", $fixture);
 		$shell->registerCommand("git status --short 'foobar.php'", '');
-		$shell->registerCommand("git show HEAD:$(git ls-files --full-name 'foobar.php')", '{"totals":{"errors":1,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
-		$shell->registerCommand("git show :0:$(git ls-files --full-name 'foobar.php')", '{"totals":{"errors":1,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
+		$shell->registerCommand("git show HEAD:$(git ls-files --full-name 'foobar.php')", '{"totals":{"errors":1,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"Variables.Defined.RequiredDefined.Unused","message":"Found unused symbol Emergent."}]}}}');
+		$shell->registerCommand("git show :0:$(git ls-files --full-name 'foobar.php')", '{"totals":{"errors":1,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"Variables.Defined.RequiredDefined.Unused","message":"Found unused symbol Emergent."}]}}}');
 		$options = [];
 		$expected = PhpcsMessages::fromArrays([], '/dev/null');
 		$messages = runGitWorkflow([$gitFile], $options, $shell, '\PhpcsChangedTests\Debug');
@@ -179,7 +141,7 @@ final class GitWorkflowTest extends TestCase {
 		$shell->registerCommand("git diff --staged --no-prefix 'foobar.php'", $fixture);
 		$shell->registerCommand("git status --short 'foobar.php'", "?? foobar.php" );
 		$shell->registerCommand("git show HEAD:$(git ls-files --full-name 'foobar.php')", "fatal: Path 'foobar.php' exists on disk, but not in 'HEAD'.", 128);
-		$shell->registerCommand("git show :0:$(git ls-files --full-name 'foobar.php')", '{"totals":{"errors":1,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
+		$shell->registerCommand("git show :0:$(git ls-files --full-name 'foobar.php')", '{"totals":{"errors":1,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"Variables.Defined.RequiredDefined.Unused","message":"Found unused symbol Foobar."}]}}}');
 		$options = [];
 		runGitWorkflow([$gitFile], $options, $shell, '\PhpcsChangedTests\Debug');
 	}
@@ -190,28 +152,9 @@ final class GitWorkflowTest extends TestCase {
 		$fixture = $this->fixture->getNewFileDiff('foobar.php');
 		$shell->registerCommand("git diff --staged --no-prefix 'foobar.php'", $fixture);
 		$shell->registerCommand("git status --short 'foobar.php'",'A foobar.php');
-		$shell->registerCommand("git show :0:$(git ls-files --full-name 'foobar.php')", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":5,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Foobar."},{"line":6,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
+		$shell->registerCommand("git show :0:$(git ls-files --full-name 'foobar.php')", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":5,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"Variables.Defined.RequiredDefined.Unused","message":"Found unused symbol Foobar."},{"line":6,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"Variables.Defined.RequiredDefined.Unused","message":"Found unused symbol Foobar."}]}}}');
 		$options = [];
-		$expected = PhpcsMessages::fromArrays([
-			[
-				'type' => 'ERROR',
-				'severity' => 5,
-				'fixable' => false,
-				'column' => 5,
-				'source' => 'ImportDetection.Imports.RequireImports.Import',
-				'line' => 5,
-				'message' => 'Found unused symbol Foobar.',
-			],
-			[
-				'type' => 'ERROR',
-				'severity' => 5,
-				'fixable' => false,
-				'column' => 5,
-				'source' => 'ImportDetection.Imports.RequireImports.Import',
-				'line' => 6,
-				'message' => 'Found unused symbol Emergent.',
-			],
-		], 'bin/foobar.php');
+		$expected = $this->phpcs->getResults('bin/foobar.php', [5, 6], 'Found unused symbol Foobar.');
 		$messages = runGitWorkflow([$gitFile], $options, $shell, '\PhpcsChangedTests\Debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
@@ -242,20 +185,10 @@ Run "phpcs --help" for usage information
 		$shell->registerCommand("git diff '0123456789abcdef0123456789abcdef01234567'... --no-prefix 'bin/foobar.php'", $fixture);
 		$shell->registerCommand("git status --short 'bin/foobar.php'", '');
 		$shell->registerCommand("git cat-file -e '0123456789abcdef0123456789abcdef01234567':'bin/foobar.php'", '');
-		$shell->registerCommand("git show '0123456789abcdef0123456789abcdef01234567':$(git ls-files --full-name 'bin/foobar.php') | phpcs --report=json -q --stdin-path='bin/foobar.php' -", '{"totals":{"errors":0,"warnings":1,"fixable":0},"files":{"\/srv\/www\/wordpress-default\/public_html\/test\/bin\/foobar.php":{"errors":0,"warnings":1,"messages":[{"message":"Found unused symbol Emergent.","source":"ImportDetection.Imports.RequireImports.Import","severity":5,"fixable":false,"type":"WARNING","line":6,"column":5}]}}}');
-		$shell->registerCommand("git show HEAD:$(git ls-files --full-name 'bin/foobar.php') | phpcs --report=json -q --stdin-path='bin/foobar.php' -", '{"totals":{"errors":0,"warnings":2,"fixable":0},"files":{"\/srv\/www\/wordpress-default\/public_html\/test\/bin\/foobar.php":{"errors":0,"warnings":2,"messages":[{"message":"Found unused symbol Foobar.","source":"ImportDetection.Imports.RequireImports.Import","severity":5,"fixable":false,"type":"WARNING","line":6,"column":5},{"message":"Found unused symbol Emergent.","source":"ImportDetection.Imports.RequireImports.Import","severity":5,"fixable":false,"type":"WARNING","line":7,"column":5}]}}}');
+		$shell->registerCommand("git show '0123456789abcdef0123456789abcdef01234567':$(git ls-files --full-name 'bin/foobar.php') | phpcs --report=json -q --stdin-path='bin/foobar.php' -", '{"totals":{"errors":0,"warnings":1,"fixable":0},"files":{"\/srv\/www\/wordpress-default\/public_html\/test\/bin\/foobar.php":{"errors":0,"warnings":1,"messages":[{"message":"Found unused symbol Emergent.","source":"Variables.Defined.RequiredDefined.Unused","severity":5,"fixable":false,"type":"ERROR","line":6,"column":5}]}}}');
+		$shell->registerCommand("git show HEAD:$(git ls-files --full-name 'bin/foobar.php') | phpcs --report=json -q --stdin-path='bin/foobar.php' -", '{"totals":{"errors":0,"warnings":2,"fixable":0},"files":{"\/srv\/www\/wordpress-default\/public_html\/test\/bin\/foobar.php":{"errors":0,"warnings":2,"messages":[{"message":"Found unused symbol Foobar.","source":"Variables.Defined.RequiredDefined.Unused","severity":5,"fixable":false,"type":"ERROR","line":6,"column":5},{"message":"Found unused symbol Emergent.","source":"Variables.Defined.RequiredDefined.Unused","severity":5,"fixable":false,"type":"ERROR","line":7,"column":5}]}}}');
 		$options = [ 'git-base' => 'master' ];
-		$expected = PhpcsMessages::fromArrays([
-			[
-				'type' => 'WARNING',
-				'severity' => 5,
-				'fixable' => false,
-				'column' => 5,
-				'source' => 'ImportDetection.Imports.RequireImports.Import',
-				'line' => 6,
-				'message' => "Found unused symbol Foobar.",
-			],
-		], 'bin/foobar.php');
+		$expected = $this->phpcs->getResults('bin/foobar.php', [6], 'Found unused symbol Foobar.');
 		$messages = runGitWorkflow([$gitFile], $options, $shell, '\PhpcsChangedTests\Debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
@@ -269,38 +202,13 @@ Run "phpcs --help" for usage information
 		$shell->registerCommand("git merge-base 'master' HEAD", "0123456789abcdef0123456789abcdef01234567\n");
 		$shell->registerCommand("git diff '0123456789abcdef0123456789abcdef01234567'... --no-prefix 'test.php'", $fixture);
 		$shell->registerCommand("git cat-file -e '0123456789abcdef0123456789abcdef01234567':'test.php'", '', 128);
-		$shell->registerCommand("git show HEAD:$(git ls-files --full-name 'test.php') | phpcs --report=json -q --stdin-path='test.php' -", '{"totals":{"errors":0,"warnings":3,"fixable":0},"files":{"\/srv\/www\/wordpress-default\/public_html\/test\/test.php":{"errors":0,"warnings":3,"messages":[{"message":"Found unused symbol ' . "'Foobar'" . '.","source":"ImportDetection.Imports.RequireImports.Import","severity":5,"fixable":false,"type":"WARNING","line":6,"column":5},{"message":"Found unused symbol ' . "'Foobar'" . '.","source":"ImportDetection.Imports.RequireImports.Import","severity":5,"fixable":false,"type":"WARNING","line":7,"column":5},{"message":"Found unused symbol ' . "'Billing\\\\Emergent'" . '.","source":"ImportDetection.Imports.RequireImports.Import","severity":5,"fixable":false,"type":"WARNING","line":8,"column":5}]}}}');
+		$shell->registerCommand("git show HEAD:$(git ls-files --full-name 'test.php') | phpcs --report=json -q --stdin-path='test.php' -", '{"totals":{"errors":0,"warnings":3,"fixable":0},"files":{"\/srv\/www\/wordpress-default\/public_html\/test\/test.php":{"errors":0,"warnings":3,"messages":[{"message":"Found unused symbol ' . "'Foobar'" . '.","source":"Variables.Defined.RequiredDefined.Unused","severity":5,"fixable":false,"type":"ERROR","line":6,"column":5},{"message":"Found unused symbol ' . "'Foobar'" . '.","source":"Variables.Defined.RequiredDefined.Unused","severity":5,"fixable":false,"type":"ERROR","line":7,"column":5},{"message":"Found unused symbol ' . "'Billing\\\\Emergent'" . '.","source":"Variables.Defined.RequiredDefined.Unused","severity":5,"fixable":false,"type":"ERROR","line":8,"column":5}]}}}');
 		$options = [ 'git-base' => 'master' ];
-		$expected = PhpcsMessages::fromArrays([
-			[
-				'type' => 'WARNING',
-				'severity' => 5,
-				'fixable' => false,
-				'column' => 5,
-				'source' => 'ImportDetection.Imports.RequireImports.Import',
-				'line' => 6,
-				'message' => "Found unused symbol 'Foobar'.",
-			],
-			[
-				'type' => 'WARNING',
-				'severity' => 5,
-				'fixable' => false,
-				'column' => 5,
-				'source' => 'ImportDetection.Imports.RequireImports.Import',
-				'line' => 7,
-				'message' => "Found unused symbol 'Foobar'.",
-				
-			],
-			[
-				'type' => 'WARNING',
-				'severity' => 5,
-				'fixable' => false,
-				'column' => 5,
-				'source' => 'ImportDetection.Imports.RequireImports.Import',
-				'line' => 8,
-				'message' => "Found unused symbol 'Billing\Emergent'.",
-			],
-		], 'test.php');
+		$expected = PhpcsMessages::merge([
+			$this->phpcs->getResults('test.php', [6], "Found unused symbol 'Foobar'."),
+			$this->phpcs->getResults('test.php', [7], "Found unused symbol 'Foobar'."),
+			$this->phpcs->getResults('test.php', [8], "Found unused symbol 'Billing\Emergent'."),
+		]);
 		$messages = runGitWorkflow([$gitFile], $options, $shell, '\PhpcsChangedTests\Debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}

--- a/tests/GitWorkflowTest.php
+++ b/tests/GitWorkflowTest.php
@@ -25,7 +25,7 @@ final class GitWorkflowTest extends TestCase {
 		$git = 'git';
 		$executeCommand = function($command) {
 			if (false !== strpos($command, "git status --short 'foobar.php'")) {
-				return 'A foobar.php';
+				return $this->fixture->getNewFileInfo('foobar.php');
 			}
 		};
 		$this->assertTrue(isNewGitFile($gitFile, $git, $executeCommand, array(), '\PhpcsChangedTests\Debug'));
@@ -36,7 +36,7 @@ final class GitWorkflowTest extends TestCase {
 		$git = 'git';
 		$executeCommand = function($command) {
 			if (false !== strpos($command, "git status --short 'foobar.php'")) {
-				return ' M foobar.php'; // note the leading space
+				return $this->fixture->getModifiedFileInfo('foobar.php');
 			}
 		};
 		$this->assertFalse(isNewGitFile($gitFile, $git, $executeCommand, array(), '\PhpcsChangedTests\Debug'));
@@ -60,7 +60,7 @@ final class GitWorkflowTest extends TestCase {
 		$shell = new TestShell([$gitFile]);
 		$fixture = $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;');
 		$shell->registerCommand("git diff --staged --no-prefix 'foobar.php'", $fixture);
-		$shell->registerCommand("git status --short 'foobar.php'", ' M foobar.php'); // note the leading space
+		$shell->registerCommand("git status --short 'foobar.php'", $this->fixture->getModifiedFileInfo('foobar.php'));
 		$shell->registerCommand("git show HEAD:$(git ls-files --full-name 'foobar.php')", '{"totals":{"errors":1,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"Variables.Defined.RequiredDefined.Unused","message":"Found unused symbol Emergent."}]}}}');
 		$shell->registerCommand("git show :0:$(git ls-files --full-name 'foobar.php')", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"Variables.Defined.RequiredDefined.Unused","message":"Found unused symbol Foobar."},{"line":21,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"Variables.Defined.RequiredDefined.Unused","message":"Found unused symbol Emergent."}]}}}');
 		$options = [];
@@ -74,7 +74,7 @@ final class GitWorkflowTest extends TestCase {
 		$shell = new TestShell([$gitFile]);
 		$fixture = $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;');
 		$shell->registerCommand("git diff --no-prefix 'foobar.php'", $fixture);
-		$shell->registerCommand("git status --short 'foobar.php'", ' M foobar.php'); // note the leading space
+		$shell->registerCommand("git status --short 'foobar.php'", $this->fixture->getModifiedFileInfo('foobar.php'));
 		$shell->registerCommand("git show :0:$(git ls-files --full-name 'foobar.php')", '{"totals":{"errors":1,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"Variables.Defined.RequiredDefined.Unused","message":"Found unused symbol Emergent."}]}}}');
 		$shell->registerCommand("cat 'foobar.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":21,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"Variables.Defined.RequiredDefined.Unused","message":"Found unused symbol Emergent."},{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"Variables.Defined.RequiredDefined.Unused","message":"Found unused symbol Foobar."}]}}}');
 		$options = ['git-unstaged' => '1'];
@@ -90,8 +90,8 @@ final class GitWorkflowTest extends TestCase {
 		$shell->registerCommand("git diff --staged --no-prefix 'foobar.php'", $fixture);
 		$fixture = $this->fixture->getAddedLineDiff('baz.php', 'use Baz;');
 		$shell->registerCommand("git diff --staged --no-prefix 'baz.php'", $fixture);
-		$shell->registerCommand("git status --short 'foobar.php'", ' M foobar.php'); // note the leading space
-		$shell->registerCommand("git status --short 'baz.php'", ' M baz.php'); // note the leading space
+		$shell->registerCommand("git status --short 'foobar.php'", $this->fixture->getModifiedFileInfo('foobar.php'));
+		$shell->registerCommand("git status --short 'baz.php'", $this->fixture->getModifiedFileInfo('baz.php'));
 		$shell->registerCommand("git show HEAD:$(git ls-files --full-name 'foobar.php')", '{"totals":{"errors":1,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"Variables.Defined.RequiredDefined.Unused","message":"Found unused symbol Emergent."}]}}}');
 		$shell->registerCommand("git show HEAD:$(git ls-files --full-name 'baz.php')", '{"totals":{"errors":1,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"Variables.Defined.RequiredDefined.Unused","message":"Found unused symbol Emergent."}]}}}');
 		$shell->registerCommand("git show :0:$(git ls-files --full-name 'foobar.php')", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"Variables.Defined.RequiredDefined.Unused","message":"Found unused symbol Foobar."},{"line":21,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"Variables.Defined.RequiredDefined.Unused","message":"Found unused symbol Emergent."}]}}}');
@@ -151,7 +151,7 @@ final class GitWorkflowTest extends TestCase {
 		$shell = new TestShell([$gitFile]);
 		$fixture = $this->fixture->getNewFileDiff('foobar.php');
 		$shell->registerCommand("git diff --staged --no-prefix 'foobar.php'", $fixture);
-		$shell->registerCommand("git status --short 'foobar.php'",'A foobar.php');
+		$shell->registerCommand("git status --short 'foobar.php'", $this->fixture->getNewFileInfo('foobar.php'));
 		$shell->registerCommand("git show :0:$(git ls-files --full-name 'foobar.php')", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":5,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"Variables.Defined.RequiredDefined.Unused","message":"Found unused symbol Foobar."},{"line":6,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"Variables.Defined.RequiredDefined.Unused","message":"Found unused symbol Foobar."}]}}}');
 		$options = [];
 		$expected = $this->phpcs->getResults('bin/foobar.php', [5, 6], 'Found unused symbol Foobar.');
@@ -164,7 +164,7 @@ final class GitWorkflowTest extends TestCase {
 		$shell = new TestShell([$gitFile]);
 		$fixture = $this->fixture->getNewFileDiff('foobar.php');
 		$shell->registerCommand("git diff --staged --no-prefix 'foobar.php'", $fixture);
-		$shell->registerCommand("git status --short 'foobar.php'", 'A foobar.php');
+		$shell->registerCommand("git status --short 'foobar.php'", $this->fixture->getNewFileInfo('foobar.php'));
 		$fixture ='ERROR: You must supply at least one file or directory to process.
 
 Run "phpcs --help" for usage information
@@ -196,7 +196,7 @@ Run "phpcs --help" for usage information
 	function testNameDetectionInFullGitWorkflowForInterBranchDiff() {
 		$gitFile = 'test.php';
 		$shell = new TestShell([$gitFile]);
-		$shell->registerCommand("git status --short 'test.php'", ' M test.php');
+		$shell->registerCommand("git status --short 'test.php'", $this->fixture->getModifiedFileInfo('test.php'));
 		
 		$fixture = $this->fixture->getAltNewFileDiff('test.php');
 		$shell->registerCommand("git merge-base 'master' HEAD", "0123456789abcdef0123456789abcdef01234567\n");

--- a/tests/SvnWorkflowTest.php
+++ b/tests/SvnWorkflowTest.php
@@ -101,7 +101,7 @@ final class SvnWorkflowTest extends TestCase {
 		$expected = $this->phpcs->getResults('bin/foobar.php', [20]);
 		$cache = new TestCache();
 		$cache->setRevision('188280');
-		$cache->setEntry('foobar.php', '', '', $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
+		$cache->setEntry('foobar.php', 'old', '', '', $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
 		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager($cache), '\PhpcsChangedTests\Debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 		$this->assertFalse($shell->wasCommandCalled("svn cat 'foobar.php'"));
@@ -295,7 +295,7 @@ final class SvnWorkflowTest extends TestCase {
 		$cache = new TestCache();
 		$cache->setCacheVersion('0.1-something-else');
 		$cache->setRevision('188280');
-		$cache->setEntry('foobar.php', '', '', 'blah'); // This invalid JSON will throw if the cache is used
+		$cache->setEntry('foobar.php', 'old', '', '', 'blah'); // This invalid JSON will throw if the cache is used
 		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager($cache), '\PhpcsChangedTests\Debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 		$this->assertTrue($shell->wasCommandCalled("svn cat 'foobar.php'"));
@@ -318,7 +318,7 @@ final class SvnWorkflowTest extends TestCase {
 		$expected = $this->phpcs->getResults('bin/foobar.php', [20]);
 		$cache = new TestCache();
 		$cache->setRevision('188280');
-		$cache->setEntry('foobar.php', '', 'TestStandard2', 'blah'); // This invalid JSON will throw if the cache is used
+		$cache->setEntry('foobar.php', 'old', '', 'TestStandard2', 'blah'); // This invalid JSON will throw if the cache is used
 		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager($cache), '\PhpcsChangedTests\Debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 		$this->assertTrue($shell->wasCommandCalled("svn cat 'foobar.php'"));
@@ -338,7 +338,7 @@ final class SvnWorkflowTest extends TestCase {
 		$expected = $this->phpcs->getResults('bin/foobar.php', [20]);
 		$cache = new TestCache();
 		$cache->setRevision('1000');
-		$cache->setEntry('foobar.php', '', '', 'blah'); // This invalid JSON will throw if the cache is used
+		$cache->setEntry('foobar.php', 'old', '', '', 'blah'); // This invalid JSON will throw if the cache is used
 		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager($cache), '\PhpcsChangedTests\Debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 		$this->assertTrue($shell->wasCommandCalled("svn cat 'foobar.php'"));
@@ -357,7 +357,7 @@ final class SvnWorkflowTest extends TestCase {
 		$expected = PhpcsMessages::fromArrays([], 'bin/foobar.php');
 		$cache = new TestCache();
 		$cache->setRevision('188280');
-		$cache->setEntry('foobar.php', '', '', $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
+		$cache->setEntry('foobar.php', 'old', '', '', $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
 		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager($cache), '\PhpcsChangedTests\Debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 		$this->assertFalse($shell->wasCommandCalled("svn cat 'foobar.php'"));

--- a/tests/SvnWorkflowTest.php
+++ b/tests/SvnWorkflowTest.php
@@ -183,7 +183,7 @@ EOF;
 		$shell->registerCommand("svn cat 'foobar.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":99,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
 		$shell->registerCommand("cat 'foobar.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":21,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
 		$options = [
-			'cache' => true,
+			'cache' => false, // getopt is weird and sets options to false
 		];
 		$expected = PhpcsMessages::fromArrays([
 			[
@@ -238,7 +238,7 @@ EOF;
 		$shell->registerCommand("svn info 'foobar.php'", $fixture);
 		$shell->registerCommand("cat 'foobar.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":21,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
 		$options = [
-			'cache' => true,
+			'cache' => false, // getopt is weird and sets options to false
 		];
 		$expected = PhpcsMessages::fromArrays([
 			[
@@ -297,7 +297,7 @@ EOF;
 		$shell->registerCommand("svn cat 'foobar.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":99,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
 		$shell->registerCommand("cat 'foobar.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":21,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
 		$options = [
-			'cache' => true,
+			'cache' => false, // getopt is weird and sets options to false
 		];
 		$expected = PhpcsMessages::fromArrays([
 			[
@@ -357,7 +357,7 @@ EOF;
 		$shell->registerCommand("svn cat 'foobar.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":99,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
 		$shell->registerCommand("cat 'foobar.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":21,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
 		$options = [
-			'no-cache' => true,
+			'no-cache' => false, // getopt is weird and sets options to false
 		];
 		$expected = PhpcsMessages::fromArrays([
 			[
@@ -417,7 +417,7 @@ EOF;
 		$shell->registerCommand("svn cat 'foobar.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":99,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
 		$shell->registerCommand("cat 'foobar.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":21,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
 		$options = [
-			'cache' => true,
+			'cache' => false, // getopt is weird and sets options to false
 		];
 		$expected = PhpcsMessages::fromArrays([
 			[
@@ -477,7 +477,7 @@ EOF;
 		$shell->registerCommand("svn cat 'foobar.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":99,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
 		$shell->registerCommand("cat 'foobar.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":21,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
 		$options = [
-			'cache' => true,
+			'cache' => false, // getopt is weird and sets options to false
 		];
 		$expected = PhpcsMessages::fromArrays([
 			[
@@ -523,7 +523,7 @@ EOF;
 		$shell->registerCommand("svn info 'foobar.php'", $fixture);
 		$shell->registerCommand("cat 'foobar.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":21,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
 		$options = [
-			'cache' => true,
+			'cache' => false, // getopt is weird and sets options to false
 		];
 		$expected = PhpcsMessages::fromArrays([], 'bin/foobar.php');
 		$cache = new TestCache();

--- a/tests/SvnWorkflowTest.php
+++ b/tests/SvnWorkflowTest.php
@@ -27,16 +27,7 @@ final class SvnWorkflowTest extends TestCase {
 			if (! $command || false === strpos($command, "svn info 'foobar.php'")) {
 				return '';
 			}
-			return "Path: foobar.php
-Name: foobar.php
-Working Copy Root Path: /home/public_html
-URL: https://svn.localhost/trunk/foobar.php
-Relative URL: ^/trunk/foobar.php
-Repository Root: https://svn.localhost
-Repository UUID: 1111-1111-1111-1111
-Node Kind: file
-Schedule: add
-";
+			return $this->fixture->getSvnInfoNewFile('foobar.php');
 		};
 		$svnFileInfo = getSvnFileInfo($svnFile, $svn, $executeCommand, '\PhpcsChangedTests\Debug');
 		$this->assertTrue(isNewSvnFile($svnFileInfo));
@@ -49,22 +40,7 @@ Schedule: add
 			if (! $command || false === strpos($command, "svn info 'foobar.php'")) {
 				return '';
 			}
-			return "Path: foobar.php
-Name: foobar.php
-Working Copy Root Path: /home/public_html
-URL: https://svn.localhost/trunk/wp-content/mu-plugins/foobar.php
-Relative URL: ^/trunk/foobar.php
-Repository Root: https://svn.localhost
-Repository UUID: 1111-1111-1111-1111
-Revision: 188280
-Node Kind: file
-Schedule: normal
-Last Changed Author: me
-Last Changed Rev: 175729
-Last Changed Date: 2018-05-22 17:34:00 +0000 (Tue, 22 May 2018)
-Text Last Updated: 2018-05-22 17:34:00 +0000 (Tue, 22 May 2018)
-Checksum: abcdefg
-";
+			return $this->fixture->getSvnInfo('foobar.php');
 		};
 		$svnFileInfo = getSvnFileInfo($svnFile, $svn, $executeCommand, '\PhpcsChangedTests\Debug');
 		$this->assertFalse(isNewSvnFile($svnFileInfo));
@@ -87,24 +63,7 @@ Checksum: abcdefg
 		$svnFile = 'foobar.php';
 		$shell = new TestShell([$svnFile]);
 		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
-		$fixture = <<<EOF
-Path: foobar.php
-Name: foobar.php
-Working Copy Root Path: /home/public_html
-URL: https://svn.localhost/trunk/wp-content/mu-plugins/foobar.php
-Relative URL: ^/trunk/foobar.php
-Repository Root: https://svn.localhost
-Repository UUID: 1111-1111-1111-1111
-Revision: 188280
-Node Kind: file
-Schedule: normal
-Last Changed Author: me
-Last Changed Rev: 175729
-Last Changed Date: 2018-05-22 17:34:00 +0000 (Tue, 22 May 2018)
-Text Last Updated: 2018-05-22 17:34:00 +0000 (Tue, 22 May 2018)
-Checksum: abcdefg
-EOF;
-		$shell->registerCommand("svn info 'foobar.php'", $fixture);
+		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php'));
 		$shell->registerCommand("svn cat 'foobar.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":99,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
 		$shell->registerCommand("cat 'foobar.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":21,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
 		$options = [];
@@ -127,24 +86,7 @@ EOF;
 		$svnFile = 'foobar.php';
 		$shell = new TestShell([$svnFile]);
 		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
-		$fixture = <<<EOF
-Path: foobar.php
-Name: foobar.php
-Working Copy Root Path: /home/public_html
-URL: https://svn.localhost/trunk/wp-content/mu-plugins/foobar.php
-Relative URL: ^/trunk/foobar.php
-Repository Root: https://svn.localhost
-Repository UUID: 1111-1111-1111-1111
-Revision: 188280
-Node Kind: file
-Schedule: normal
-Last Changed Author: me
-Last Changed Rev: 175729
-Last Changed Date: 2018-05-22 17:34:00 +0000 (Tue, 22 May 2018)
-Text Last Updated: 2018-05-22 17:34:00 +0000 (Tue, 22 May 2018)
-Checksum: abcdefg
-EOF;
-		$shell->registerCommand("svn info 'foobar.php'", $fixture);
+		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php'));
 		$shell->registerCommand("svn cat 'foobar.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":99,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
 		$shell->registerCommand("cat 'foobar.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":21,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
 		$options = [
@@ -169,24 +111,7 @@ EOF;
 		$svnFile = 'foobar.php';
 		$shell = new TestShell([$svnFile]);
 		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
-		$fixture = <<<EOF
-Path: foobar.php
-Name: foobar.php
-Working Copy Root Path: /home/public_html
-URL: https://svn.localhost/trunk/wp-content/mu-plugins/foobar.php
-Relative URL: ^/trunk/foobar.php
-Repository Root: https://svn.localhost
-Repository UUID: 1111-1111-1111-1111
-Revision: 188280
-Node Kind: file
-Schedule: normal
-Last Changed Author: me
-Last Changed Rev: 175729
-Last Changed Date: 2018-05-22 17:34:00 +0000 (Tue, 22 May 2018)
-Text Last Updated: 2018-05-22 17:34:00 +0000 (Tue, 22 May 2018)
-Checksum: abcdefg
-EOF;
-		$shell->registerCommand("svn info 'foobar.php'", $fixture);
+		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php', '188280'));
 		$shell->registerCommand("cat 'foobar.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":21,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
 		$options = [
 			'cache' => false, // getopt is weird and sets options to false
@@ -213,24 +138,7 @@ EOF;
 		$svnFile = 'foobar.php';
 		$shell = new TestShell([$svnFile]);
 		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
-		$fixture = <<<EOF
-Path: foobar.php
-Name: foobar.php
-Working Copy Root Path: /home/public_html
-URL: https://svn.localhost/trunk/wp-content/mu-plugins/foobar.php
-Relative URL: ^/trunk/foobar.php
-Repository Root: https://svn.localhost
-Repository UUID: 1111-1111-1111-1111
-Revision: 188280
-Node Kind: file
-Schedule: normal
-Last Changed Author: me
-Last Changed Rev: 175729
-Last Changed Date: 2018-05-22 17:34:00 +0000 (Tue, 22 May 2018)
-Text Last Updated: 2018-05-22 17:34:00 +0000 (Tue, 22 May 2018)
-Checksum: abcdefg
-EOF;
-		$shell->registerCommand("svn info 'foobar.php'", $fixture);
+		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php', '188280'));
 		$shell->registerCommand("svn cat 'foobar.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":99,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
 		$shell->registerCommand("cat 'foobar.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":21,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
 		$options = [
@@ -266,24 +174,7 @@ EOF;
 		$svnFile = 'foobar.php';
 		$shell = new TestShell([$svnFile]);
 		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
-		$fixture = <<<EOF
-Path: foobar.php
-Name: foobar.php
-Working Copy Root Path: /home/public_html
-URL: https://svn.localhost/trunk/wp-content/mu-plugins/foobar.php
-Relative URL: ^/trunk/foobar.php
-Repository Root: https://svn.localhost
-Repository UUID: 1111-1111-1111-1111
-Revision: 188280
-Node Kind: file
-Schedule: normal
-Last Changed Author: me
-Last Changed Rev: 175729
-Last Changed Date: 2018-05-22 17:34:00 +0000 (Tue, 22 May 2018)
-Text Last Updated: 2018-05-22 17:34:00 +0000 (Tue, 22 May 2018)
-Checksum: abcdefg
-EOF;
-		$shell->registerCommand("svn info 'foobar.php'", $fixture);
+		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php', '188280'));
 		$shell->registerCommand("svn cat 'foobar.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":99,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
 		$shell->registerCommand("cat 'foobar.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":21,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
 		$options = [
@@ -330,24 +221,7 @@ EOF;
 		$svnFile = 'foobar.php';
 		$shell = new TestShell([$svnFile]);
 		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
-		$fixture = <<<EOF
-Path: foobar.php
-Name: foobar.php
-Working Copy Root Path: /home/public_html
-URL: https://svn.localhost/trunk/wp-content/mu-plugins/foobar.php
-Relative URL: ^/trunk/foobar.php
-Repository Root: https://svn.localhost
-Repository UUID: 1111-1111-1111-1111
-Revision: 188280
-Node Kind: file
-Schedule: normal
-Last Changed Author: me
-Last Changed Rev: 175729
-Last Changed Date: 2018-05-22 17:34:00 +0000 (Tue, 22 May 2018)
-Text Last Updated: 2018-05-22 17:34:00 +0000 (Tue, 22 May 2018)
-Checksum: abcdefg
-EOF;
-		$shell->registerCommand("svn info 'foobar.php'", $fixture);
+		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php', '188280'));
 		$shell->registerCommand("svn cat 'foobar.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":99,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
 		$shell->registerCommand("cat 'foobar.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":21,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
 		$options = [
@@ -402,24 +276,7 @@ EOF;
 		$svnFile = 'foobar.php';
 		$shell = new TestShell([$svnFile]);
 		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
-		$fixture = <<<EOF
-Path: foobar.php
-Name: foobar.php
-Working Copy Root Path: /home/public_html
-URL: https://svn.localhost/trunk/wp-content/mu-plugins/foobar.php
-Relative URL: ^/trunk/foobar.php
-Repository Root: https://svn.localhost
-Repository UUID: 1111-1111-1111-1111
-Revision: 188280
-Node Kind: file
-Schedule: normal
-Last Changed Author: me
-Last Changed Rev: 175729
-Last Changed Date: 2018-05-22 17:34:00 +0000 (Tue, 22 May 2018)
-Text Last Updated: 2018-05-22 17:34:00 +0000 (Tue, 22 May 2018)
-Checksum: abcdefg
-EOF;
-		$shell->registerCommand("svn info 'foobar.php'", $fixture);
+		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php', '188280'));
 		$shell->registerCommand("svn cat 'foobar.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":99,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
 		$shell->registerCommand("cat 'foobar.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":21,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
 		$options = [
@@ -475,24 +332,7 @@ EOF;
 		$svnFile = 'foobar.php';
 		$shell = new TestShell([$svnFile]);
 		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
-		$fixture = <<<EOF
-Path: foobar.php
-Name: foobar.php
-Working Copy Root Path: /home/public_html
-URL: https://svn.localhost/trunk/wp-content/mu-plugins/foobar.php
-Relative URL: ^/trunk/foobar.php
-Repository Root: https://svn.localhost
-Repository UUID: 1111-1111-1111-1111
-Revision: 188280
-Node Kind: file
-Schedule: normal
-Last Changed Author: me
-Last Changed Rev: 175729
-Last Changed Date: 2018-05-22 17:34:00 +0000 (Tue, 22 May 2018)
-Text Last Updated: 2018-05-22 17:34:00 +0000 (Tue, 22 May 2018)
-Checksum: abcdefg
-EOF;
-		$shell->registerCommand("svn info 'foobar.php'", $fixture);
+		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php'));
 		$shell->registerCommand("svn cat 'foobar.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":99,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
 		$shell->registerCommand("cat 'foobar.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":21,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
 		$options = [
@@ -521,24 +361,7 @@ EOF;
 		$svnFile = 'foobar.php';
 		$shell = new TestShell([$svnFile]);
 		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
-		$fixture = <<<EOF
-Path: foobar.php
-Name: foobar.php
-Working Copy Root Path: /home/public_html
-URL: https://svn.localhost/trunk/wp-content/mu-plugins/foobar.php
-Relative URL: ^/trunk/foobar.php
-Repository Root: https://svn.localhost
-Repository UUID: 1111-1111-1111-1111
-Revision: 188280
-Node Kind: file
-Schedule: normal
-Last Changed Author: me
-Last Changed Rev: 175729
-Last Changed Date: 2018-05-22 17:34:00 +0000 (Tue, 22 May 2018)
-Text Last Updated: 2018-05-22 17:34:00 +0000 (Tue, 22 May 2018)
-Checksum: abcdefg
-EOF;
-		$shell->registerCommand("svn info 'foobar.php'", $fixture);
+		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php', '188280'));
 		$shell->registerCommand("svn cat 'foobar.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":99,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
 		$shell->registerCommand("cat 'foobar.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":21,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
 		$options = [
@@ -567,24 +390,7 @@ EOF;
 		$svnFile = 'foobar.php';
 		$shell = new TestShell([$svnFile]);
 		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
-		$fixture = <<<EOF
-Path: foobar.php
-Name: foobar.php
-Working Copy Root Path: /home/public_html
-URL: https://svn.localhost/trunk/wp-content/mu-plugins/foobar.php
-Relative URL: ^/trunk/foobar.php
-Repository Root: https://svn.localhost
-Repository UUID: 1111-1111-1111-1111
-Revision: 188280
-Node Kind: file
-Schedule: normal
-Last Changed Author: me
-Last Changed Rev: 175729
-Last Changed Date: 2018-05-22 17:34:00 +0000 (Tue, 22 May 2018)
-Text Last Updated: 2018-05-22 17:34:00 +0000 (Tue, 22 May 2018)
-Checksum: abcdefg
-EOF;
-		$shell->registerCommand("svn info 'foobar.php'", $fixture);
+		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php', '188280'));
 		$shell->registerCommand("svn cat 'foobar.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":99,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
 		$shell->registerCommand("cat 'foobar.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":21,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
 		$options = [
@@ -613,24 +419,7 @@ EOF;
 		$svnFile = 'foobar.php';
 		$shell = new TestShell([$svnFile]);
 		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
-		$fixture = <<<EOF
-Path: foobar.php
-Name: foobar.php
-Working Copy Root Path: /home/public_html
-URL: https://svn.localhost/trunk/wp-content/mu-plugins/foobar.php
-Relative URL: ^/trunk/foobar.php
-Repository Root: https://svn.localhost
-Repository UUID: 1111-1111-1111-1111
-Revision: 188280
-Node Kind: file
-Schedule: normal
-Last Changed Author: me
-Last Changed Rev: 175729
-Last Changed Date: 2018-05-22 17:34:00 +0000 (Tue, 22 May 2018)
-Text Last Updated: 2018-05-22 17:34:00 +0000 (Tue, 22 May 2018)
-Checksum: abcdefg
-EOF;
-		$shell->registerCommand("svn info 'foobar.php'", $fixture);
+		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php', '188280'));
 		$shell->registerCommand("svn cat 'foobar.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":99,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
 		$shell->registerCommand("cat 'foobar.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":21,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
 		$options = [
@@ -658,24 +447,7 @@ EOF;
 		$svnFile = 'foobar.php';
 		$shell = new TestShell([$svnFile]);
 		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getEmptyFileDiff());
-		$fixture = <<<EOF
-Path: foobar.php
-Name: foobar.php
-Working Copy Root Path: /home/public_html
-URL: https://svn.localhost/trunk/wp-content/mu-plugins/foobar.php
-Relative URL: ^/trunk/foobar.php
-Repository Root: https://svn.localhost
-Repository UUID: 1111-1111-1111-1111
-Revision: 188280
-Node Kind: file
-Schedule: normal
-Last Changed Author: me
-Last Changed Rev: 175729
-Last Changed Date: 2018-05-22 17:34:00 +0000 (Tue, 22 May 2018)
-Text Last Updated: 2018-05-22 17:34:00 +0000 (Tue, 22 May 2018)
-Checksum: abcdefg
-EOF;
-		$shell->registerCommand("svn info 'foobar.php'", $fixture);
+		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php', '188280'));
 		$shell->registerCommand("cat 'foobar.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":21,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
 		$options = [
 			'cache' => false, // getopt is weird and sets options to false
@@ -693,42 +465,8 @@ EOF;
 		$shell = new TestShell($svnFiles);
 		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
 		$shell->registerCommand("svn diff 'baz.php'", $this->fixture->getAddedLineDiff('baz.php', 'use Baz;'));
-		$fixture = <<<EOF
-Path: foobar.php
-Name: foobar.php
-Working Copy Root Path: /home/public_html
-URL: https://svn.localhost/trunk/wp-content/mu-plugins/foobar.php
-Relative URL: ^/trunk/foobar.php
-Repository Root: https://svn.localhost
-Repository UUID: 1111-1111-1111-1111
-Revision: 188280
-Node Kind: file
-Schedule: normal
-Last Changed Author: me
-Last Changed Rev: 175729
-Last Changed Date: 2018-05-22 17:34:00 +0000 (Tue, 22 May 2018)
-Text Last Updated: 2018-05-22 17:34:00 +0000 (Tue, 22 May 2018)
-Checksum: abcdefg
-EOF;
-		$shell->registerCommand("svn info 'foobar.php'", $fixture);
-		$fixture = <<<EOF
-Path: baz.php
-Name: baz.php
-Working Copy Root Path: /home/public_html
-URL: https://svn.localhost/trunk/wp-content/mu-plugins/baz.php
-Relative URL: ^/trunk/baz.php
-Repository Root: https://svn.localhost
-Repository UUID: 1111-1111-1111-1111
-Revision: 188280
-Node Kind: file
-Schedule: normal
-Last Changed Author: me
-Last Changed Rev: 175729
-Last Changed Date: 2018-05-22 17:34:00 +0000 (Tue, 22 May 2018)
-Text Last Updated: 2018-05-22 17:34:00 +0000 (Tue, 22 May 2018)
-Checksum: abcdefg
-EOF;
-		$shell->registerCommand("svn info 'baz.php'", $fixture);
+		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php'));
+		$shell->registerCommand("svn info 'baz.php'", $this->fixture->getSvnInfo('baz.php'));
 		$shell->registerCommand("svn cat 'foobar.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":99,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
 		$shell->registerCommand("cat 'foobar.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":21,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
 		$shell->registerCommand("svn cat 'baz.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Baz."},{"line":99,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Baz."}]}}}');
@@ -766,24 +504,7 @@ EOF;
 		$svnFile = 'foobar.php';
 		$shell = new TestShell([$svnFile]);
 		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getEmptyFileDiff());
-					$fixture = <<<EOF
-Path: foobar.php
-Name: foobar.php
-Working Copy Root Path: /home/public_html
-URL: https://svn.localhost/trunk/wp-content/mu-plugins/foobar.php
-Relative URL: ^/trunk/foobar.php
-Repository Root: https://svn.localhost
-Repository UUID: 1111-1111-1111-1111
-Revision: 188280
-Node Kind: file
-Schedule: normal
-Last Changed Author: me
-Last Changed Rev: 175729
-Last Changed Date: 2018-05-22 17:34:00 +0000 (Tue, 22 May 2018)
-Text Last Updated: 2018-05-22 17:34:00 +0000 (Tue, 22 May 2018)
-Checksum: abcdefg
-EOF;
-		$shell->registerCommand("svn info 'foobar.php'", $fixture);
+		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php'));
 		$shell->registerCommand("svn cat 'foobar.php'|phpcs", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":99,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
 		$shell->registerCommand("cat 'foobar.php'|phpcs", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":99,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
 		$options = [];
@@ -796,24 +517,7 @@ EOF;
 		$svnFile = 'foobar.php';
 		$shell = new TestShell([$svnFile]);
 		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getEmptyFileDiff());
-		$fixture = <<<EOF
-Path: foobar.php
-Name: foobar.php
-Working Copy Root Path: /home/public_html
-URL: https://svn.localhost/trunk/wp-content/mu-plugins/foobar.php
-Relative URL: ^/trunk/foobar.php
-Repository Root: https://svn.localhost
-Repository UUID: 1111-1111-1111-1111
-Revision: 188280
-Node Kind: file
-Schedule: normal
-Last Changed Author: me
-Last Changed Rev: 175729
-Last Changed Date: 2018-05-22 17:34:00 +0000 (Tue, 22 May 2018)
-Text Last Updated: 2018-05-22 17:34:00 +0000 (Tue, 22 May 2018)
-Checksum: abcdefg
-EOF;
-		$shell->registerCommand("svn info 'foobar.php'", $fixture);
+		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php'));
 		$shell->registerCommand("svn cat 'foobar.php'|phpcs", '{"totals":{"errors":0,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":0,"warnings":0,"messages":[]}}}');
 		$shell->registerCommand("cat 'foobar.php'|phpcs", '{"totals":{"errors":0,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":0,"warnings":0,"messages":[]}}}');
 		$options = [];
@@ -827,12 +531,7 @@ EOF;
 		$svnFile = 'foobar.php';
 		$shell = new TestShell([$svnFile]);
 		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getNonSvnFileDiff('foobar.php'), 1);
-		$fixture = <<<EOF
-svn: warning: W155010: The node 'foobar.php' was not found.
-
-svn: E200009: Could not display info for all targets because some targets don't exist
-EOF;
-		$shell->registerCommand("svn info 'foobar.php'", $fixture, 1);
+		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfoNonSvnFile('foobar.php'), 1);
 		$shell->registerCommand("svn cat 'foobar.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":99,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
 		$shell->registerCommand("cat 'foobar.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":99,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
 		$options = [];
@@ -843,18 +542,7 @@ EOF;
 		$svnFile = 'foobar.php';
 		$shell = new TestShell([$svnFile]);
 		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getNewFileDiff('foobar.php'));
-		$fixture = <<<EOF
-Path: foobar.php
-Name: foobar.php
-Working Copy Root Path: /home/public_html
-URL: https://svn.localhost/trunk/foobar.php
-Relative URL: ^/trunk/foobar.php
-Repository Root: https://svn.localhost
-Repository UUID: 1111-1111-1111-1111
-Node Kind: file
-Schedule: add
-EOF;
-		$shell->registerCommand("svn info 'foobar.php'", $fixture);
+		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfoNewFile('foobar.php'));
 		$shell->registerCommand("cat 'foobar.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":21,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
 		$options = [];
 		$expected = PhpcsMessages::fromArrays([
@@ -885,18 +573,7 @@ EOF;
 		$svnFile = 'foobar.php';
 		$shell = new TestShell([$svnFile]);
 		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getNewFileDiff('foobar.php'));
-		$fixture = <<<EOF
-Path: foobar.php
-Name: foobar.php
-Working Copy Root Path: /home/public_html
-URL: https://svn.localhost/trunk/foobar.php
-Relative URL: ^/trunk/foobar.php
-Repository Root: https://svn.localhost
-Repository UUID: 1111-1111-1111-1111
-Node Kind: file
-Schedule: add
-EOF;
-		$shell->registerCommand("svn info 'foobar.php'", $fixture);
+		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfoNewFile('foobar.php'));
 		$fixture = 'ERROR: You must supply at least one file or directory to process.
 
 Run "phpcs --help" for usage information

--- a/tests/SvnWorkflowTest.php
+++ b/tests/SvnWorkflowTest.php
@@ -489,6 +489,89 @@ EOF;
 		$this->assertTrue($shell->wasCommandCalled("cat 'foobar.php'"));
 	}
 
+	public function testFullSvnWorkflowForOneDoesNotClearCacheWhenStandardChanges() {
+		$svnFile = 'foobar.php';
+		$shell = new TestShell([$svnFile]);
+		$fixture = <<<EOF
+Index: foobar.php
+===================================================================
+--- bin/foobar.php	(revision 183265)
++++ bin/foobar.php	(working copy)
+@@ -17,6 +17,7 @@
+ use Billing\Purchases\Order;
+ use Billing\Services;
+ use Billing\Ebanx;
++use Foobar;
+ use Billing\Emergent;
+ use Billing\Monetary_Amount;
+ use Stripe\Error;
+EOF;
+		$shell->registerCommand("svn diff 'foobar.php'", $fixture);
+		$fixture = <<<EOF
+Path: foobar.php
+Name: foobar.php
+Working Copy Root Path: /home/public_html
+URL: https://svn.localhost/trunk/wp-content/mu-plugins/foobar.php
+Relative URL: ^/trunk/foobar.php
+Repository Root: https://svn.localhost
+Repository UUID: 1111-1111-1111-1111
+Revision: 188280
+Node Kind: file
+Schedule: normal
+Last Changed Author: me
+Last Changed Rev: 175729
+Last Changed Date: 2018-05-22 17:34:00 +0000 (Tue, 22 May 2018)
+Text Last Updated: 2018-05-22 17:34:00 +0000 (Tue, 22 May 2018)
+Checksum: abcdefg
+EOF;
+		$shell->registerCommand("svn info 'foobar.php'", $fixture);
+		$shell->registerCommand("svn cat 'foobar.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":99,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
+		$shell->registerCommand("cat 'foobar.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":21,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
+		$options = [
+			'cache' => false, // getopt is weird and sets options to false
+		];
+		$expected = PhpcsMessages::fromArrays([
+			[
+				'type' => 'ERROR',
+				'severity' => 5,
+				'fixable' => false,
+				'column' => 5,
+				'source' => 'ImportDetection.Imports.RequireImports.Import',
+				'line' => 20,
+				'message' => 'Found unused symbol Emergent.',
+			],
+		], 'bin/foobar.php');
+
+		$cache = new TestCache();
+		$manager = new CacheManager($cache);
+		$cache->setRevision('188280');
+
+		// Run once to cache results
+		$options['standard'] = 'one';
+		runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\Debug');
+		$this->assertTrue($shell->wasCommandCalled("cat 'foobar.php'"));
+
+		// Run again to prove results have been cached
+		$shell->resetCommandsCalled();
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\Debug');
+		$this->assertEquals($expected->getMessages(), $messages->getMessages());
+		$this->assertFalse($shell->wasCommandCalled("cat 'foobar.php'"));
+
+		// Run a third time, with the standard changed, and make sure we don't use the cache
+		$options['standard'] = 'two';
+		$shell->resetCommandsCalled();
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\Debug');
+		$this->assertEquals($expected->getMessages(), $messages->getMessages());
+		$this->assertTrue($shell->wasCommandCalled("cat 'foobar.php'"));
+
+		// Run a fourth time, restoring the standard, and make sure we do use the cache
+		$options['standard'] = 'one';
+		$shell->resetCommandsCalled();
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\Debug');
+		$this->assertEquals($expected->getMessages(), $messages->getMessages());
+		$this->assertFalse($shell->wasCommandCalled("cat 'foobar.php'"));
+	}
+
 	public function testFullSvnWorkflowForOneFileUncachedWhenCachingIsDisabled() {
 		$svnFile = 'foobar.php';
 		$shell = new TestShell([$svnFile]);

--- a/tests/SvnWorkflowTest.php
+++ b/tests/SvnWorkflowTest.php
@@ -74,6 +74,19 @@ final class SvnWorkflowTest extends TestCase {
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 
+	public function testFullSvnWorkflowForOneFileWithNoMessages() {
+		$svnFile = 'foobar.php';
+		$shell = new TestShell([$svnFile]);
+		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
+		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php'));
+		$shell->registerCommand("svn cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
+		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getEmptyResults()->toPhpcsJson());
+		$options = [];
+		$expected = $this->phpcs->getEmptyResults();
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\Debug');
+		$this->assertEquals($expected->getMessages(), $messages->getMessages());
+	}
+
 	public function testFullSvnWorkflowForOneFileWithCachingEnabledButNoCache() {
 		$svnFile = 'foobar.php';
 		$shell = new TestShell([$svnFile]);

--- a/tests/SvnWorkflowTest.php
+++ b/tests/SvnWorkflowTest.php
@@ -132,6 +132,8 @@ final class SvnWorkflowTest extends TestCase {
 		$cache->setEntry('foobar.php', '', '', '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":99,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
 		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager($cache), '\PhpcsChangedTests\Debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
+		$this->assertFalse($shell->wasCommandCalled("svn cat 'foobar.php'"));
+		$this->assertTrue($shell->wasCommandCalled("cat 'foobar.php'"));
 	}
 
 	public function testFullSvnWorkflowForOneFileUncachedThenCachesBothVersionsOfTheFile() {
@@ -384,6 +386,8 @@ final class SvnWorkflowTest extends TestCase {
 		$cache->setEntry('foobar.php', '', '', 'blah'); // This invalid JSON will throw if the cache is used
 		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager($cache), '\PhpcsChangedTests\Debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
+		$this->assertTrue($shell->wasCommandCalled("svn cat 'foobar.php'"));
+		$this->assertTrue($shell->wasCommandCalled("cat 'foobar.php'"));
 	}
 
 	public function testFullSvnWorkflowForOneFileWithCacheThatHasDifferentStandard() {
@@ -413,6 +417,8 @@ final class SvnWorkflowTest extends TestCase {
 		$cache->setEntry('foobar.php', '', 'TestStandard2', 'blah'); // This invalid JSON will throw if the cache is used
 		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager($cache), '\PhpcsChangedTests\Debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
+		$this->assertTrue($shell->wasCommandCalled("svn cat 'foobar.php'"));
+		$this->assertTrue($shell->wasCommandCalled("cat 'foobar.php'"));
 	}
 
 	public function testFullSvnWorkflowForOneFileWithOutdatedCache() {
@@ -441,6 +447,8 @@ final class SvnWorkflowTest extends TestCase {
 		$cache->setEntry('foobar.php', '', '', 'blah'); // This invalid JSON will throw if the cache is used
 		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager($cache), '\PhpcsChangedTests\Debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
+		$this->assertTrue($shell->wasCommandCalled("svn cat 'foobar.php'"));
+		$this->assertTrue($shell->wasCommandCalled("cat 'foobar.php'"));
 	}
 
 	public function testFullSvnWorkflowForUnchangedFileWithCache() {
@@ -458,6 +466,8 @@ final class SvnWorkflowTest extends TestCase {
 		$cache->setEntry('foobar.php', '', '', '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":21,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
 		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager($cache), '\PhpcsChangedTests\Debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
+		$this->assertFalse($shell->wasCommandCalled("svn cat 'foobar.php'"));
+		$this->assertFalse($shell->wasCommandCalled("cat 'foobar.php'"));
 	}
 
 	public function testFullSvnWorkflowForMultipleFiles() {

--- a/tests/SvnWorkflowTest.php
+++ b/tests/SvnWorkflowTest.php
@@ -250,10 +250,10 @@ EOF;
 				'message' => 'Found unused symbol Emergent.',
 			],
 		], 'bin/foobar.php');
-		$cache = new TestCache();
-		runSvnWorkflow([$svnFile], $options, $shell, new CacheManager($cache), '\PhpcsChangedTests\Debug');
-		$shell->registerCommand("svn cat 'foobar.php'", '{}', 0, true);
-		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager($cache), '\PhpcsChangedTests\Debug');
+		$manager = new CacheManager(new TestCache());
+		runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\Debug');
+		$shell->deregisterCommand("svn cat 'foobar.php'");
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\Debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 

--- a/tests/SvnWorkflowTest.php
+++ b/tests/SvnWorkflowTest.php
@@ -7,7 +7,7 @@ require_once __DIR__ . '/helpers/helpers.php';
 use PHPUnit\Framework\TestCase;
 use PhpcsChanged\PhpcsMessages;
 use PhpcsChanged\ShellException;
-use PhpcsChanged\Cache\CacheManager;
+use PhpcsChanged\CacheManager;
 use PhpcsChangedTests\TestShell;
 use PhpcsChangedTests\TestCache;
 use function PhpcsChanged\Cli\runSvnWorkflow;

--- a/tests/SvnWorkflowTest.php
+++ b/tests/SvnWorkflowTest.php
@@ -378,6 +378,66 @@ EOF;
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 
+	public function testFullSvnWorkflowForOneFileWithOldCacheVersion() {
+		$svnFile = 'foobar.php';
+		$shell = new TestShell([$svnFile]);
+		$fixture = <<<EOF
+Index: foobar.php
+===================================================================
+--- bin/foobar.php	(revision 183265)
++++ bin/foobar.php	(working copy)
+@@ -17,6 +17,7 @@
+ use Billing\Purchases\Order;
+ use Billing\Services;
+ use Billing\Ebanx;
++use Foobar;
+ use Billing\Emergent;
+ use Billing\Monetary_Amount;
+ use Stripe\Error;
+EOF;
+		$shell->registerCommand("svn diff 'foobar.php'", $fixture);
+		$fixture = <<<EOF
+Path: foobar.php
+Name: foobar.php
+Working Copy Root Path: /home/public_html
+URL: https://svn.localhost/trunk/wp-content/mu-plugins/foobar.php
+Relative URL: ^/trunk/foobar.php
+Repository Root: https://svn.localhost
+Repository UUID: 1111-1111-1111-1111
+Revision: 188280
+Node Kind: file
+Schedule: normal
+Last Changed Author: me
+Last Changed Rev: 175729
+Last Changed Date: 2018-05-22 17:34:00 +0000 (Tue, 22 May 2018)
+Text Last Updated: 2018-05-22 17:34:00 +0000 (Tue, 22 May 2018)
+Checksum: abcdefg
+EOF;
+		$shell->registerCommand("svn info 'foobar.php'", $fixture);
+		$shell->registerCommand("svn cat 'foobar.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":99,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
+		$shell->registerCommand("cat 'foobar.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":21,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
+		$options = [
+			'cache' => true,
+		];
+		$expected = PhpcsMessages::fromArrays([
+			[
+				'type' => 'ERROR',
+				'severity' => 5,
+				'fixable' => false,
+				'column' => 5,
+				'source' => 'ImportDetection.Imports.RequireImports.Import',
+				'line' => 20,
+				'message' => 'Found unused symbol Emergent.',
+			],
+		], 'bin/foobar.php');
+		$cache = new TestCache();
+		$cache->setCacheVersion('0.1-something-else');
+		$cache->setRevision('188280');
+		$cache->setEntry('foobar.php', 'blah', ''); // This invalid JSON will throw if the cache is used
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager($cache), '\PhpcsChangedTests\Debug');
+		$this->assertEquals($expected->getMessages(), $messages->getMessages());
+	}
+
 	public function testFullSvnWorkflowForOneFileWithOutdatedCache() {
 		$svnFile = 'foobar.php';
 		$shell = new TestShell([$svnFile]);
@@ -432,7 +492,7 @@ EOF;
 		], 'bin/foobar.php');
 		$cache = new TestCache();
 		$cache->setRevision('1000');
-		$cache->setEntry('foobar.php', '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":21,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}', '');
+		$cache->setEntry('foobar.php', 'blah', ''); // This invalid JSON will throw if the cache is used
 		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager($cache), '\PhpcsChangedTests\Debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}

--- a/tests/SvnWorkflowTest.php
+++ b/tests/SvnWorkflowTest.php
@@ -10,10 +10,16 @@ use PhpcsChanged\ShellException;
 use PhpcsChanged\CacheManager;
 use PhpcsChangedTests\TestShell;
 use PhpcsChangedTests\TestCache;
+use PhpcsChangedTests\SvnFixture;
 use function PhpcsChanged\Cli\runSvnWorkflow;
 use function PhpcsChanged\SvnWorkflow\{getSvnFileInfo, isNewSvnFile, getSvnUnifiedDiff};
 
 final class SvnWorkflowTest extends TestCase {
+	public function setUp(): void {
+		parent::setUp();
+		$this->fixture = new SvnFixture();
+	}
+
 	public function testIsNewSvnFileReturnsTrueForNewFile() {
 		$svnFile = 'foobar.php';
 		$svn = 'svn';
@@ -67,20 +73,7 @@ Checksum: abcdefg
 	public function testGetSvnUnifiedDiff() {
 		$svnFile = 'foobar.php';
 		$svn = 'svn';
-		$diff = <<<EOF
-Index: foobar.php
-===================================================================
---- bin/foobar.php	(revision 183265)
-+++ bin/foobar.php	(working copy)
-@@ -17,6 +17,7 @@
- use Billing\Purchases\Order;
- use Billing\Services;
- use Billing\Ebanx;
-+use Foobar;
- use Billing\Emergent;
- use Billing\Monetary_Amount;
- use Stripe\Error;
-EOF;
+		$diff = $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;');
 		$executeCommand = function($command) use ($diff) {
 			if (! $command || false === strpos($command, "svn diff 'foobar.php'")) {
 				return '';
@@ -93,21 +86,7 @@ EOF;
 	public function testFullSvnWorkflowForOneFile() {
 		$svnFile = 'foobar.php';
 		$shell = new TestShell([$svnFile]);
-		$fixture = <<<EOF
-Index: foobar.php
-===================================================================
---- bin/foobar.php	(revision 183265)
-+++ bin/foobar.php	(working copy)
-@@ -17,6 +17,7 @@
- use Billing\Purchases\Order;
- use Billing\Services;
- use Billing\Ebanx;
-+use Foobar;
- use Billing\Emergent;
- use Billing\Monetary_Amount;
- use Stripe\Error;
-EOF;
-		$shell->registerCommand("svn diff 'foobar.php'", $fixture);
+		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
 		$fixture = <<<EOF
 Path: foobar.php
 Name: foobar.php
@@ -147,21 +126,7 @@ EOF;
 	public function testFullSvnWorkflowForOneFileWithCachingEnabledButNoCache() {
 		$svnFile = 'foobar.php';
 		$shell = new TestShell([$svnFile]);
-		$fixture = <<<EOF
-Index: foobar.php
-===================================================================
---- bin/foobar.php	(revision 183265)
-+++ bin/foobar.php	(working copy)
-@@ -17,6 +17,7 @@
- use Billing\Purchases\Order;
- use Billing\Services;
- use Billing\Ebanx;
-+use Foobar;
- use Billing\Emergent;
- use Billing\Monetary_Amount;
- use Stripe\Error;
-EOF;
-		$shell->registerCommand("svn diff 'foobar.php'", $fixture);
+		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
 		$fixture = <<<EOF
 Path: foobar.php
 Name: foobar.php
@@ -203,21 +168,7 @@ EOF;
 	public function testFullSvnWorkflowForOneFileCached() {
 		$svnFile = 'foobar.php';
 		$shell = new TestShell([$svnFile]);
-		$fixture = <<<EOF
-Index: foobar.php
-===================================================================
---- bin/foobar.php	(revision 183265)
-+++ bin/foobar.php	(working copy)
-@@ -17,6 +17,7 @@
- use Billing\Purchases\Order;
- use Billing\Services;
- use Billing\Ebanx;
-+use Foobar;
- use Billing\Emergent;
- use Billing\Monetary_Amount;
- use Stripe\Error;
-EOF;
-		$shell->registerCommand("svn diff 'foobar.php'", $fixture);
+		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
 		$fixture = <<<EOF
 Path: foobar.php
 Name: foobar.php
@@ -261,21 +212,7 @@ EOF;
 	public function testFullSvnWorkflowForOneFileUncachedThenCachesBothVersionsOfTheFile() {
 		$svnFile = 'foobar.php';
 		$shell = new TestShell([$svnFile]);
-		$fixture = <<<EOF
-Index: foobar.php
-===================================================================
---- bin/foobar.php	(revision 183265)
-+++ bin/foobar.php	(working copy)
-@@ -17,6 +17,7 @@
- use Billing\Purchases\Order;
- use Billing\Services;
- use Billing\Ebanx;
-+use Foobar;
- use Billing\Emergent;
- use Billing\Monetary_Amount;
- use Stripe\Error;
-EOF;
-		$shell->registerCommand("svn diff 'foobar.php'", $fixture);
+		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
 		$fixture = <<<EOF
 Path: foobar.php
 Name: foobar.php
@@ -328,21 +265,7 @@ EOF;
 	public function testFullSvnWorkflowForOneDoesNotUseNewFileCacheWhenHashChanges() {
 		$svnFile = 'foobar.php';
 		$shell = new TestShell([$svnFile]);
-		$fixture = <<<EOF
-Index: foobar.php
-===================================================================
---- bin/foobar.php	(revision 183265)
-+++ bin/foobar.php	(working copy)
-@@ -17,6 +17,7 @@
- use Billing\Purchases\Order;
- use Billing\Services;
- use Billing\Ebanx;
-+use Foobar;
- use Billing\Emergent;
- use Billing\Monetary_Amount;
- use Stripe\Error;
-EOF;
-		$shell->registerCommand("svn diff 'foobar.php'", $fixture);
+		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
 		$fixture = <<<EOF
 Path: foobar.php
 Name: foobar.php
@@ -406,21 +329,7 @@ EOF;
 	public function testFullSvnWorkflowForOneClearsCacheForFileWhenHashChanges() {
 		$svnFile = 'foobar.php';
 		$shell = new TestShell([$svnFile]);
-		$fixture = <<<EOF
-Index: foobar.php
-===================================================================
---- bin/foobar.php	(revision 183265)
-+++ bin/foobar.php	(working copy)
-@@ -17,6 +17,7 @@
- use Billing\Purchases\Order;
- use Billing\Services;
- use Billing\Ebanx;
-+use Foobar;
- use Billing\Emergent;
- use Billing\Monetary_Amount;
- use Stripe\Error;
-EOF;
-		$shell->registerCommand("svn diff 'foobar.php'", $fixture);
+		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
 		$fixture = <<<EOF
 Path: foobar.php
 Name: foobar.php
@@ -492,21 +401,7 @@ EOF;
 	public function testFullSvnWorkflowForOneDoesNotClearCacheWhenStandardChanges() {
 		$svnFile = 'foobar.php';
 		$shell = new TestShell([$svnFile]);
-		$fixture = <<<EOF
-Index: foobar.php
-===================================================================
---- bin/foobar.php	(revision 183265)
-+++ bin/foobar.php	(working copy)
-@@ -17,6 +17,7 @@
- use Billing\Purchases\Order;
- use Billing\Services;
- use Billing\Ebanx;
-+use Foobar;
- use Billing\Emergent;
- use Billing\Monetary_Amount;
- use Stripe\Error;
-EOF;
-		$shell->registerCommand("svn diff 'foobar.php'", $fixture);
+		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
 		$fixture = <<<EOF
 Path: foobar.php
 Name: foobar.php
@@ -579,21 +474,7 @@ EOF;
 	public function testFullSvnWorkflowForOneFileUncachedWhenCachingIsDisabled() {
 		$svnFile = 'foobar.php';
 		$shell = new TestShell([$svnFile]);
-		$fixture = <<<EOF
-Index: foobar.php
-===================================================================
---- bin/foobar.php	(revision 183265)
-+++ bin/foobar.php	(working copy)
-@@ -17,6 +17,7 @@
- use Billing\Purchases\Order;
- use Billing\Services;
- use Billing\Ebanx;
-+use Foobar;
- use Billing\Emergent;
- use Billing\Monetary_Amount;
- use Stripe\Error;
-EOF;
-		$shell->registerCommand("svn diff 'foobar.php'", $fixture);
+		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
 		$fixture = <<<EOF
 Path: foobar.php
 Name: foobar.php
@@ -639,21 +520,7 @@ EOF;
 	public function testFullSvnWorkflowForOneFileWithOldCacheVersion() {
 		$svnFile = 'foobar.php';
 		$shell = new TestShell([$svnFile]);
-		$fixture = <<<EOF
-Index: foobar.php
-===================================================================
---- bin/foobar.php	(revision 183265)
-+++ bin/foobar.php	(working copy)
-@@ -17,6 +17,7 @@
- use Billing\Purchases\Order;
- use Billing\Services;
- use Billing\Ebanx;
-+use Foobar;
- use Billing\Emergent;
- use Billing\Monetary_Amount;
- use Stripe\Error;
-EOF;
-		$shell->registerCommand("svn diff 'foobar.php'", $fixture);
+		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
 		$fixture = <<<EOF
 Path: foobar.php
 Name: foobar.php
@@ -699,21 +566,7 @@ EOF;
 	public function testFullSvnWorkflowForOneFileWithCacheThatHasDifferentStandard() {
 		$svnFile = 'foobar.php';
 		$shell = new TestShell([$svnFile]);
-		$fixture = <<<EOF
-Index: foobar.php
-===================================================================
---- bin/foobar.php	(revision 183265)
-+++ bin/foobar.php	(working copy)
-@@ -17,6 +17,7 @@
- use Billing\Purchases\Order;
- use Billing\Services;
- use Billing\Ebanx;
-+use Foobar;
- use Billing\Emergent;
- use Billing\Monetary_Amount;
- use Stripe\Error;
-EOF;
-		$shell->registerCommand("svn diff 'foobar.php'", $fixture);
+		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
 		$fixture = <<<EOF
 Path: foobar.php
 Name: foobar.php
@@ -759,21 +612,7 @@ EOF;
 	public function testFullSvnWorkflowForOneFileWithOutdatedCache() {
 		$svnFile = 'foobar.php';
 		$shell = new TestShell([$svnFile]);
-		$fixture = <<<EOF
-Index: foobar.php
-===================================================================
---- bin/foobar.php	(revision 183265)
-+++ bin/foobar.php	(working copy)
-@@ -17,6 +17,7 @@
- use Billing\Purchases\Order;
- use Billing\Services;
- use Billing\Ebanx;
-+use Foobar;
- use Billing\Emergent;
- use Billing\Monetary_Amount;
- use Stripe\Error;
-EOF;
-		$shell->registerCommand("svn diff 'foobar.php'", $fixture);
+		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
 		$fixture = <<<EOF
 Path: foobar.php
 Name: foobar.php
@@ -818,9 +657,7 @@ EOF;
 	public function testFullSvnWorkflowForUnchangedFileWithCache() {
 		$svnFile = 'foobar.php';
 		$shell = new TestShell([$svnFile]);
-		$fixture = <<<EOF
-EOF;
-		$shell->registerCommand("svn diff 'foobar.php'", $fixture);
+		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getEmptyFileDiff());
 		$fixture = <<<EOF
 Path: foobar.php
 Name: foobar.php
@@ -854,36 +691,8 @@ EOF;
 	public function testFullSvnWorkflowForMultipleFiles() {
 		$svnFiles = ['foobar.php', 'baz.php'];
 		$shell = new TestShell($svnFiles);
-		$fixture = <<<EOF
-Index: foobar.php
-===================================================================
---- bin/foobar.php	(revision 183265)
-+++ bin/foobar.php	(working copy)
-@@ -17,6 +17,7 @@
- use Billing\Purchases\Order;
- use Billing\Services;
- use Billing\Ebanx;
-+use Foobar;
- use Billing\Emergent;
- use Billing\Monetary_Amount;
- use Stripe\Error;
-EOF;
-		$shell->registerCommand("svn diff 'foobar.php'", $fixture);
-		$fixture = <<<EOF
-Index: baz.php
-===================================================================
---- bin/baz.php	(revision 183265)
-+++ bin/baz.php	(working copy)
-@@ -17,6 +17,7 @@
- use Billing\Purchases\Order;
- use Billing\Services;
- use Billing\Ebanx;
-+use Baz;
- use Billing\Emergent;
- use Billing\Monetary_Amount;
- use Stripe\Error;
-EOF;
-		$shell->registerCommand("svn diff 'baz.php'", $fixture);
+		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
+		$shell->registerCommand("svn diff 'baz.php'", $this->fixture->getAddedLineDiff('baz.php', 'use Baz;'));
 		$fixture = <<<EOF
 Path: foobar.php
 Name: foobar.php
@@ -956,9 +765,7 @@ EOF;
 	public function testFullSvnWorkflowForUnchangedFileWithPhpCsMessages() {
 		$svnFile = 'foobar.php';
 		$shell = new TestShell([$svnFile]);
-		$fixture = <<<EOF
-EOF;
-		$shell->registerCommand("svn diff 'foobar.php'", $fixture);
+		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getEmptyFileDiff());
 					$fixture = <<<EOF
 Path: foobar.php
 Name: foobar.php
@@ -988,9 +795,7 @@ EOF;
 	public function testFullSvnWorkflowForUnchangedFileWithoutPhpCsMessages() {
 		$svnFile = 'foobar.php';
 		$shell = new TestShell([$svnFile]);
-		$fixture = <<<EOF
-EOF;
-		$shell->registerCommand("svn diff 'foobar.php'", $fixture);
+		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getEmptyFileDiff());
 		$fixture = <<<EOF
 Path: foobar.php
 Name: foobar.php
@@ -1021,10 +826,7 @@ EOF;
 		$this->expectException(ShellException::class);
 		$svnFile = 'foobar.php';
 		$shell = new TestShell([$svnFile]);
-		$fixture = <<<EOF
-svn: E155010: The node 'foobar.php' was not found.
-EOF;
-		$shell->registerCommand("svn diff 'foobar.php'", $fixture, 1);
+		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getNonSvnFileDiff('foobar.php'), 1);
 		$fixture = <<<EOF
 svn: warning: W155010: The node 'foobar.php' was not found.
 
@@ -1040,18 +842,7 @@ EOF;
 	public function testFullSvnWorkflowForNewFile() {
 		$svnFile = 'foobar.php';
 		$shell = new TestShell([$svnFile]);
-		$fixture = <<<EOF
-Index: foobar.php
-===================================================================
-
-Property changes on: foobar.php
-___________________________________________________________________
-Added: svn:eol-style
-## -0,0 +1 ##
-+native
-\ No newline at end of property
-EOF;
-		$shell->registerCommand("svn diff 'foobar.php'", $fixture);
+		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getNewFileDiff('foobar.php'));
 		$fixture = <<<EOF
 Path: foobar.php
 Name: foobar.php
@@ -1093,18 +884,7 @@ EOF;
 	public function testFullSvnWorkflowForEmptyNewFile() {
 		$svnFile = 'foobar.php';
 		$shell = new TestShell([$svnFile]);
-		$fixture = <<<EOF
-Index: foobar.php
-===================================================================
-
-Property changes on: foobar.php
-___________________________________________________________________
-Added: svn:eol-style
-## -0,0 +1 ##
-+native
-\ No newline at end of property
-EOF;
-		$shell->registerCommand("svn diff 'foobar.php'", $fixture);
+		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getNewFileDiff('foobar.php'));
 		$fixture = <<<EOF
 Path: foobar.php
 Name: foobar.php

--- a/tests/SvnWorkflowTest.php
+++ b/tests/SvnWorkflowTest.php
@@ -549,12 +549,14 @@ EOF;
 		// Run once to cache results
 		$options['standard'] = 'one';
 		runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\Debug');
+		$this->assertTrue($shell->wasCommandCalled("svn cat 'foobar.php'"));
 		$this->assertTrue($shell->wasCommandCalled("cat 'foobar.php'"));
 
 		// Run again to prove results have been cached
 		$shell->resetCommandsCalled();
 		$messages = runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\Debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
+		$this->assertFalse($shell->wasCommandCalled("svn cat 'foobar.php'"));
 		$this->assertFalse($shell->wasCommandCalled("cat 'foobar.php'"));
 
 		// Run a third time, with the standard changed, and make sure we don't use the cache
@@ -562,6 +564,7 @@ EOF;
 		$shell->resetCommandsCalled();
 		$messages = runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\Debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
+		$this->assertTrue($shell->wasCommandCalled("svn cat 'foobar.php'"));
 		$this->assertTrue($shell->wasCommandCalled("cat 'foobar.php'"));
 
 		// Run a fourth time, restoring the standard, and make sure we do use the cache
@@ -569,6 +572,7 @@ EOF;
 		$shell->resetCommandsCalled();
 		$messages = runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\Debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
+		$this->assertFalse($shell->wasCommandCalled("svn cat 'foobar.php'"));
 		$this->assertFalse($shell->wasCommandCalled("cat 'foobar.php'"));
 	}
 

--- a/tests/SvnWorkflowTest.php
+++ b/tests/SvnWorkflowTest.php
@@ -7,6 +7,7 @@ require_once __DIR__ . '/helpers/helpers.php';
 use PHPUnit\Framework\TestCase;
 use PhpcsChanged\PhpcsMessages;
 use PhpcsChanged\ShellException;
+use PhpcsChanged\Cache\CacheManager;
 use PhpcsChangedTests\TestShell;
 use PhpcsChangedTests\TestCache;
 use function PhpcsChanged\Cli\runSvnWorkflow;
@@ -139,7 +140,7 @@ EOF;
 				'message' => 'Found unused symbol Emergent.',
 			],
 		], 'bin/foobar.php');
-		$messages = runSvnWorkflow([$svnFile], $options, $shell, new TestCache(), '\PhpcsChangedTests\Debug');
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\Debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 
@@ -194,8 +195,8 @@ EOF;
 		], 'bin/foobar.php');
 		$cache = new TestCache();
 		$cache->setRevision('188280');
-		$cache->fileDataByPath['foobar.php'] = '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":99,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}';
-		$messages = runSvnWorkflow([$svnFile], $options, $shell, $cache, '\PhpcsChangedTests\Debug');
+		$cache->setEntry('foobar.php', '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":99,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}', '');
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager($cache), '\PhpcsChangedTests\Debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 
@@ -250,9 +251,9 @@ EOF;
 			],
 		], 'bin/foobar.php');
 		$cache = new TestCache();
-		runSvnWorkflow([$svnFile], $options, $shell, $cache, '\PhpcsChangedTests\Debug');
+		runSvnWorkflow([$svnFile], $options, $shell, new CacheManager($cache), '\PhpcsChangedTests\Debug');
 		$shell->registerCommand("svn cat 'foobar.php'", '{}', 0, true);
-		$messages = runSvnWorkflow([$svnFile], $options, $shell, $cache, '\PhpcsChangedTests\Debug');
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager($cache), '\PhpcsChangedTests\Debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 
@@ -308,8 +309,8 @@ EOF;
 		], 'bin/foobar.php');
 		$cache = new TestCache();
 		$cache->setRevision('1000');
-		$cache->fileDataByPath['foobar.php'] = '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":21,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}';
-		$messages = runSvnWorkflow([$svnFile], $options, $shell, $cache, '\PhpcsChangedTests\Debug');
+		$cache->setEntry('foobar.php', '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":21,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}', '');
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager($cache), '\PhpcsChangedTests\Debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 
@@ -342,8 +343,8 @@ EOF;
 		$expected = PhpcsMessages::fromArrays([], 'bin/foobar.php');
 		$cache = new TestCache();
 		$cache->setRevision('188280');
-		$cache->fileDataByPath['foobar.php'] = '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":21,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}';
-		$messages = runSvnWorkflow([$svnFile], $options, $shell, $cache, '\PhpcsChangedTests\Debug');
+		$cache->setEntry('foobar.php', '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":21,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}', '');
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager($cache), '\PhpcsChangedTests\Debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 
@@ -445,7 +446,7 @@ EOF;
 				],
 			], 'bin/baz.php'),
 		]);
-		$messages = runSvnWorkflow($svnFiles, $options, $shell, new TestCache(), '\PhpcsChangedTests\Debug');
+		$messages = runSvnWorkflow($svnFiles, $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\Debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 
@@ -477,7 +478,7 @@ EOF;
 		$shell->registerCommand("cat 'foobar.php'|phpcs", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":99,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
 		$options = [];
 		$expected = PhpcsMessages::fromArrays([], 'STDIN');
-		$messages = runSvnWorkflow([$svnFile], $options, $shell, new TestCache(), '\PhpcsChangedTests\Debug');
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\Debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 
@@ -509,7 +510,7 @@ EOF;
 		$shell->registerCommand("cat 'foobar.php'|phpcs", '{"totals":{"errors":0,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":0,"warnings":0,"messages":[]}}}');
 		$options = [];
 		$expected = PhpcsMessages::fromArrays([], 'STDIN');
-		$messages = runSvnWorkflow([$svnFile], $options, $shell, new TestCache(), '\PhpcsChangedTests\Debug');
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\Debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 
@@ -530,7 +531,7 @@ EOF;
 		$shell->registerCommand("svn cat 'foobar.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":99,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
 		$shell->registerCommand("cat 'foobar.php'", '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":99,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
 		$options = [];
-		runSvnWorkflow([$svnFile], $options, $shell, new TestCache(), '\PhpcsChangedTests\Debug');
+		runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\Debug');
 	}
 
 	public function testFullSvnWorkflowForNewFile() {
@@ -582,7 +583,7 @@ EOF;
 				'message' => 'Found unused symbol Emergent.',
 			],
 		], 'STDIN');
-		$messages = runSvnWorkflow([$svnFile], $options, $shell, new TestCache(), '\PhpcsChangedTests\Debug');
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\Debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 
@@ -620,7 +621,7 @@ Run "phpcs --help" for usage information
 		$shell->registerCommand( "cat 'foobar.php'", $fixture);
 		$options = [];
 		$expected = PhpcsMessages::fromArrays([], 'STDIN');
-		$messages = runSvnWorkflow([$svnFile], $options, $shell, new TestCache(), '\PhpcsChangedTests\Debug');
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\Debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 }

--- a/tests/SvnWorkflowTest.php
+++ b/tests/SvnWorkflowTest.php
@@ -253,7 +253,7 @@ EOF;
 		], 'bin/foobar.php');
 		$cache = new TestCache();
 		$cache->setRevision('188280');
-		$cache->setEntry('foobar.php', '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":99,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}', '');
+		$cache->setEntry('foobar.php', '', '', '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":1,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":99,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
 		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager($cache), '\PhpcsChangedTests\Debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
@@ -433,7 +433,7 @@ EOF;
 		$cache = new TestCache();
 		$cache->setCacheVersion('0.1-something-else');
 		$cache->setRevision('188280');
-		$cache->setEntry('foobar.php', 'blah', ''); // This invalid JSON will throw if the cache is used
+		$cache->setEntry('foobar.php', '', '', 'blah'); // This invalid JSON will throw if the cache is used
 		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager($cache), '\PhpcsChangedTests\Debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
@@ -492,7 +492,7 @@ EOF;
 		], 'bin/foobar.php');
 		$cache = new TestCache();
 		$cache->setRevision('1000');
-		$cache->setEntry('foobar.php', 'blah', ''); // This invalid JSON will throw if the cache is used
+		$cache->setEntry('foobar.php', '', '', 'blah'); // This invalid JSON will throw if the cache is used
 		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager($cache), '\PhpcsChangedTests\Debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
@@ -528,7 +528,7 @@ EOF;
 		$expected = PhpcsMessages::fromArrays([], 'bin/foobar.php');
 		$cache = new TestCache();
 		$cache->setRevision('188280');
-		$cache->setEntry('foobar.php', '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":21,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}', '');
+		$cache->setEntry('foobar.php', '', '', '{"totals":{"errors":2,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":2,"warnings":0,"messages":[{"line":20,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."},{"line":21,"type":"ERROR","severity":5,"fixable":false,"column":5,"source":"ImportDetection.Imports.RequireImports.Import","message":"Found unused symbol Emergent."}]}}}');
 		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager($cache), '\PhpcsChangedTests\Debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}

--- a/tests/SvnWorkflowTest.php
+++ b/tests/SvnWorkflowTest.php
@@ -253,6 +253,7 @@ EOF;
 		$manager = new CacheManager(new TestCache());
 		runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\Debug');
 		$shell->deregisterCommand("svn cat 'foobar.php'");
+		$shell->deregisterCommand("cat 'foobar.php'");
 		$messages = runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\Debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}

--- a/tests/helpers/GitFixture.php
+++ b/tests/helpers/GitFixture.php
@@ -72,4 +72,12 @@ index 0000000..b3d9bbc
 
 EOF;
 	}
+
+	public function getNewFileInfo(string $filename): string {
+		return "A {$filename}";
+	}
+
+	public function getModifiedFileInfo(string $filename): string {
+		return " M {$filename}"; // note the leading space
+	}
 }

--- a/tests/helpers/GitFixture.php
+++ b/tests/helpers/GitFixture.php
@@ -84,8 +84,4 @@ EOF;
 	public function getNonGitFileShow(string $filename): string {
 		return "fatal: Path '{$filename}' exists on disk, but not in 'HEAD'.";
 	}
-
-	public function getGitRevisionId(): string {
-		return 'abcdefg';
-	}
 }

--- a/tests/helpers/GitFixture.php
+++ b/tests/helpers/GitFixture.php
@@ -84,4 +84,8 @@ EOF;
 	public function getNonGitFileShow(string $filename): string {
 		return "fatal: Path '{$filename}' exists on disk, but not in 'HEAD'.";
 	}
+
+	public function getGitRevisionId(): string {
+		return 'abcdefg';
+	}
 }

--- a/tests/helpers/GitFixture.php
+++ b/tests/helpers/GitFixture.php
@@ -80,4 +80,8 @@ EOF;
 	public function getModifiedFileInfo(string $filename): string {
 		return " M {$filename}"; // note the leading space
 	}
+
+	public function getNonGitFileShow(string $filename): string {
+		return "fatal: Path '{$filename}' exists on disk, but not in 'HEAD'.";
+	}
 }

--- a/tests/helpers/GitFixture.php
+++ b/tests/helpers/GitFixture.php
@@ -1,0 +1,75 @@
+<?php
+namespace PhpcsChangedTests;
+
+class GitFixture {
+	public function getAddedLineDiff(string $filename, string $newLine): string {
+		return <<<EOF
+diff --git bin/{$filename} bin/{$filename}
+index 038d718..d6c3357 100644
+--- bin/{$filename}
++++ bin/{$filename}
+@@ -17,6 +17,7 @@
+ use Billing\Purchases\Order;
+ use Billing\Services;
+ use Billing\Ebanx;
++{$newLine}
+ use Billing\Emergent;
+ use Billing\Monetary_Amount;
+ use Stripe\Error;
+EOF;
+	}
+
+	public function getAltAddedLineDiff(string $filename, string $newLine): string {
+		return <<<EOF
+diff --git bin/{$filename} bin/{$filename}
+index c012707..319ecf3 100644
+--- bin/{$filename}
++++ bin/{$filename}
+@@ -3,6 +3,7 @@
+ use Billing\Purchases\Order;
+ use Billing\Services;
+ use Billing\Ebanx;
++{$newLine}
+ use Billing\Emergent;
+ use Billing\Monetary_Amount;
+ use Stripe\Error;
+EOF;
+	}
+
+	public function getEmptyFileDiff(): string {
+		return <<<EOF
+EOF;
+	}
+
+	public function getNewFileDiff(string $filename): string {
+		return <<<EOF
+diff --git bin/{$filename} bin/{$filename}
+new file mode 100644
+index 0000000..efa970f
+--- /dev/null
++++ bin/{$filename}
+@@ -0,0 +1,8 @@
++<?php
++use Billing\Purchases\Order;
++use Billing\Services;
++use Billing\Ebanx;
++use Foobar;
++use Billing\Emergent;
++use Billing\Monetary_Amount;
++use Stripe\Error;
+EOF;
+	}
+
+	public function getAltNewFileDiff(string $filename): string {
+		return <<<EOF
+diff --git {$filename} {$filename}
+new file mode 100644
+index 0000000..b3d9bbc
+--- /dev/null
++++ test.php
+@@ -0,0 +1 @@
++<?php
+
+EOF;
+	}
+}

--- a/tests/helpers/PhpcsFixture.php
+++ b/tests/helpers/PhpcsFixture.php
@@ -19,4 +19,8 @@ class PhpcsFixture {
 		}, $lineNumbers);
 		return PhpcsMessages::fromArrays($arrays, $filename);
 	}
+
+	public function getEmptyResults(): PhpcsMessages {
+		return PhpcsMessages::fromPhpcsJson('{"totals":{"errors":0,"warnings":0,"fixable":0},"files":{}}');
+	}
 }

--- a/tests/helpers/PhpcsFixture.php
+++ b/tests/helpers/PhpcsFixture.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace PhpcsChangedTests;
+
+use PhpcsChanged\PhpcsMessages;
+
+class PhpcsFixture {
+	public function getResults(string $filename, array $lineNumbers, string $message = 'Found unused symbol Foo.'): PhpcsMessages {
+		$arrays = array_map(function(int $lineNumber) use ($message): array {
+			return [
+				'type' => 'ERROR',
+				'severity' => 5,
+				'fixable' => false,
+				'column' => 5,
+				'source' => 'Variables.Defined.RequiredDefined.Unused',
+				'line' => $lineNumber,
+				'message' => $message,
+			];
+		}, $lineNumbers);
+		return PhpcsMessages::fromArrays($arrays, $filename);
+	}
+}

--- a/tests/helpers/SvnFixture.php
+++ b/tests/helpers/SvnFixture.php
@@ -43,4 +43,45 @@ Added: svn:eol-style
 \ No newline at end of property
 EOF;
 	}
+
+	public function getSvnInfo(string $filename, string $revision = '188280'): string {
+		return <<<EOF
+Path: {$filename}
+Name: {$filename}
+Working Copy Root Path: /home/public_html
+URL: https://svn.localhost/trunk/wp-content/mu-plugins/{$filename}
+Relative URL: ^/trunk/{$filename}
+Repository Root: https://svn.localhost
+Repository UUID: 1111-1111-1111-1111
+Revision: {$revision}
+Node Kind: file
+Schedule: normal
+Last Changed Author: me
+Last Changed Rev: 175729
+Last Changed Date: 2018-05-22 17:34:00 +0000 (Tue, 22 May 2018)
+Text Last Updated: 2018-05-22 17:34:00 +0000 (Tue, 22 May 2018)
+Checksum: abcdefg
+EOF;
+	}
+
+	public function getSvnInfoNewFile(string $filename): string {
+			return "Path: {$filename}
+Name: {$filename}
+Working Copy Root Path: /home/public_html
+URL: https://svn.localhost/trunk/{$filename}
+Relative URL: ^/trunk/{$filename}
+Repository Root: https://svn.localhost
+Repository UUID: 1111-1111-1111-1111
+Node Kind: file
+Schedule: add
+";
+	}
+
+	public function getSvnInfoNonSvnFile(string $filename): string {
+		return <<<EOF
+svn: warning: W155010: The node '{$filename}' was not found.
+
+svn: E200009: Could not display info for all targets because some targets don't exist
+EOF;
+	}
 }

--- a/tests/helpers/SvnFixture.php
+++ b/tests/helpers/SvnFixture.php
@@ -1,0 +1,46 @@
+<?php
+namespace PhpcsChangedTests;
+
+class SvnFixture {
+	public function getAddedLineDiff(string $filename, string $newLine): string {
+		return <<<EOF
+Index: {$filename}
+===================================================================
+--- bin/{$filename}	(revision 183265)
++++ bin/{$filename} copy)
+@@ -17,6 +17,7 @@
+ use Billing\Purchases\Order;
+ use Billing\Services;
+ use Billing\Ebanx;
++{$newLine}
+ use Billing\Emergent;
+ use Billing\Monetary_Amount;
+ use Stripe\Error;
+EOF;
+	}
+
+	public function getEmptyFileDiff(): string {
+		return <<<EOF
+EOF;
+	}
+
+	public function getNonSvnFileDiff(string $filename): string {
+		return <<<EOF
+svn: E155010: The node '{$filename}' was not found.
+EOF;
+	}
+
+	public function getNewFileDiff(string $filename): string {
+		return <<<EOF
+Index: {$filename}
+===================================================================
+
+Property changes on: {$filename}
+___________________________________________________________________
+Added: svn:eol-style
+## -0,0 +1 ##
++native
+\ No newline at end of property
+EOF;
+	}
+}

--- a/tests/helpers/TestCache.php
+++ b/tests/helpers/TestCache.php
@@ -15,6 +15,11 @@ class TestCache implements CacheInterface {
 	/**
 	 * @var string
 	 */
+	private $cacheVersion = '';
+
+	/**
+	 * @var string
+	 */
 	private $revisionId = '';
 
 	/**
@@ -32,6 +37,7 @@ class TestCache implements CacheInterface {
 			return;
 		}
 		$this->didSave = false;
+		$manager->setCacheVersion($this->cacheVersion);
 		$manager->setRevision($this->revisionId);
 		foreach(array_values($this->fileData) as $entry) {
 			$manager->setCacheForFile($entry['path'], $entry['data'], $entry['cacheKey']);
@@ -43,6 +49,7 @@ class TestCache implements CacheInterface {
 			return;
 		}
 		$this->didSave = true;
+		$this->setCacheVersion($manager->getCacheVersion());
 		$this->setRevision($manager->getRevision());
 		foreach($manager->getEntries() as $entry) {
 			$this->setEntry($entry->path, $entry->data, $entry->cacheKey);
@@ -59,5 +66,9 @@ class TestCache implements CacheInterface {
 
 	public function setRevision(string $revisionId): void {
 		$this->revisionId = $revisionId;
+	}
+
+	public function setCacheVersion(string $cacheVersion): void {
+		$this->cacheVersion = $cacheVersion;
 	}
 }

--- a/tests/helpers/TestCache.php
+++ b/tests/helpers/TestCache.php
@@ -34,7 +34,7 @@ class TestCache implements CacheInterface {
 		$this->didSave = false;
 		$manager->setRevision($this->revisionId);
 		foreach(array_values($this->fileData) as $entry) {
-			$manager->setCacheForFile($entry['path'], $entry['data'], $entry['phpcsStandard']);
+			$manager->setCacheForFile($entry['path'], $entry['data'], $entry['cacheKey']);
 		}
 	}
 
@@ -45,15 +45,15 @@ class TestCache implements CacheInterface {
 		$this->didSave = true;
 		$this->setRevision($manager->getRevision());
 		foreach($manager->getEntries() as $entry) {
-			$this->setEntry($entry->path, $entry->data, $entry->phpcsStandard);
+			$this->setEntry($entry->path, $entry->data, $entry->cacheKey);
 		}
 	}
 
-	public function setEntry(string $path, string $data, string $phpcsStandard): void {
+	public function setEntry(string $path, string $data, string $cacheKey): void {
 		$this->fileData[$path] = [
 			'path' => $path,
 			'data' => $data,
-			'phpcsStandard' => $phpcsStandard,
+			'cacheKey' => $cacheKey,
 		];
 	}
 

--- a/tests/helpers/TestCache.php
+++ b/tests/helpers/TestCache.php
@@ -55,15 +55,16 @@ class TestCache implements CacheInterface {
 		$this->setRevision($manager->getRevision());
 		$this->savedFileData = [];
 		foreach($manager->getEntries() as $entry) {
-			$this->setEntry($entry->path, $entry->hash, $entry->phpcsStandard, $entry->data);
+			$this->setEntry($entry->path, $entry->type, $entry->hash, $entry->phpcsStandard, $entry->data);
 		}
 	}
 
-	public function setEntry(string $path, string $hash, string $phpcsStandard, string $data): void {
+	public function setEntry(string $path, string $type, string $hash, string $phpcsStandard, string $data): void {
 		$this->savedFileData[] = [
 			'path' => $path,
 			'hash' => $hash,
 			'data' => $data,
+			'type' => $type,
 			'phpcsStandard' => $phpcsStandard,
 		];
 	}

--- a/tests/helpers/TestCache.php
+++ b/tests/helpers/TestCache.php
@@ -5,6 +5,7 @@ namespace PhpcsChangedTests;
 
 use PhpcsChanged\CacheInterface;
 use PhpcsChanged\CacheManager;
+use PhpcsChanged\CacheEntry;
 use function PhpcsChanged\getVersion;
 
 class TestCache implements CacheInterface {
@@ -41,7 +42,7 @@ class TestCache implements CacheInterface {
 		$manager->setCacheVersion($this->cacheVersion ?? getVersion());
 		$manager->setRevision($this->revisionId);
 		foreach(array_values($this->fileData) as $entry) {
-			$manager->setCacheForFile($entry['path'], $entry['data'], $entry['cacheKey']);
+			$manager->addCacheEntry(CacheEntry::fromJson($entry));
 		}
 	}
 
@@ -53,15 +54,16 @@ class TestCache implements CacheInterface {
 		$this->setCacheVersion($manager->getCacheVersion());
 		$this->setRevision($manager->getRevision());
 		foreach($manager->getEntries() as $entry) {
-			$this->setEntry($entry->path, $entry->data, $entry->cacheKey);
+			$this->setEntry($entry->path, $entry->hash, $entry->phpcsStandard, $entry->data);
 		}
 	}
 
-	public function setEntry(string $path, string $data, string $cacheKey): void {
+	public function setEntry(string $path, string $hash, string $phpcsStandard, string $data): void {
 		$this->fileData[$path] = [
 			'path' => $path,
+			'hash' => $hash,
 			'data' => $data,
-			'cacheKey' => $cacheKey,
+			'phpcsStandard' => $phpcsStandard,
 		];
 	}
 

--- a/tests/helpers/TestCache.php
+++ b/tests/helpers/TestCache.php
@@ -22,7 +22,15 @@ class TestCache implements CacheInterface {
 	 */
 	public $didSave = false;
 
+	/**
+	 * @var bool
+	 */
+	public $disabled = false;
+
 	public function load(CacheManager $manager): void {
+		if ($this->disabled) {
+			return;
+		}
 		$this->didSave = false;
 		$manager->setRevision($this->revisionId);
 		foreach(array_values($this->fileData) as $entry) {
@@ -31,6 +39,9 @@ class TestCache implements CacheInterface {
 	}
 
 	public function save(CacheManager $manager): void {
+		if ($this->disabled) {
+			return;
+		}
 		$this->didSave = true;
 		$this->setRevision($manager->getRevision());
 		foreach($manager->getEntries() as $entry) {

--- a/tests/helpers/TestCache.php
+++ b/tests/helpers/TestCache.php
@@ -25,17 +25,21 @@ class TestCache implements CacheInterface {
 	public function load(CacheManager $manager): void {
 		$this->didSave = false;
 		$manager->setRevision($this->revisionId);
-		foreach($this->fileData as $entry) {
+		foreach(array_values($this->fileData) as $entry) {
 			$manager->setCacheForFile($entry['path'], $entry['data'], $entry['phpcsStandard']);
 		}
 	}
 
-	public function save(CacheManager $manager): void { // phpcs:ignore VariableAnalysis
+	public function save(CacheManager $manager): void {
 		$this->didSave = true;
+		$this->setRevision($manager->getRevision());
+		foreach($manager->getEntries() as $entry) {
+			$this->setEntry($entry->path, $entry->data, $entry->phpcsStandard);
+		}
 	}
 
 	public function setEntry(string $path, string $data, string $phpcsStandard): void {
-		$this->fileData[] = [
+		$this->fileData[$path] = [
 			'path' => $path,
 			'data' => $data,
 			'phpcsStandard' => $phpcsStandard,

--- a/tests/helpers/TestCache.php
+++ b/tests/helpers/TestCache.php
@@ -5,6 +5,7 @@ namespace PhpcsChangedTests;
 
 use PhpcsChanged\CacheInterface;
 use PhpcsChanged\CacheManager;
+use function PhpcsChanged\getVersion;
 
 class TestCache implements CacheInterface {
 	/**
@@ -13,9 +14,9 @@ class TestCache implements CacheInterface {
 	private $fileData = [];
 
 	/**
-	 * @var string
+	 * @var string|null
 	 */
-	private $cacheVersion = '';
+	private $cacheVersion;
 
 	/**
 	 * @var string
@@ -37,7 +38,7 @@ class TestCache implements CacheInterface {
 			return;
 		}
 		$this->didSave = false;
-		$manager->setCacheVersion($this->cacheVersion);
+		$manager->setCacheVersion($this->cacheVersion ?? getVersion());
 		$manager->setRevision($this->revisionId);
 		foreach(array_values($this->fileData) as $entry) {
 			$manager->setCacheForFile($entry['path'], $entry['data'], $entry['cacheKey']);

--- a/tests/helpers/TestCache.php
+++ b/tests/helpers/TestCache.php
@@ -12,7 +12,7 @@ class TestCache implements CacheInterface {
 	/**
 	 * @var array
 	 */
-	private $fileData = [];
+	private $savedFileData = [];
 
 	/**
 	 * @var string|null
@@ -41,7 +41,7 @@ class TestCache implements CacheInterface {
 		$this->didSave = false;
 		$manager->setCacheVersion($this->cacheVersion ?? getVersion());
 		$manager->setRevision($this->revisionId);
-		foreach(array_values($this->fileData) as $entry) {
+		foreach(array_values($this->savedFileData) as $entry) {
 			$manager->addCacheEntry(CacheEntry::fromJson($entry));
 		}
 	}
@@ -53,13 +53,14 @@ class TestCache implements CacheInterface {
 		$this->didSave = true;
 		$this->setCacheVersion($manager->getCacheVersion());
 		$this->setRevision($manager->getRevision());
+		$this->savedFileData = [];
 		foreach($manager->getEntries() as $entry) {
 			$this->setEntry($entry->path, $entry->hash, $entry->phpcsStandard, $entry->data);
 		}
 	}
 
 	public function setEntry(string $path, string $hash, string $phpcsStandard, string $data): void {
-		$this->fileData[$path] = [
+		$this->savedFileData[] = [
 			'path' => $path,
 			'hash' => $hash,
 			'data' => $data,

--- a/tests/helpers/TestCache.php
+++ b/tests/helpers/TestCache.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 namespace PhpcsChangedTests;
 
-use PhpcsChanged\Cache\CacheInterface;
-use PhpcsChanged\Cache\CacheManager;
+use PhpcsChanged\CacheInterface;
+use PhpcsChanged\CacheManager;
 
 class TestCache implements CacheInterface {
 	/**

--- a/tests/helpers/TestCache.php
+++ b/tests/helpers/TestCache.php
@@ -15,7 +15,7 @@ class TestCache implements CacheInterface {
 	/**
 	 * @var string
 	 */
-	private $revisionId;
+	private $revisionId = '';
 
 	/**
 	 * @var bool

--- a/tests/helpers/TestShell.php
+++ b/tests/helpers/TestShell.php
@@ -36,6 +36,14 @@ class TestShell implements ShellOperator {
 		throw new \Exception("Already registered command: {$command}");
 	}
 
+	public function deregisterCommand(string $command): bool {
+		if (isset($this->commands[$command])) {
+			unset($this->commands[$command]);
+			return true;
+		}
+		throw new \Exception("No registered command: {$command}");
+	}
+
 	public function isReadable(string $fileName): bool {
 		return isset($this->readableFileNames[$fileName]);
 	}

--- a/tests/helpers/TestShell.php
+++ b/tests/helpers/TestShell.php
@@ -11,6 +11,8 @@ class TestShell implements ShellOperator {
 
 	private $commands = [];
 
+	private $commandsCalled = [];
+
 	private $fileHashes = [];
 
 	public function __construct(array $readableFileNames) {
@@ -69,10 +71,19 @@ class TestShell implements ShellOperator {
 			if ($registeredCommand === substr($command, 0, strlen($registeredCommand)) ) {
 				$return_val = $return['return_val'];
 				$output = $return['output'];
+				$this->commandsCalled[$registeredCommand] = $command;
 				return $return['output'];
 			}
 		}
 
 		throw new \Exception("Unknown command: {$command}");
+	}
+
+	public function resetCommandsCalled(): void {
+		$this->commandsCalled = [];
+	}
+
+	public function wasCommandCalled(string $registeredCommand): bool {
+		return isset($this->commandsCalled[$registeredCommand]);
 	}
 }

--- a/tests/helpers/TestShell.php
+++ b/tests/helpers/TestShell.php
@@ -11,6 +11,8 @@ class TestShell implements ShellOperator {
 
 	private $commands = [];
 
+	private $fileHashes = [];
+
 	public function __construct(array $readableFileNames) {
 		foreach ($readableFileNames as $fileName) {
 			$this->registerReadableFileName($fileName);
@@ -44,6 +46,10 @@ class TestShell implements ShellOperator {
 		throw new \Exception("No registered command: {$command}");
 	}
 
+	public function setFileHash(string $fileName, string $hash): void {
+		$this->fileHashes[$fileName] = $hash;
+	}
+
 	public function isReadable(string $fileName): bool {
 		return isset($this->readableFileNames[$fileName]);
 	}
@@ -53,6 +59,10 @@ class TestShell implements ShellOperator {
 	public function printError(string $message): void {} // phpcs:ignore VariableAnalysis
 
 	public function validateExecutableExists(string $name, string $command): void {} // phpcs:ignore VariableAnalysis
+
+	public function getFileHash(string $fileName): string {
+		return $this->fileHashes[$fileName] ?? $fileName;
+	}
 
 	public function executeCommand(string $command, array &$output = null, int &$return_val = null): string {
 		foreach ($this->commands as $registeredCommand => $return) {

--- a/tests/helpers/helpers.php
+++ b/tests/helpers/helpers.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace PhpcsChangedTests;
 
+require_once __DIR__ . '/PhpcsFixture.php';
 require_once __DIR__ . '/SvnFixture.php';
 require_once __DIR__ . '/TestShell.php';
 require_once __DIR__ . '/TestCache.php';

--- a/tests/helpers/helpers.php
+++ b/tests/helpers/helpers.php
@@ -5,6 +5,7 @@ namespace PhpcsChangedTests;
 
 require_once __DIR__ . '/PhpcsFixture.php';
 require_once __DIR__ . '/SvnFixture.php';
+require_once __DIR__ . '/GitFixture.php';
 require_once __DIR__ . '/TestShell.php';
 require_once __DIR__ . '/TestCache.php';
 require_once __DIR__ . '/Functions.php';

--- a/tests/helpers/helpers.php
+++ b/tests/helpers/helpers.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace PhpcsChangedTests;
 
+require_once __DIR__ . '/SvnFixture.php';
 require_once __DIR__ . '/TestShell.php';
 require_once __DIR__ . '/TestCache.php';
 require_once __DIR__ . '/Functions.php';


### PR DESCRIPTION
Running phpcs is probably the largest overhead of using phpcs-changed, since it needs to be run twice for each file. In addition, just getting the contents of some of those files can be expensive, notably old versions of svn files. In this PR we cache each phpcs result for later use. Each cache entry is removed if the svn revision changes (for svn mode), or if the file hash of any file changes. We keep caches for different phpcs standards so that phpcs-changed can be run on the same file for different standards multiple times and still benefit from the cache.

This PR adds caching to svn mode and git mode. To activate the cache, you must use the `--cache` CLI option, and it can be explicitly disabled using `--no-cache`. The cache can be completely cleared by using the `--clear-cache` option.