### PR TITLE
Do not fetch file diff if updated file has no messages

### DIFF
--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -237,12 +237,15 @@ function runSvnWorkflowForFile(string $svnFile, array $options, ShellOperator $s
 			throw new ShellException("Cannot read file '{$svnFile}'");
 		}
 		$svnFileInfo = getSvnFileInfo($svnFile, $svn, [$shell, 'executeCommand'], $debug);
-		$unifiedDiff = getSvnUnifiedDiff($svnFile, $svn, [$shell, 'executeCommand'], $debug);
 		$revisionId = getSvnRevisionId($svnFileInfo);
 		$isNewFile = isNewSvnFile($svnFileInfo);
 
-		$newFileHash = $shell->getFileHash($svnFile);
-		$newFilePhpcsOutput = isCachingEnabled($options) ? $cache->getCacheForFile($svnFile, 'new', $newFileHash, $phpcsStandard ?? '') : null;
+		$newFileHash = '';
+		$newFilePhpcsOutput = null;
+		if (isCachingEnabled($options)) {
+			$newFileHash = $shell->getFileHash($svnFile);
+			$newFilePhpcsOutput = $cache->getCacheForFile($svnFile, 'new', $newFileHash, $phpcsStandard ?? '');
+		}
 		if ($newFilePhpcsOutput) {
 			$debug("Using cache for new file '{$svnFile}' at revision '{$revisionId}', hash '{$newFileHash}', and standard '{$phpcsStandard}'");
 		}
@@ -253,12 +256,19 @@ function runSvnWorkflowForFile(string $svnFile, array $options, ShellOperator $s
 				$cache->setCacheForFile($svnFile, 'new', $newFileHash, $phpcsStandard ?? '', $newFilePhpcsOutput);
 			}
 		}
-		$fileName = DiffLineMap::getFileNameFromDiff($unifiedDiff);
+
+		$fileName = $shell->getFileNameFromPath($svnFile);
 		$newFilePhpcsMessages = PhpcsMessages::fromPhpcsJson($newFilePhpcsOutput, $fileName);
 		$hasNewPhpcsMessages = !empty($newFilePhpcsMessages->getMessages());
 
+		if (! $hasNewPhpcsMessages) {
+			throw new NoChangesException("New file '{$svnFile}' has no PHPCS messages; skipping");
+		}
+
+		$unifiedDiff = getSvnUnifiedDiff($svnFile, $svn, [$shell, 'executeCommand'], $debug);
+
 		$oldFilePhpcsOutput = '';
