### PR TITLE
Cache svn previous file by last changed version

### DIFF
--- a/PhpcsChanged/CacheManager.php
+++ b/PhpcsChanged/CacheManager.php
@@ -84,10 +84,6 @@ class CacheManager {
 		$this->hasBeenModified = false;
 	}
 
-	public function getRevision(): ?string {
-		return $this->cacheObject->revisionId;
-	}
-
 	public function getCacheVersion(): string {
 		return $this->cacheObject->cacheVersion;
 	}
@@ -129,17 +125,6 @@ class CacheManager {
 		$this->hasBeenModified = true;
 		$this->clearCache();
 		$this->cacheObject->cacheVersion = $cacheVersion;
-	}
-
-	public function setRevision(string $revisionId): void {
-		if (! $this->cacheObject->revisionId || $this->cacheObject->revisionId === $revisionId) {
-			$this->cacheObject->revisionId = $revisionId;
-			return;
-		}
-		($this->debug)("Revision has changed ('{$this->cacheObject->revisionId}' -> '{$revisionId}'). Clearing cache.");
-		$this->hasBeenModified = true;
-		$this->clearCache();
-		$this->cacheObject->revisionId = $revisionId;
 	}
 
 	public function getCacheForFile(string $filePath, string $type, string $hash, string $phpcsStandard): ?string {
@@ -203,7 +188,6 @@ class CacheManager {
 	public function clearCache(): void {
 		($this->debug)("Cache cleared");
 		$this->hasBeenModified = true;
-		$this->cacheObject->revisionId = '';
 		$this->fileDataByPath = [];
 		$this->cacheObject->entries = [];
 	}

--- a/PhpcsChanged/CacheObject.php
+++ b/PhpcsChanged/CacheObject.php
@@ -12,11 +12,6 @@ class CacheObject {
 	/**
 	 * @var string
 	 */
-	public $revisionId;
-
-	/**
-	 * @var string
-	 */
 	public $cacheVersion;
 }
 

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -239,11 +239,7 @@ function runSvnWorkflowForFile(string $svnFile, array $options, ShellOperator $s
 
 		$oldFilePhpcsOutput = '';
 		if ( ! $isNewFile ) {
-			if (isCachingEnabled($options)) {
-				$cache->setRevision($revisionId);
-			}
-
-			$oldFilePhpcsOutput = isCachingEnabled($options) ? $cache->getCacheForFile($svnFile, 'old', '', $phpcsStandard ?? '') : null;
+			$oldFilePhpcsOutput = isCachingEnabled($options) ? $cache->getCacheForFile($svnFile, 'old', $revisionId, $phpcsStandard ?? '') : null;
 			if ($oldFilePhpcsOutput) {
 				$debug("Using cache for old file '{$svnFile}' at revision '{$revisionId}' and standard '{$phpcsStandard}'");
 			}
@@ -251,7 +247,7 @@ function runSvnWorkflowForFile(string $svnFile, array $options, ShellOperator $s
 				$debug("Not using cache for old file '{$svnFile}' at revision '{$revisionId}' and standard '{$phpcsStandard}'");
 				$oldFilePhpcsOutput = getSvnBasePhpcsOutput($svnFile, $svn, $phpcs, $phpcsStandardOption, [$shell, 'executeCommand'], $debug);
 				if (isCachingEnabled($options)) {
-					$cache->setCacheForFile($svnFile, 'old', '', $phpcsStandard ?? '', $oldFilePhpcsOutput);
+					$cache->setCacheForFile($svnFile, 'old', $revisionId, $phpcsStandard ?? '', $oldFilePhpcsOutput);
 				}
 			}
 		}

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -329,9 +329,6 @@ function runGitWorkflowForFile(string $gitFile, array $options, ShellOperator $s
 		$isNewFile = isNewGitFile($gitFile, $git, [$shell, 'executeCommand'], $options, $debug);
 		$oldFilePhpcsOutput = '';
 		if (! $isNewFile) {
-			if (isCachingEnabled($options)) {
-				$cache->setRevision(''); // git files are all protected by a hash key; there is no need to invalidate the cache if the version changes
-			}
 			$oldFileHash = getOldGitFileHash($gitFile, $git, $cat, [$shell, 'executeCommand'], $options, $debug);
 			$oldFilePhpcsOutput = isCachingEnabled($options) ? $cache->getCacheForFile($gitFile, 'old', $oldFileHash, $phpcsStandard ?? '') : null;
 			if ($oldFilePhpcsOutput) {

--- a/PhpcsChanged/FileCache.php
+++ b/PhpcsChanged/FileCache.php
@@ -29,7 +29,6 @@ class FileCache implements CacheInterface {
 		}
 		$cacheObject = new CacheObject();
 		$cacheObject->cacheVersion = $decoded['cacheVersion'];
-		$cacheObject->revisionId = $decoded['revisionId'];
 		foreach($decoded['entries'] as $entry) {
 			if (! $this->isDecodedEntryValid($entry)) {
 				throw new \Exception('Invalid cache file entry: ' . $entry);
@@ -42,7 +41,6 @@ class FileCache implements CacheInterface {
 	public function save(CacheObject $cacheObject): void {
 		$data = [
 			'cacheVersion' => $cacheObject->cacheVersion,
-			'revisionId' => $cacheObject->revisionId,
 			'entries' => $cacheObject->entries,
 		];
 		$result = file_put_contents($this->cacheFilePath, json_encode($data));
@@ -57,16 +55,12 @@ class FileCache implements CacheInterface {
 	private function isDecodedDataValid($decoded): bool {
 		if (! is_array($decoded) ||
 			! array_key_exists('cacheVersion', $decoded) ||
-			! array_key_exists('revisionId', $decoded) ||
 			! array_key_exists('entries', $decoded) ||
 			! is_array($decoded['entries'])
 		) {
 			return false;
 		}
 		if (! is_string($decoded['cacheVersion'])) {
-			return false;
-		}
-		if (! is_string($decoded['revisionId'])) {
 			return false;
 		}
 		// Note that this does not validate the entries to avoid iterating over

--- a/PhpcsChanged/SvnWorkflow.php
+++ b/PhpcsChanged/SvnWorkflow.php
@@ -33,7 +33,7 @@ function isNewSvnFile(string $svnFileInfo): bool {
 }
 
 function getSvnRevisionId(string $svnFileInfo): string {
-	preg_match('/\bRevision:\s([^\n]+)/', $svnFileInfo, $matches);
+	preg_match('/\bLast Changed Rev:\s([^\n]+)/', $svnFileInfo, $matches);
 	$version = $matches[1] ?? null;
 	if (! $version) {
 		// New files will not have a revision

--- a/tests/SvnWorkflowTest.php
+++ b/tests/SvnWorkflowTest.php
@@ -31,7 +31,7 @@ final class SvnWorkflowTest extends TestCase {
 			}
 			return $this->fixture->getSvnInfoNewFile('foobar.php');
 		};
-		$svnFileInfo = getSvnFileInfo($svnFile, $svn, $executeCommand, '\PhpcsChangedTests\Debug');
+		$svnFileInfo = getSvnFileInfo($svnFile, $svn, $executeCommand, '\PhpcsChangedTests\debug');
 		$this->assertTrue(isNewSvnFile($svnFileInfo));
 	}
 
@@ -44,7 +44,7 @@ final class SvnWorkflowTest extends TestCase {
 			}
 			return $this->fixture->getSvnInfo('foobar.php');
 		};
-		$svnFileInfo = getSvnFileInfo($svnFile, $svn, $executeCommand, '\PhpcsChangedTests\Debug');
+		$svnFileInfo = getSvnFileInfo($svnFile, $svn, $executeCommand, '\PhpcsChangedTests\debug');
 		$this->assertFalse(isNewSvnFile($svnFileInfo));
 	}
 
@@ -58,7 +58,7 @@ final class SvnWorkflowTest extends TestCase {
 			}
 			return $diff;
 		};
-		$this->assertEquals($diff, getSvnUnifiedDiff($svnFile, $svn, $executeCommand, '\PhpcsChangedTests\Debug'));
+		$this->assertEquals($diff, getSvnUnifiedDiff($svnFile, $svn, $executeCommand, '\PhpcsChangedTests\debug'));
 	}
 
 	public function testFullSvnWorkflowForOneFile() {
@@ -70,7 +70,7 @@ final class SvnWorkflowTest extends TestCase {
 		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
 		$options = [];
 		$expected = $this->phpcs->getResults('bin/foobar.php', [20]);
-		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\Debug');
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 
@@ -83,7 +83,7 @@ final class SvnWorkflowTest extends TestCase {
 		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getEmptyResults()->toPhpcsJson());
 		$options = [];
 		$expected = $this->phpcs->getEmptyResults();
-		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\Debug');
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 
@@ -98,7 +98,7 @@ final class SvnWorkflowTest extends TestCase {
 			'cache' => false, // getopt is weird and sets options to false
 		];
 		$expected = $this->phpcs->getResults('bin/foobar.php', [20]);
-		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\Debug');
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 
@@ -113,9 +113,8 @@ final class SvnWorkflowTest extends TestCase {
 		];
 		$expected = $this->phpcs->getResults('bin/foobar.php', [20]);
 		$cache = new TestCache();
-		$cache->setRevision('188280');
-		$cache->setEntry('foobar.php', 'old', '', '', $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
-		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager($cache), '\PhpcsChangedTests\Debug');
+		$cache->setEntry('foobar.php', 'old', '188280', '', $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager($cache), '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 		$this->assertFalse($shell->wasCommandCalled("svn cat 'foobar.php'"));
 		$this->assertTrue($shell->wasCommandCalled("cat 'foobar.php'"));
@@ -135,15 +134,14 @@ final class SvnWorkflowTest extends TestCase {
 
 		$cache = new TestCache();
 		$manager = new CacheManager($cache);
-		$cache->setRevision('188280');
 
 		// Run once to cache results
-		runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\Debug');
+		runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\debug');
 
 		// Run again to prove results have been cached
 		$shell->deregisterCommand("svn cat 'foobar.php'");
 		$shell->deregisterCommand("cat 'foobar.php'");
-		$messages = runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\Debug');
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 
@@ -161,17 +159,16 @@ final class SvnWorkflowTest extends TestCase {
 
 		$cache = new TestCache();
 		$manager = new CacheManager($cache);
-		$cache->setRevision('188280');
 
 		// Run once to cache results
-		runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\Debug');
+		runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\debug');
 		$this->assertTrue($shell->wasCommandCalled("cat 'foobar.php'"));
 
 		// Run again to prove results have been cached
 		$shell->deregisterCommand("svn cat 'foobar.php'");
 		$shell->deregisterCommand("cat 'foobar.php'");
 		$shell->resetCommandsCalled();
-		$messages = runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\Debug');
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 		$this->assertFalse($shell->wasCommandCalled("cat 'foobar.php'"));
 
@@ -179,7 +176,7 @@ final class SvnWorkflowTest extends TestCase {
 		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
 		$shell->setFileHash('foobar.php', 'different-hash');
 		$shell->resetCommandsCalled();
-		$messages = runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\Debug');
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 		$this->assertTrue($shell->wasCommandCalled("cat 'foobar.php'"));
 	}
@@ -199,17 +196,16 @@ final class SvnWorkflowTest extends TestCase {
 
 		$cache = new TestCache();
 		$manager = new CacheManager($cache);
-		$cache->setRevision('188280');
 
 		// Run once to cache results
-		runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\Debug');
+		runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\debug');
 		$this->assertTrue($shell->wasCommandCalled("cat 'foobar.php'"));
 
 		// Run again to prove results have been cached
 		$shell->deregisterCommand("svn cat 'foobar.php'");
 		$shell->deregisterCommand("cat 'foobar.php'");
 		$shell->resetCommandsCalled();
-		$messages = runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\Debug');
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 		$this->assertFalse($shell->wasCommandCalled("cat 'foobar.php'"));
 
@@ -217,14 +213,14 @@ final class SvnWorkflowTest extends TestCase {
 		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
 		$shell->setFileHash('foobar.php', 'different-hash');
 		$shell->resetCommandsCalled();
-		$messages = runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\Debug');
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 		$this->assertTrue($shell->wasCommandCalled("cat 'foobar.php'"));
 
 		// Run a fourth time, restoring the old hash, and make sure we still don't use the (new file) cache
 		$shell->setFileHash('foobar.php', $original_hash);
 		$shell->resetCommandsCalled();
-		$messages = runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\Debug');
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 		$this->assertTrue($shell->wasCommandCalled("cat 'foobar.php'"));
 	}
@@ -243,17 +239,16 @@ final class SvnWorkflowTest extends TestCase {
 
 		$cache = new TestCache();
 		$manager = new CacheManager($cache);
-		$cache->setRevision('188280');
 
 		// Run once to cache results
 		$options['standard'] = 'one';
-		runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\Debug');
+		runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\debug');
 		$this->assertTrue($shell->wasCommandCalled("svn cat 'foobar.php'"));
 		$this->assertTrue($shell->wasCommandCalled("cat 'foobar.php'"));
 
 		// Run again to prove results have been cached
 		$shell->resetCommandsCalled();
-		$messages = runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\Debug');
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 		$this->assertFalse($shell->wasCommandCalled("svn cat 'foobar.php'"));
 		$this->assertFalse($shell->wasCommandCalled("cat 'foobar.php'"));
@@ -261,7 +256,7 @@ final class SvnWorkflowTest extends TestCase {
 		// Run a third time, with the standard changed, and make sure we don't use the cache
 		$options['standard'] = 'two';
 		$shell->resetCommandsCalled();
-		$messages = runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\Debug');
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 		$this->assertTrue($shell->wasCommandCalled("svn cat 'foobar.php'"));
 		$this->assertTrue($shell->wasCommandCalled("cat 'foobar.php'"));
@@ -269,7 +264,7 @@ final class SvnWorkflowTest extends TestCase {
 		// Run a fourth time, restoring the standard, and make sure we do use the cache
 		$options['standard'] = 'one';
 		$shell->resetCommandsCalled();
-		$messages = runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\Debug');
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 		$this->assertFalse($shell->wasCommandCalled("svn cat 'foobar.php'"));
 		$this->assertFalse($shell->wasCommandCalled("cat 'foobar.php'"));
@@ -289,8 +284,8 @@ final class SvnWorkflowTest extends TestCase {
 		$cache = new TestCache();
 		$cache->disabled = true;
 		$manager = new CacheManager($cache);
-		runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\Debug');
-		$messages = runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\Debug');
+		runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\debug');
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 
@@ -307,9 +302,8 @@ final class SvnWorkflowTest extends TestCase {
 		$expected = $this->phpcs->getResults('bin/foobar.php', [20]);
 		$cache = new TestCache();
 		$cache->setCacheVersion('0.1-something-else');
-		$cache->setRevision('188280');
-		$cache->setEntry('foobar.php', 'old', '', '', 'blah'); // This invalid JSON will throw if the cache is used
-		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager($cache), '\PhpcsChangedTests\Debug');
+		$cache->setEntry('foobar.php', 'old', '188280', '', 'blah'); // This invalid JSON will throw if the cache is used
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager($cache), '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 		$this->assertTrue($shell->wasCommandCalled("svn cat 'foobar.php'"));
 		$this->assertTrue($shell->wasCommandCalled("cat 'foobar.php'"));
@@ -330,19 +324,17 @@ final class SvnWorkflowTest extends TestCase {
 		];
 		$expected = $this->phpcs->getResults('bin/foobar.php', [20]);
 		$cache = new TestCache();
-		$cache->setRevision('188280');
-		$cache->setEntry('foobar.php', 'old', '', 'TestStandard2', 'blah'); // This invalid JSON will throw if the cache is used
-		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager($cache), '\PhpcsChangedTests\Debug');
+		$cache->setEntry('foobar.php', 'old', '188280', 'TestStandard2', 'blah'); // This invalid JSON will throw if the cache is used
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager($cache), '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 		$this->assertTrue($shell->wasCommandCalled("svn cat 'foobar.php'"));
 		$this->assertTrue($shell->wasCommandCalled("cat 'foobar.php'"));
 	}
 
-	public function testFullSvnWorkflowForOneFileWithOutdatedCache() {
+	public function testFullSvnWorkflowForOneFileWithCacheOfOldFileVersionDoesNotUseCache() {
 		$svnFile = 'foobar.php';
 		$shell = new TestShell([$svnFile]);
 		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
-		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php', '188280'));
 		$shell->registerCommand("svn cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
 		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
 		$options = [
@@ -350,12 +342,19 @@ final class SvnWorkflowTest extends TestCase {
 		];
 		$expected = $this->phpcs->getResults('bin/foobar.php', [20]);
 		$cache = new TestCache();
-		$cache->setRevision('1000');
-		$cache->setEntry('foobar.php', 'old', '', '', 'blah'); // This invalid JSON will throw if the cache is used
-		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager($cache), '\PhpcsChangedTests\Debug');
+
+		// Set the saved cached revisionId to 1000
+		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php', '188280', '1000'));
+		runSvnWorkflow([$svnFile], $options, $shell, new CacheManager($cache), '\PhpcsChangedTests\debug');
+
+		// The revisionId of the previous version of the file will be 188000
+		$shell->deregisterCommand("svn info 'foobar.php'");
+		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php', '188280', '188000'));
+		$shell->resetCommandsCalled();
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager($cache), '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 		$this->assertTrue($shell->wasCommandCalled("svn cat 'foobar.php'"));
-		$this->assertTrue($shell->wasCommandCalled("cat 'foobar.php'"));
+		$this->assertFalse($shell->wasCommandCalled("cat 'foobar.php'"));
 	}
 
 	public function testFullSvnWorkflowForUnchangedFileWithCache() {
@@ -369,9 +368,8 @@ final class SvnWorkflowTest extends TestCase {
 		];
 		$expected = PhpcsMessages::fromArrays([], 'bin/foobar.php');
 		$cache = new TestCache();
-		$cache->setRevision('188280');
-		$cache->setEntry('foobar.php', 'old', '', '', $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
-		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager($cache), '\PhpcsChangedTests\Debug');
+		$cache->setEntry('foobar.php', 'old', '188280', '', $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager($cache), '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 		$this->assertFalse($shell->wasCommandCalled("svn cat 'foobar.php'"));
 		$this->assertFalse($shell->wasCommandCalled("cat 'foobar.php'"));
@@ -395,7 +393,7 @@ final class SvnWorkflowTest extends TestCase {
 			$this->phpcs->getResults('bin/foobar.php', [20]),
 			$this->phpcs->getResults('bin/baz.php', [20], 'Found unused symbol Baz.'),
 		]);
-		$messages = runSvnWorkflow($svnFiles, $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\Debug');
+		$messages = runSvnWorkflow($svnFiles, $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 
@@ -408,7 +406,7 @@ final class SvnWorkflowTest extends TestCase {
 		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
 		$options = [];
 		$expected = PhpcsMessages::fromArrays([], 'STDIN');
-		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\Debug');
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 
@@ -421,7 +419,7 @@ final class SvnWorkflowTest extends TestCase {
 		$shell->registerCommand("cat 'foobar.php'|phpcs", '{"totals":{"errors":0,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":0,"warnings":0,"messages":[]}}}');
 		$options = [];
 		$expected = PhpcsMessages::fromArrays([], 'STDIN');
-		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\Debug');
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 
@@ -434,7 +432,7 @@ final class SvnWorkflowTest extends TestCase {
 		$shell->registerCommand("svn cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
 		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
 		$options = [];
-		runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\Debug');
+		runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
 	}
 
 	public function testFullSvnWorkflowForNewFile() {
@@ -445,7 +443,7 @@ final class SvnWorkflowTest extends TestCase {
 		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
 		$options = [];
 		$expected = $this->phpcs->getResults('STDIN', [20, 21]);
-		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\Debug');
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 
@@ -461,7 +459,7 @@ Run "phpcs --help" for usage information
 		$shell->registerCommand( "cat 'foobar.php'", $fixture);
 		$options = [];
 		$expected = PhpcsMessages::fromArrays([], 'STDIN');
-		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\Debug');
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 }

--- a/tests/helpers/Functions.php
+++ b/tests/helpers/Functions.php
@@ -4,3 +4,9 @@ declare(strict_types=1);
 namespace PhpcsChangedTests;
 
 function debug($message) {} //phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+
+function debugWithOutput(...$messages) {
+	foreach($messages as $message) {
+		var_dump($message);
+	}
+}

--- a/tests/helpers/SvnFixture.php
+++ b/tests/helpers/SvnFixture.php
@@ -44,7 +44,8 @@ Added: svn:eol-style
 EOF;
 	}
 
-	public function getSvnInfo(string $filename, string $revision = '188280'): string {
+	public function getSvnInfo(string $filename, string $revision = '188280', string $lastChangedRevision = null): string {
+		$lastChangedRevision = $lastChangedRevision ?? $revision;
 		return <<<EOF
 Path: {$filename}
 Name: {$filename}
@@ -57,7 +58,7 @@ Revision: {$revision}
 Node Kind: file
 Schedule: normal
 Last Changed Author: me
-Last Changed Rev: 175729
+Last Changed Rev: {$lastChangedRevision}
 Last Changed Date: 2018-05-22 17:34:00 +0000 (Tue, 22 May 2018)
 Text Last Updated: 2018-05-22 17:34:00 +0000 (Tue, 22 May 2018)
 Checksum: abcdefg

--- a/tests/helpers/TestCache.php
+++ b/tests/helpers/TestCache.php
@@ -20,11 +20,6 @@ class TestCache implements CacheInterface {
 	private $cacheVersion;
 
 	/**
-	 * @var string
-	 */
-	private $revisionId = '';
-
-	/**
 	 * @var bool
 	 */
 	public $didSave = false;
@@ -41,7 +36,6 @@ class TestCache implements CacheInterface {
 		$this->didSave = false;
 		$cacheObject = new CacheObject();
 		$cacheObject->cacheVersion = $this->cacheVersion ?? getVersion();
-		$cacheObject->revisionId = $this->revisionId;
 		foreach(array_values($this->savedFileData) as $entry) {
 			$cacheObject->entries[] = CacheEntry::fromJson($entry);
 		}
@@ -54,7 +48,6 @@ class TestCache implements CacheInterface {
 		}
 		$this->didSave = true;
 		$this->setCacheVersion($cacheObject->cacheVersion);
-		$this->setRevision($cacheObject->revisionId);
 		$this->savedFileData = [];
 		foreach($cacheObject->entries as $entry) {
 			$this->setEntry($entry->path, $entry->type, $entry->hash, $entry->phpcsStandard, $entry->data);
@@ -69,10 +62,6 @@ class TestCache implements CacheInterface {
 			'type' => $type,
 			'phpcsStandard' => $phpcsStandard,
 		];
-	}
-
-	public function setRevision(string $revisionId): void {
-		$this->revisionId = $revisionId;
 	}
 
 	public function setCacheVersion(string $cacheVersion): void {


### PR DESCRIPTION
Previously we were invalidating the whole cache for svn files whenever the svn revision changed, but this is overly broad. Most files of a repo will not change when the revision changes, and we should be able to use their cached versions.

This PR changes the cache so that it uses the file's last changed revision as the hash for that file, and does not clear the whole cache based on revision.