### PR TITLE
Always return 0 from reportMessagesAndExit when run with --arc-lint flag

### DIFF
--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -385,6 +385,9 @@ function runGitWorkflowForFile(string $gitFile, array $options, ShellOperator $s
 function reportMessagesAndExit(PhpcsMessages $messages, string $reportType, array $options): void {
 	$reporter = getReporter($reportType);
 	echo $reporter->getFormattedMessages($messages, $options);
+	if ( isset($options['arc-lint']) ) {
+		exit(0);
+	}
 	exit($reporter->getExitCode($messages));
 }
 

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -385,7 +385,7 @@ function runGitWorkflowForFile(string $gitFile, array $options, ShellOperator $s
 function reportMessagesAndExit(PhpcsMessages $messages, string $reportType, array $options): void {
 	$reporter = getReporter($reportType);
 	echo $reporter->getFormattedMessages($messages, $options);
-	if ( isset($options['arc-lint']) ) {
+	if ( isset($options['always-exit-zero']) ) {
 		exit(0);
 	}
 	exit($reporter->getExitCode($messages));

--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ The `--no-cache` option will disable the cache if it's been enabled. (This may a
 
 The `--clear-cache` option will clear the cache before running. This works with or without caching enabled.
 
+The `--always-exit-zero` option will make sure the run will always exit with `0` return code, no matter if there are lint issues or not. When not set, `1` is returned in case there are some lint issues, `0` if no lint issues were found. The flag makes the phpcs-changed working with other scripts which could detect `1` as failure in the script run (eg.: arcanist). 
+
 THE `--arc-lint` option can be used when the phpcs-changed is run via arcanist, as it skips some checks, which are performed by arcanist itself. It leads to better performance when used with arcanist.
 
 ## PHP Library

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -47,6 +47,7 @@ $options = getopt(
 		'no-cache',
 		'clear-cache',
 		'arc-lint',
+		'always-exit-zero'
 	],
 	$optind
 );


### PR DESCRIPTION
When using futures in arcanist linter, the external lint program, eg.: phpcs-changed in this case, should always return 0 status, even if there are lint errors, otherwise the external program's run is considered being unsuccessful.