-		if ( ! $isNewFile && $hasNewPhpcsMessages) {
+		if (! $isNewFile) {
 			$oldFilePhpcsOutput = isCachingEnabled($options) ? $cache->getCacheForFile($svnFile, 'old', $revisionId, $phpcsStandard ?? '') : null;
 			if ($oldFilePhpcsOutput) {
 				$debug("Using cache for old file '{$svnFile}' at revision '{$revisionId}' and standard '{$phpcsStandard}'");
@@ -269,12 +279,6 @@ function runSvnWorkflowForFile(string $svnFile, array $options, ShellOperator $s
 				if (isCachingEnabled($options)) {
 					$cache->setCacheForFile($svnFile, 'old', $revisionId, $phpcsStandard ?? '', $oldFilePhpcsOutput);
 				}
-			}
-		} else {
-			if ($isNewFile) {
-				$debug('Skipping the linting of the orig file version as it is a new file.');
-			} else {
-				$debug('Skipping the linting of the orig file version as the new version of the file contains no lint errors.');
 			}
 		}
 	} catch( NoChangesException $err ) {

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -156,6 +156,7 @@ EOF;
 		'--arc-lint' => 'The command is being run from within the "arc lint" command. Employ some performance improvements.',
 		'--always-exit-zero' => 'Always exit the script with a 0 return code. Otherwise, a 1 return code indicates phpcs messages.',
 		'--no-cache-git-root' => 'Prevent caching the git root used by the git workflow.',
+		'--no-verify-git-file' => 'Prevent checking if a file is tracked by git in the git workflow.',
 	], "	");
 	echo <<<EOF
 Overrides:

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -335,7 +335,6 @@ function runGitWorkflowForFile(string $gitFile, array $options, ShellOperator $s
 
 	try {
 		validateGitFileExists($gitFile, $git, [$shell, 'isReadable'], [$shell, 'executeCommand'], $debug, $options);
-		$unifiedDiff = getGitUnifiedDiff($gitFile, $git, [$shell, 'executeCommand'], $options, $debug);
 		$isNewFile = isNewGitFile($gitFile, $git, [$shell, 'executeCommand'], $options, $debug);
 
 		$newFilePhpcsOutput = null;
@@ -355,13 +354,16 @@ function runGitWorkflowForFile(string $gitFile, array $options, ShellOperator $s
 				$cache->setCacheForFile($gitFile, 'new', $newFileHash, $phpcsStandard ?? '', $newFilePhpcsOutput);
 			}
 		}
-		$fileName = DiffLineMap::getFileNameFromDiff($unifiedDiff);
+
+		$fileName = $shell->getFileNameFromPath($gitFile);
 		$newFilePhpcsMessages = PhpcsMessages::fromPhpcsJson($newFilePhpcsOutput, $fileName);
 		$hasNewFilePhpcsIssues = !empty($newFilePhpcsMessages->getMessages());
 
+		$unifiedDiff = '';
 		$oldFilePhpcsOutput = '';
 		if (! $isNewFile && $hasNewFilePhpcsIssues) {
 			$debug('Checking the orig file version for PHPCS issues since the file is not new and contains some linting issues.');
+			$unifiedDiff = getGitUnifiedDiff($gitFile, $git, [$shell, 'executeCommand'], $options, $debug);
 			$oldFilePhpcsOutput = null;
 			$oldFileHash = '';
 			if (isCachingEnabled($options)) {

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -236,9 +236,6 @@ function runSvnWorkflowForFile(string $svnFile, array $options, ShellOperator $s
 		if (! $shell->isReadable($svnFile)) {
 			throw new ShellException("Cannot read file '{$svnFile}'");
 		}
-		$svnFileInfo = getSvnFileInfo($svnFile, $svn, [$shell, 'executeCommand'], $debug);
-		$revisionId = getSvnRevisionId($svnFileInfo);
-		$isNewFile = isNewSvnFile($svnFileInfo);
 
 		$newFileHash = '';
 		$newFilePhpcsOutput = null;
@@ -247,10 +244,10 @@ function runSvnWorkflowForFile(string $svnFile, array $options, ShellOperator $s
 			$newFilePhpcsOutput = $cache->getCacheForFile($svnFile, 'new', $newFileHash, $phpcsStandard ?? '');
 		}
 		if ($newFilePhpcsOutput) {
-			$debug("Using cache for new file '{$svnFile}' at revision '{$revisionId}', hash '{$newFileHash}', and standard '{$phpcsStandard}'");
+			$debug("Using cache for new file '{$svnFile}', hash '{$newFileHash}', and standard '{$phpcsStandard}'");
 		}
 		if (! $newFilePhpcsOutput) {
-			$debug("Not using cache for new file '{$svnFile}' at revision '{$revisionId}', hash '{$newFileHash}', and standard '{$phpcsStandard}'");
+			$debug("Not using cache for new file '{$svnFile}', hash '{$newFileHash}', and standard '{$phpcsStandard}'");
 			$newFilePhpcsOutput = getSvnNewPhpcsOutput($svnFile, $phpcs, $cat, $phpcsStandardOption, [$shell, 'executeCommand'], $debug);
 			if (isCachingEnabled($options)) {
 				$cache->setCacheForFile($svnFile, 'new', $newFileHash, $phpcsStandard ?? '', $newFilePhpcsOutput);
@@ -267,6 +264,9 @@ function runSvnWorkflowForFile(string $svnFile, array $options, ShellOperator $s
 
 		$unifiedDiff = getSvnUnifiedDiff($svnFile, $svn, [$shell, 'executeCommand'], $debug);
 
+		$svnFileInfo = getSvnFileInfo($svnFile, $svn, [$shell, 'executeCommand'], $debug);
+		$revisionId = getSvnRevisionId($svnFileInfo);
+		$isNewFile = isNewSvnFile($svnFileInfo);
 		$oldFilePhpcsOutput = '';
 		if (! $isNewFile) {
 			$oldFilePhpcsOutput = isCachingEnabled($options) ? $cache->getCacheForFile($svnFile, 'old', $revisionId, $phpcsStandard ?? '') : null;

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -267,6 +267,9 @@ function runSvnWorkflowForFile(string $svnFile, array $options, ShellOperator $s
 		$svnFileInfo = getSvnFileInfo($svnFile, $svn, [$shell, 'executeCommand'], $debug);
 		$revisionId = getSvnRevisionId($svnFileInfo);
 		$isNewFile = isNewSvnFile($svnFileInfo);
+		if ($isNewFile) {
+			$debug('Skipping the linting of the old file version as it is a new file.');
+		}
 		$oldFilePhpcsOutput = '';
 		if (! $isNewFile) {
 			$oldFilePhpcsOutput = isCachingEnabled($options) ? $cache->getCacheForFile($svnFile, 'old', $revisionId, $phpcsStandard ?? '') : null;
@@ -372,6 +375,9 @@ function runGitWorkflowForFile(string $gitFile, array $options, ShellOperator $s
 		}
 
 		$isNewFile = isNewGitFile($gitFile, $git, [$shell, 'executeCommand'], $options, $debug);
+		if ($isNewFile) {
+			$debug('Skipping the linting of the old file version as it is a new file.');
+		}
 		if (! $isNewFile) {
 			$debug('Checking the orig file version with PHPCS since the file is not new and contains some messages.');
 			$unifiedDiff = getGitUnifiedDiff($gitFile, $git, [$shell, 'executeCommand'], $options, $debug);

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -154,6 +154,7 @@ EOF;
 		'--clear-cache' => 'Clear the cache before running.',
 		'-i' => 'Show a list of installed coding standards',
 		'--arc-lint' => 'The command is being run from within the "arc lint" command. Employ some performance improvements.',
+		'--no-cache-git-root' => 'Prevent caching the git root used by the git workflow.',
 	], "	");
 	echo <<<EOF
 Overrides:

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -154,6 +154,7 @@ EOF;
 		'--clear-cache' => 'Clear the cache before running.',
 		'-i' => 'Show a list of installed coding standards',
 		'--arc-lint' => 'The command is being run from within the "arc lint" command. Employ some performance improvements.',
+		'--always-exit-zero' => 'Always exit the script with a 0 return code. Otherwise, a 1 return code indicates phpcs messages.',
 		'--no-cache-git-root' => 'Prevent caching the git root used by the git workflow.',
 	], "	");
 	echo <<<EOF

--- a/PhpcsChanged/GitWorkflow.php
+++ b/PhpcsChanged/GitWorkflow.php
@@ -165,8 +165,6 @@ function getOldGitRevisionContentsCommand(string $gitFile, string $git, array $o
 	return "${git} show {$rev}:$(${git} ls-files --full-name " . escapeshellarg($gitFile) . ")";
 }
 
-
-
 function getNewGitFileHash(string $gitFile, string $git, string $cat, callable $executeCommand, array $options, callable $debug): string {
 	$fileContents = getNewGitRevisionContentsCommand($gitFile, $git, $cat, $options, $executeCommand, $debug);
 	$command = "{$fileContents} | {$git} hash-object --stdin";

--- a/PhpcsChanged/GitWorkflow.php
+++ b/PhpcsChanged/GitWorkflow.php
@@ -92,7 +92,7 @@ function isNewGitFileLocal(string $gitFile, string $git, callable $executeComman
 	$gitStatusOutput = $executeCommand($gitStatusCommand);
 	$debug('git status output:', $gitStatusOutput);
 	if (! $gitStatusOutput || false === strpos($gitStatusOutput, $gitFile)) {
-		throw new ShellException("Cannot get git status for file '{$gitFile}'");
+		return false;
 	}
 	if (isset($gitStatusOutput[0]) && $gitStatusOutput[0] === '?') {
 		throw new ShellException("File does not appear to be tracked by git: '{$gitFile}'");

--- a/PhpcsChanged/GitWorkflow.php
+++ b/PhpcsChanged/GitWorkflow.php
@@ -23,8 +23,11 @@ function validateGitFileExists(string $gitFile, string $git, callable $isReadabl
 	}
 }
 
-function isRunFromGitRoot( string $git, callable $executeCommand, callable $debug ): bool {
+function isRunFromGitRoot(string $git, callable $executeCommand, array $options, callable $debug): bool {
 	static $isRunFromGitRoot;
+	if (isset($options['no-cache-git-root'])) {
+		$isRunFromGitRoot = null;
+	}
 	if (null !== $isRunFromGitRoot) {
 		return $isRunFromGitRoot;
 	}
@@ -133,7 +136,7 @@ function getGitNewPhpcsOutput(string $gitFile, string $git, string $phpcs, strin
 function getNewGitRevisionContentsCommand(string $gitFile, string $git, string $cat, array $options, callable $executeCommand, callable $debug): string {
 	if (isset($options['git-base']) && ! empty($options['git-base'])) {
 		// for git-base mode, we get the contents of the file from the HEAD version of the file in the current branch
-		if (isRunFromGitRoot($git, $executeCommand, $debug)) {
+		if (isRunFromGitRoot($git, $executeCommand, $options, $debug)) {
 			return "{$git} show HEAD:" . escapeshellarg($gitFile);
 		}
 		return "{$git} show HEAD:$(${git} ls-files --full-name " . escapeshellarg($gitFile) . ')';
@@ -142,7 +145,7 @@ function getNewGitRevisionContentsCommand(string $gitFile, string $git, string $
 		return "{$cat} " . escapeshellarg($gitFile);
 	}
 	// default mode is git-staged, so we get the contents from the staged version of the file
-	if (isRunFromGitRoot($git, $executeCommand, $debug)) {
+	if (isRunFromGitRoot($git, $executeCommand, $options, $debug)) {
 		return "{$git} show :0:" . escapeshellarg($gitFile);
 	}
 	return "{$git} show :0:$(${git} ls-files --full-name " . escapeshellarg($gitFile) . ')';
@@ -159,7 +162,7 @@ function getOldGitRevisionContentsCommand(string $gitFile, string $git, array $o
 		// git-staged
 		$rev = 'HEAD';
 	}
-	if (isRunFromGitRoot($git, $executeCommand, $debug)) {
+	if (isRunFromGitRoot($git, $executeCommand, $options, $debug)) {
 		return "${git} show {$rev}:" . escapeshellarg($gitFile);
 	}
 	return "${git} show {$rev}:$(${git} ls-files --full-name " . escapeshellarg($gitFile) . ")";

--- a/PhpcsChanged/GitWorkflow.php
+++ b/PhpcsChanged/GitWorkflow.php
@@ -7,8 +7,8 @@ use PhpcsChanged\NoChangesException;
 use PhpcsChanged\ShellException;
 
 function validateGitFileExists(string $gitFile, string $git, callable $isReadable, callable $executeCommand, callable $debug, array $options): void {
-	if (isset($options['arc-lint'])) {
-		$debug('Skipping Git file exists check, as it has been performed by arc-lint already.');
+	if (isset($options['no-verify-git-file'])) {
+		$debug('skipping Git file exists check.');
 		return;
 	}
 	if (! $isReadable($gitFile)) {

--- a/PhpcsChanged/ShellOperator.php
+++ b/PhpcsChanged/ShellOperator.php
@@ -18,4 +18,6 @@ interface ShellOperator {
 	public function exitWithCode(int $code): void;
 
 	public function printError(string $message): void;
+
+	public function getFileNameFromPath(string $path): string;
 }

--- a/PhpcsChanged/UnixShell.php
+++ b/PhpcsChanged/UnixShell.php
@@ -41,4 +41,9 @@ class UnixShell implements ShellOperator {
 	public function printError(string $output): void {
 		printError($output);
 	}
+
+	public function getFileNameFromPath(string $path): string {
+		$parts = explode('/', $path);
+		return end($parts);
+	}
 }

--- a/README.md
+++ b/README.md
@@ -114,7 +114,9 @@ The `--clear-cache` option will clear the cache before running. This works with 
 
 The `--always-exit-zero` option will make sure the run will always exit with `0` return code, no matter if there are lint issues or not. When not set, `1` is returned in case there are some lint issues, `0` if no lint issues were found. The flag makes the phpcs-changed working with other scripts which could detect `1` as failure in the script run (eg.: arcanist). 
 
-THE `--arc-lint` option can be used when the phpcs-changed is run via arcanist, as it skips some checks, which are performed by arcanist itself. It leads to better performance when used with arcanist.
+The `--arc-lint` option can be used when the phpcs-changed is run via arcanist, as it skips some checks, which are performed by arcanist itself. It leads to better performance when used with arcanist.
+
+The `--no-verify-git-file` option will prevent checking to see if a file is tracked by git during the git workflow. This can save a little time if you can guarantee this otherwise.
 
 The `--no-cache-git-root` option will prevent caching the check used by the git workflow to determine the git root within a single execution. This is probably only useful for automated tests.
 

--- a/README.md
+++ b/README.md
@@ -114,11 +114,11 @@ The `--clear-cache` option will clear the cache before running. This works with 
 
 The `--always-exit-zero` option will make sure the run will always exit with `0` return code, no matter if there are lint issues or not. When not set, `1` is returned in case there are some lint issues, `0` if no lint issues were found. The flag makes the phpcs-changed working with other scripts which could detect `1` as failure in the script run (eg.: arcanist). 
 
-The `--arc-lint` option can be used when the phpcs-changed is run via arcanist, as it skips some checks, which are performed by arcanist itself. It leads to better performance when used with arcanist.
-
 The `--no-verify-git-file` option will prevent checking to see if a file is tracked by git during the git workflow. This can save a little time if you can guarantee this otherwise.
 
 The `--no-cache-git-root` option will prevent caching the check used by the git workflow to determine the git root within a single execution. This is probably only useful for automated tests.
+
+The `--arc-lint` option can be used when the phpcs-changed is run via arcanist, as it skips some checks, which are performed by arcanist itself. It leads to better performance when used with arcanist. (Equivalent to `--no-verify-git-file --always-exit-zero`.)
 
 ## PHP Library
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ The `--always-exit-zero` option will make sure the run will always exit with `0`
 
 THE `--arc-lint` option can be used when the phpcs-changed is run via arcanist, as it skips some checks, which are performed by arcanist itself. It leads to better performance when used with arcanist.
 
+The `--no-cache-git-root` option will prevent caching the check used by the git workflow to determine the git root within a single execution. This is probably only useful for automated tests.
+
 ## PHP Library
 
 🐘🐘🐘

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -101,6 +101,7 @@ if (isset($options['git-branch'])) {
 if (isset($options['arc-lint'])) {
 	$options['no-verify-git-file'] = 1;
 	$options['always-exit-zero'] = 1;
+	unset($options['arc-lint']);
 }
 
 $debug = getDebug(isset($options['debug']));

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -47,7 +47,9 @@ $options = getopt(
 		'no-cache',
 		'clear-cache',
 		'arc-lint',
-		'always-exit-zero'
+		'always-exit-zero',
+		'no-cache-git-root',
+		'no-verify-git-file',
 	],
 	$optind
 );
@@ -89,10 +91,16 @@ if (isset($options['i'])) {
 	printInstalledCodingStandards();
 }
 
-// --git-branch exists for compatibility, --git-bases supports branches
+// --git-branch exists for compatibility, --git-base supports branches
 if (isset($options['git-branch'])) {
 	$options['git-base'] = $options['git-branch'];
 	unset($options['git-branch']);
+}
+
+// --arc-lint is a shorthand for several other options
+if (isset($options['arc-lint'])) {
+	$options['no-verify-git-file'] = 1;
+	$options['always-exit-zero'] = 1;
 }
 
 $debug = getDebug(isset($options['debug']));

--- a/tests/GitWorkflowTest.php
+++ b/tests/GitWorkflowTest.php
@@ -89,11 +89,9 @@ final class GitWorkflowTest extends TestCase {
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 
-	public function testFullGitWorkflowForOneFileUnstagedLintOnlyPhpcsNewFile() {
+	public function testFullGitWorkflowForOneChangedFileWithoutPhpcsMessagesLintsOnlyNewFile() {
 		$gitFile = 'foobar.php';
 		$shell = new TestShell([$gitFile]);
-		$fixture = $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;');
-		$shell->registerCommand("git diff --no-prefix 'foobar.php'", $fixture);
 		$shell->registerCommand("git status --porcelain 'foobar.php'", $this->fixture->getModifiedFileInfo('foobar.php'));
 		$shell->registerCommand("cat 'foobar.php' | phpcs", $this->phpcs->getEmptyResults()->toPhpcsJson());
 
@@ -106,6 +104,7 @@ final class GitWorkflowTest extends TestCase {
 		$messages = runGitWorkflow([$gitFile], $options, $shell, $cache, '\PhpcsChangedTests\Debug');
 
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
+		$this->assertFalse($shell->wasCommandCalled("git diff --no-prefix 'foobar.php'"));
 		$this->assertFalse($shell->wasCommandCalled("git show :0:$(git ls-files --full-name 'foobar.php') | phpcs"));
 	}
 

--- a/tests/GitWorkflowTest.php
+++ b/tests/GitWorkflowTest.php
@@ -270,7 +270,7 @@ final class GitWorkflowTest extends TestCase {
 		$shell->registerCommand("git rev-parse --show-toplevel", 'run-from-git-root');
 		$options = [];
 		$cache = new CacheManager( new TestCache() );
-		$expected = $this->phpcs->getResults('bin/foobar.php', [5, 6], 'Found unused symbol Foobar.');
+		$expected = $this->phpcs->getResults('foobar.php', [5, 6], 'Found unused symbol Foobar.');
 		$messages = runGitWorkflow([$gitFile], $options, $shell, $cache, '\PhpcsChangedTests\Debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}

--- a/tests/GitWorkflowTest.php
+++ b/tests/GitWorkflowTest.php
@@ -66,7 +66,7 @@ final class GitWorkflowTest extends TestCase {
 		$shell->registerCommand("git show HEAD:$(git ls-files --full-name 'foobar.php')", $this->phpcs->getResults('STDIN', [20])->toPhpcsJson());
 		$shell->registerCommand("git show :0:$(git ls-files --full-name 'foobar.php')", $this->phpcs->getResults('STDIN', [20, 21], 'Found unused symbol Foobar.')->toPhpcsJson());
 		$shell->registerCommand("git rev-parse --show-toplevel", 'run-from-git-root');
-		$options = [];
+		$options = ['no-cache-git-root' => 1];
 		$cache = new CacheManager( new TestCache() );
 		$expected = $this->phpcs->getResults('bin/foobar.php', [20], 'Found unused symbol Foobar.');
 		$messages = runGitWorkflow([$gitFile], $options, $shell, $cache, '\PhpcsChangedTests\Debug');
@@ -82,7 +82,7 @@ final class GitWorkflowTest extends TestCase {
 		$shell->registerCommand("git show :0:$(git ls-files --full-name 'foobar.php')", $this->phpcs->getResults('STDIN', [20], 'Found unused symbol Foobar.')->toPhpcsJson());
 		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getResults('STDIN', [21, 20], 'Found unused symbol Foobar.')->toPhpcsJson());
 		$shell->registerCommand("git rev-parse --show-toplevel", 'run-from-git-root');
-		$options = ['git-unstaged' => '1'];
+		$options = ['no-cache-git-root' => 1, 'git-unstaged' => '1'];
 		$cache = new CacheManager( new TestCache() );
 		$expected = $this->phpcs->getResults('bin/foobar.php', [20], 'Found unused symbol Foobar.');
 		$messages = runGitWorkflow([$gitFile], $options, $shell, $cache, '\PhpcsChangedTests\Debug');
@@ -96,6 +96,7 @@ final class GitWorkflowTest extends TestCase {
 		$shell->registerCommand("cat 'foobar.php' | phpcs", $this->phpcs->getEmptyResults()->toPhpcsJson());
 
 		$options = [
+			'no-cache-git-root' => 1,
 			'git-unstaged' => '1',
 		];
 		$cache = new CacheManager( new TestCache(), '\PhpcsChangedTests\Debug' );
@@ -120,6 +121,7 @@ final class GitWorkflowTest extends TestCase {
 		$shell->registerCommand("cat 'foobar.php' | git hash-object --stdin", 'new-file-hash');
 		$shell->registerCommand("git rev-parse --show-toplevel", 'run-from-git-root');
 		$options = [
+			'no-cache-git-root' => 1,
 			'git-unstaged' => '1',
 			'cache' => false, // getopt is weird and sets options to false
 		];
@@ -147,6 +149,7 @@ final class GitWorkflowTest extends TestCase {
 		$shell->registerCommand("cat 'foobar.php' | git hash-object --stdin", 'new-file-hash');
 		$shell->registerCommand("git rev-parse --show-toplevel", 'run-from-git-root');
 		$options = [
+			'no-cache-git-root' => 1,
 			'git-unstaged' => '1',
 			'cache' => false, // getopt is weird and sets options to false
 		];
@@ -176,6 +179,7 @@ final class GitWorkflowTest extends TestCase {
 		$shell->registerCommand("cat 'foobar.php' | git hash-object --stdin", 'new-file-hash');
 		$shell->registerCommand("git rev-parse --show-toplevel", 'run-from-git-root');
 		$options = [
+			'no-cache-git-root' => 1,
 			'git-unstaged' => '1',
 			'cache' => false, // getopt is weird and sets options to false
 		];
@@ -207,7 +211,7 @@ final class GitWorkflowTest extends TestCase {
 		$shell->registerCommand("git show :0:$(git ls-files --full-name 'foobar.php')", $this->phpcs->getResults('STDIN', [20, 21], 'Found unused symbol Foobar.')->toPhpcsJson());
 		$shell->registerCommand("git show :0:$(git ls-files --full-name 'baz.php')", $this->phpcs->getResults('STDIN', [20, 21], 'Found unused symbol Baz.')->toPhpcsJson());
 		$shell->registerCommand("git rev-parse --show-toplevel", 'run-from-git-root');
-		$options = [];
+		$options = ['no-cache-git-root' => 1];
 		$cache = new CacheManager( new TestCache() );
 		$expected = PhpcsMessages::merge([
 			$this->phpcs->getResults('bin/foobar.php', [20], 'Found unused symbol Foobar.'),
@@ -226,7 +230,7 @@ final class GitWorkflowTest extends TestCase {
 		$shell->registerCommand("git show HEAD:$(git ls-files --full-name 'foobar.php')", $this->phpcs->getResults('STDIN', [20])->toPhpcsJson());
 		$shell->registerCommand("git show :0:$(git ls-files --full-name 'foobar.php')", $this->phpcs->getResults('STDIN', [20])->toPhpcsJson());
 		$shell->registerCommand("git rev-parse --show-toplevel", 'run-from-git-root');
-		$options = [];
+		$options = ['no-cache-git-root' => 1];
 		$cache = new CacheManager( new TestCache() );
 		$expected = PhpcsMessages::fromArrays([], '/dev/null');
 		$messages = runGitWorkflow([$gitFile], $options, $shell, $cache, '\PhpcsChangedTests\Debug');
@@ -239,7 +243,8 @@ final class GitWorkflowTest extends TestCase {
 		$shell->registerCommand("git status --porcelain 'foobar.php'", '');
 		$shell->registerCommand("git show HEAD:$(git ls-files --full-name 'foobar.php')", $this->phpcs->getResults('STDIN', [])->toPhpcsJson());
 		$shell->registerCommand("git show :0:$(git ls-files --full-name 'foobar.php')", $this->phpcs->getResults('STDIN', [])->toPhpcsJson());
-		$options = [];
+		$shell->registerCommand("git rev-parse --show-toplevel", 'run-from-git-root');
+		$options = ['no-cache-git-root' => 1];
 		$cache = new CacheManager( new TestCache() );
 		$expected = PhpcsMessages::fromArrays([], '/dev/null');
 		$messages = runGitWorkflow([$gitFile], $options, $shell, $cache, '\PhpcsChangedTests\Debug');
@@ -255,7 +260,7 @@ final class GitWorkflowTest extends TestCase {
 		$shell->registerCommand("git status --porcelain 'foobar.php'", "?? foobar.php" );
 		$shell->registerCommand("git show HEAD:$(git ls-files --full-name 'foobar.php')", $this->fixture->getNonGitFileShow('foobar.php'), 128);
 		$shell->registerCommand("git show :0:$(git ls-files --full-name 'foobar.php')", $this->phpcs->getResults('STDIN', [20], 'Found unused symbol Foobar.')->toPhpcsJson());
-		$options = [];
+		$options = ['no-cache-git-root' => 1];
 		$cache = new CacheManager( new TestCache() );
 		runGitWorkflow([$gitFile], $options, $shell, $cache, '\PhpcsChangedTests\Debug');
 	}
@@ -268,7 +273,7 @@ final class GitWorkflowTest extends TestCase {
 		$shell->registerCommand("git status --porcelain 'foobar.php'", $this->fixture->getNewFileInfo('foobar.php'));
 		$shell->registerCommand("git show :0:$(git ls-files --full-name 'foobar.php')", $this->phpcs->getResults('STDIN', [5, 6], 'Found unused symbol Foobar.')->toPhpcsJson());
 		$shell->registerCommand("git rev-parse --show-toplevel", 'run-from-git-root');
-		$options = [];
+		$options = ['no-cache-git-root' => 1];
 		$cache = new CacheManager( new TestCache() );
 		$expected = $this->phpcs->getResults('foobar.php', [5, 6], 'Found unused symbol Foobar.');
 		$messages = runGitWorkflow([$gitFile], $options, $shell, $cache, '\PhpcsChangedTests\Debug');
@@ -288,7 +293,7 @@ Run "phpcs --help" for usage information
 ';
 		$shell->registerCommand("git show :0:$(git ls-files --full-name 'foobar.php')", $fixture, 1);
 
-		$options = [];
+		$options = ['no-cache-git-root' => 1];
 		$cache = new CacheManager( new TestCache() );
 		$expected = PhpcsMessages::fromArrays([], '/dev/null');
 		$messages = runGitWorkflow([$gitFile], $options, $shell, $cache, '\PhpcsChangedTests\Debug');
@@ -308,7 +313,7 @@ Run "phpcs --help" for usage information
 		$shell->registerCommand("git show HEAD:$(git ls-files --full-name 'bin/foobar.php') | phpcs --report=json -q --stdin-path='bin/foobar.php' -", $this->phpcs->getResults('\/srv\/www\/wordpress-default\/public_html\/test\/bin\/foobar.php', [6, 7], 'Found unused symbol Foobar.')->toPhpcsJson());
 		$shell->registerCommand("git show HEAD:$(git ls-files --full-name 'bin/foobar.php') | git hash-object --stdin", 'new-file-hash');
 		$shell->registerCommand("git rev-parse --show-toplevel", 'run-from-git-root');
-		$options = [ 'git-base' => 'master' ];
+		$options = ['no-cache-git-root' => 1, 'git-base' => 'master'];
 		$cache = new CacheManager( new TestCache() );
 		$expected = $this->phpcs->getResults('bin/foobar.php', [6], 'Found unused symbol Foobar.');
 		$messages = runGitWorkflow([$gitFile], $options, $shell, $cache, '\PhpcsChangedTests\Debug');
@@ -328,7 +333,7 @@ Run "phpcs --help" for usage information
 		$shell->registerCommand("git show '0123456789abcdef0123456789abcdef01234567':$(git ls-files --full-name 'test.php') | git hash-object --stdin", 'previous-file-hash');
 		$shell->registerCommand("git show HEAD:$(git ls-files --full-name 'test.php') | git hash-object --stdin", 'new-file-hash');
 		$shell->registerCommand("git rev-parse --show-toplevel", 'run-from-git-root');
-		$options = [ 'git-base' => 'master' ];
+		$options = ['no-cache-git-root' => 1, 'git-base' => 'master'];
 		$cache = new CacheManager( new TestCache() );
 		$expected = PhpcsMessages::merge([
 			$this->phpcs->getResults('test.php', [6], "Found unused symbol 'Foobar'."),

--- a/tests/GitWorkflowTest.php
+++ b/tests/GitWorkflowTest.php
@@ -225,6 +225,7 @@ final class GitWorkflowTest extends TestCase {
 		$shell->registerCommand("git status --porcelain 'foobar.php'", '');
 		$shell->registerCommand("git show HEAD:$(git ls-files --full-name 'foobar.php')", $this->phpcs->getResults('STDIN', [20])->toPhpcsJson());
 		$shell->registerCommand("git show :0:$(git ls-files --full-name 'foobar.php')", $this->phpcs->getResults('STDIN', [20])->toPhpcsJson());
+		$shell->registerCommand("git rev-parse --show-toplevel", 'run-from-git-root');
 		$options = [];
 		$cache = new CacheManager( new TestCache() );
 		$expected = PhpcsMessages::fromArrays([], '/dev/null');

--- a/tests/GitWorkflowTest.php
+++ b/tests/GitWorkflowTest.php
@@ -236,8 +236,6 @@ final class GitWorkflowTest extends TestCase {
 	public function testFullGitWorkflowForUnchangedFileWithoutPhpcsMessages() {
 		$gitFile = 'foobar.php';
 		$shell = new TestShell([$gitFile]);
-		$fixture = $this->fixture->getEmptyFileDiff();
-		$shell->registerCommand("git diff --staged --no-prefix 'foobar.php'", $fixture);
 		$shell->registerCommand("git status --porcelain 'foobar.php'", '');
 		$shell->registerCommand("git show HEAD:$(git ls-files --full-name 'foobar.php')", $this->phpcs->getResults('STDIN', [])->toPhpcsJson());
 		$shell->registerCommand("git show :0:$(git ls-files --full-name 'foobar.php')", $this->phpcs->getResults('STDIN', [])->toPhpcsJson());

--- a/tests/SvnWorkflowTest.php
+++ b/tests/SvnWorkflowTest.php
@@ -102,7 +102,7 @@ final class SvnWorkflowTest extends TestCase {
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 
-	public function testFullSvnWorkflowForOneFileCached() {
+	public function testFullSvnWorkflowForOneFileWithOldFileCached() {
 		$svnFile = 'foobar.php';
 		$shell = new TestShell([$svnFile]);
 		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
@@ -357,7 +357,7 @@ final class SvnWorkflowTest extends TestCase {
 		$this->assertFalse($shell->wasCommandCalled("cat 'foobar.php'"));
 	}
 
-	public function testFullSvnWorkflowForUnchangedFileWithCache() {
+	public function testFullSvnWorkflowForUnchangedFileWithBothFilesCached() {
 		$svnFile = 'foobar.php';
 		$shell = new TestShell([$svnFile]);
 		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getEmptyFileDiff());
@@ -374,6 +374,24 @@ final class SvnWorkflowTest extends TestCase {
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 		$this->assertFalse($shell->wasCommandCalled("svn cat 'foobar.php'"));
 		$this->assertFalse($shell->wasCommandCalled("cat 'foobar.php'"));
+	}
+
+	public function testFullSvnWorkflowForUnchangedFileWithOldFileCached() {
+		$svnFile = 'foobar.php';
+		$shell = new TestShell([$svnFile]);
+		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getEmptyFileDiff());
+		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php', '188280'));
+		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
+		$options = [
+			'cache' => false, // getopt is weird and sets options to false
+		];
+		$expected = PhpcsMessages::fromArrays([], 'bin/foobar.php');
+		$cache = new TestCache();
+		$cache->setEntry('foobar.php', 'old', '188280', '', $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager($cache), '\PhpcsChangedTests\debug');
+		$this->assertEquals($expected->getMessages(), $messages->getMessages());
+		$this->assertFalse($shell->wasCommandCalled("svn cat 'foobar.php'"));
+		$this->assertTrue($shell->wasCommandCalled("cat 'foobar.php'"));
 	}
 
 	public function testFullSvnWorkflowForMultipleFiles() {

--- a/tests/SvnWorkflowTest.php
+++ b/tests/SvnWorkflowTest.php
@@ -453,6 +453,7 @@ final class SvnWorkflowTest extends TestCase {
 		runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
 		$this->assertFalse($shell->wasCommandCalled("svn diff 'foobar.php'"));
 		$this->assertFalse($shell->wasCommandCalled("svn cat 'foobar.php'"));
+		$this->assertFalse($shell->wasCommandCalled("svn info 'foobar.php'"));
 	}
 
 	public function testFullSvnWorkflowForNonSvnFile() {

--- a/tests/helpers/TestShell.php
+++ b/tests/helpers/TestShell.php
@@ -86,4 +86,9 @@ class TestShell implements ShellOperator {
 	public function wasCommandCalled(string $registeredCommand): bool {
 		return isset($this->commandsCalled[$registeredCommand]);
 	}
+
+	public function getFileNameFromPath(string $path): string {
+		$parts = explode('/', $path);
+		return end($parts);
+	}
 }


### PR DESCRIPTION
This is a follow-up to #51, which modifies the automatic mode workflows so that they do not run phpcs on the previous version of a file if the current version has no phpcs messages; in this PR we modify them further to also not generate a VCS diff of the file in that case.

Fixes https://github.com/sirbrillig/phpcs-changed/issues/53

To do:

- [x] Change git workflow
- [x] Change svn workflow
- [x] Clean up docs.