### PR TITLE
Refactor CacheInterface so that it deals only with a value object

### DIFF
--- a/PhpcsChanged/CacheInterface.php
+++ b/PhpcsChanged/CacheInterface.php
@@ -3,10 +3,10 @@ declare(strict_types=1);
 
 namespace PhpcsChanged;
 
-use PhpcsChanged\CacheManager;
+use PhpcsChanged\CacheObject;
 
 interface CacheInterface {
-	public function load(CacheManager $manager): void;
+	public function load(): CacheObject;
 
-	public function save(CacheManager $manager): void;
+	public function save(CacheObject $cacheObject): void;
 }

--- a/PhpcsChanged/CacheObject.php
+++ b/PhpcsChanged/CacheObject.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace PhpcsChanged;
+
+class CacheObject {
+	/**
+	 * @var CacheEntry[]
+	 */
+	public $entries = [];
+
+	/**
+	 * @var string
+	 */
+	public $revisionId;
+
+	/**
+	 * @var string
+	 */
+	public $cacheVersion;
+}
+

--- a/index.php
+++ b/index.php
@@ -18,6 +18,7 @@ require_once __DIR__ . '/PhpcsChanged/ShellException.php';
 require_once __DIR__ . '/PhpcsChanged/ShellOperator.php';
 require_once __DIR__ . '/PhpcsChanged/UnixShell.php';
 require_once __DIR__ . '/PhpcsChanged/CacheEntry.php';
+require_once __DIR__ . '/PhpcsChanged/CacheObject.php';
 require_once __DIR__ . '/PhpcsChanged/CacheInterface.php';
 require_once __DIR__ . '/PhpcsChanged/CacheManager.php';
 require_once __DIR__ . '/PhpcsChanged/FileCache.php';


### PR DESCRIPTION
Cache interfaces shouldn't need to know the internal workings of the `CacheManager`, nor have direct access to it. That's a leaky abstraction. They should just be concerned with saving the state of the cache to storage and loading it again.

In this PR I introduce a value object for the state of the cache, called `CacheObject`. Mostly it's a collection of `CacheEntry` objects but there's also a few metadata values which are kept by the state: `revisionId` and `cacheVersion`. Each cache interface now just has to persist a `CacheObject` and return one. If more cache interfaces are introduced in the future, this should greatly simplify their APIs.