### PR TITLE
Only run orig file PHPCS linting when the new version has lint issues

### DIFF
--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -279,7 +279,7 @@ function runSvnWorkflowForFile(string $svnFile, array $options, ShellOperator $s
 		$unifiedDiff = '';
 		$oldFilePhpcsOutput = '';
 		$newFilePhpcsOutput = '';
-		$newFilePhpcsMessages = [];
+		$newFilePhpcsMessages = PhpcsMessages::fromArrays([]);
 	} catch( \Exception $err ) {
 		$shell->printError($err->getMessage());
 		$shell->exitWithCode(1);
@@ -392,7 +392,7 @@ function runGitWorkflowForFile(string $gitFile, array $options, ShellOperator $s
 		$unifiedDiff = '';
 		$oldFilePhpcsOutput = '';
 		$newFilePhpcsOutput = '';
-		$newFilePhpcsMessages = [];
+		$newFilePhpcsMessages = PhpcsMessages::fromArrays([]);
 	} catch(\Exception $err) {
 		$shell->printError($err->getMessage());
 		$shell->exitWithCode(1);

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -278,8 +278,7 @@ function runSvnWorkflowForFile(string $svnFile, array $options, ShellOperator $s
 		$debug($err->getMessage());
 		$unifiedDiff = '';
 		$oldFilePhpcsOutput = '';
-		$newFilePhpcsOutput = '';
-		$newFilePhpcsMessages = PhpcsMessages::fromArrays([]);
+		$newFilePhpcsMessages = PhpcsMessages::fromPhpcsJson('');
 	} catch( \Exception $err ) {
 		$shell->printError($err->getMessage());
 		$shell->exitWithCode(1);
@@ -391,8 +390,7 @@ function runGitWorkflowForFile(string $gitFile, array $options, ShellOperator $s
 		$debug($err->getMessage());
 		$unifiedDiff = '';
 		$oldFilePhpcsOutput = '';
-		$newFilePhpcsOutput = '';
-		$newFilePhpcsMessages = PhpcsMessages::fromArrays([]);
+		$newFilePhpcsMessages = PhpcsMessages::fromPhpcsJson('');
 	} catch(\Exception $err) {
 		$shell->printError($err->getMessage());
 		$shell->exitWithCode(1);

--- a/tests/GitWorkflowTest.php
+++ b/tests/GitWorkflowTest.php
@@ -89,6 +89,26 @@ final class GitWorkflowTest extends TestCase {
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 
+	public function testFullGitWorkflowForOneFileUnstagedLintOnlyPhpcsNewFile() {
+		$gitFile = 'foobar.php';
+		$shell = new TestShell([$gitFile]);
+		$fixture = $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;');
+		$shell->registerCommand("git diff --no-prefix 'foobar.php'", $fixture);
+		$shell->registerCommand("git status --porcelain 'foobar.php'", $this->fixture->getModifiedFileInfo('foobar.php'));
+		$shell->registerCommand("cat 'foobar.php' | phpcs", $this->phpcs->getEmptyResults()->toPhpcsJson());
+
+		$options = [
+			'git-unstaged' => '1',
+		];
+		$cache = new CacheManager( new TestCache(), '\PhpcsChangedTests\Debug' );
+		$expected = $this->phpcs->getEmptyResults();
+
+		$messages = runGitWorkflow([$gitFile], $options, $shell, $cache, '\PhpcsChangedTests\Debug');
+
+		$this->assertEquals($expected->getMessages(), $messages->getMessages());
+		$this->assertFalse($shell->wasCommandCalled("git show :0:$(git ls-files --full-name 'foobar.php') | phpcs"));
+	}
+
 	public function testFullGitWorkflowForOneFileUnstagedCachesDataThenUsesCache() {
 		$gitFile = 'foobar.php';
 		$shell = new TestShell([$gitFile]);

--- a/tests/SvnWorkflowTest.php
+++ b/tests/SvnWorkflowTest.php
@@ -79,12 +79,12 @@ final class SvnWorkflowTest extends TestCase {
 		$shell = new TestShell([$svnFile]);
 		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
 		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php'));
-		$shell->registerCommand("svn cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
 		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getEmptyResults()->toPhpcsJson());
 		$options = [];
 		$expected = $this->phpcs->getEmptyResults();
 		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
+		$this->assertFalse($shell->wasCommandCalled("svn cat 'foobar.php'"));
 	}
 
 	public function testFullSvnWorkflowForOneFileWithCachingEnabledButNoCache() {


### PR DESCRIPTION
When there are no linting issues reported by PHPCS in the new file, there is no point in checking the orig verion, since we would not report any issues anyway.

This should speed up the phpcs-changed for files w/o lint issues.

props to @sirbrillig for the idea.