### PR TITLE
Use "unmodified" > "modified" terms

### DIFF
--- a/PhpcsChanged/CacheManager.php
+++ b/PhpcsChanged/CacheManager.php
@@ -12,7 +12,7 @@ class CacheManager {
 	 * A cache map with four levels of keys:
 	 *
 	 * 1. The file path
-	 * 2. The cache type; either 'new' (new version of a file) or 'old' (old version of a file)
+	 * 2. The cache type; either 'new' (modified version of a file) or 'old' (unmodified version of a file)
 	 * 3. The file hash (if needed; this is not used for old files)
 	 * 4. The phpcs standard
 	 *

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -239,26 +239,26 @@ function runSvnWorkflowForFile(string $svnFile, array $options, ShellOperator $s
 			throw new ShellException("Cannot read file '{$svnFile}'");
 		}
 
-		$changedFileHash = '';
-		$changedFilePhpcsOutput = null;
+		$modifiedFileHash = '';
+		$modifiedFilePhpcsOutput = null;
 		if (isCachingEnabled($options)) {
-			$changedFileHash = $shell->getFileHash($svnFile);
-			$changedFilePhpcsOutput = $cache->getCacheForFile($svnFile, 'new', $changedFileHash, $phpcsStandard ?? '');
+			$modifiedFileHash = $shell->getFileHash($svnFile);
+			$modifiedFilePhpcsOutput = $cache->getCacheForFile($svnFile, 'new', $modifiedFileHash, $phpcsStandard ?? '');
 		}
-		if ($changedFilePhpcsOutput) {
-			$debug("Using cache for changed file '{$svnFile}', hash '{$changedFileHash}', and standard '{$phpcsStandard}'");
+		if ($modifiedFilePhpcsOutput) {
+			$debug("Using cache for modified file '{$svnFile}', hash '{$modifiedFileHash}', and standard '{$phpcsStandard}'");
 		}
-		if (! $changedFilePhpcsOutput) {
-			$debug("Not using cache for changed file '{$svnFile}', hash '{$changedFileHash}', and standard '{$phpcsStandard}'");
-			$changedFilePhpcsOutput = getSvnModifiedPhpcsOutput($svnFile, $phpcs, $cat, $phpcsStandardOption, [$shell, 'executeCommand'], $debug);
+		if (! $modifiedFilePhpcsOutput) {
+			$debug("Not using cache for modified file '{$svnFile}', hash '{$modifiedFileHash}', and standard '{$phpcsStandard}'");
+			$modifiedFilePhpcsOutput = getSvnModifiedPhpcsOutput($svnFile, $phpcs, $cat, $phpcsStandardOption, [$shell, 'executeCommand'], $debug);
 			if (isCachingEnabled($options)) {
-				$cache->setCacheForFile($svnFile, 'new', $changedFileHash, $phpcsStandard ?? '', $changedFilePhpcsOutput);
+				$cache->setCacheForFile($svnFile, 'new', $modifiedFileHash, $phpcsStandard ?? '', $modifiedFilePhpcsOutput);
 			}
 		}
 
 		$fileName = $shell->getFileNameFromPath($svnFile);
-		$changedFilePhpcsMessages = PhpcsMessages::fromPhpcsJson($changedFilePhpcsOutput, $fileName);
-		$hasNewPhpcsMessages = !empty($changedFilePhpcsMessages->getMessages());
+		$modifiedFilePhpcsMessages = PhpcsMessages::fromPhpcsJson($modifiedFilePhpcsOutput, $fileName);
+		$hasNewPhpcsMessages = !empty($modifiedFilePhpcsMessages->getMessages());
 
 		if (! $hasNewPhpcsMessages) {
 			throw new NoChangesException("Modified file '{$svnFile}' has no PHPCS messages; skipping");
@@ -290,7 +290,7 @@ function runSvnWorkflowForFile(string $svnFile, array $options, ShellOperator $s
 		$debug($err->getMessage());
 		$unifiedDiff = '';
 		$unmodifiedFilePhpcsOutput = '';
-		$changedFilePhpcsMessages = PhpcsMessages::fromPhpcsJson('');
+		$modifiedFilePhpcsMessages = PhpcsMessages::fromPhpcsJson('');
 	} catch( \Exception $err ) {
 		$shell->printError($err->getMessage());
 		$shell->exitWithCode(1);
@@ -302,7 +302,7 @@ function runSvnWorkflowForFile(string $svnFile, array $options, ShellOperator $s
 	return getNewPhpcsMessages(
 		$unifiedDiff,
 		PhpcsMessages::fromPhpcsJson($unmodifiedFilePhpcsOutput, $fileName),
-		$changedFilePhpcsMessages
+		$modifiedFilePhpcsMessages
 	);
 }
 
@@ -348,27 +348,27 @@ function runGitWorkflowForFile(string $gitFile, array $options, ShellOperator $s
 	try {
 		validateGitFileExists($gitFile, $git, [$shell, 'isReadable'], [$shell, 'executeCommand'], $debug, $options);
 
-		$changedFilePhpcsOutput = null;
-		$changedFileHash = '';
+		$modifiedFilePhpcsOutput = null;
+		$modifiedFileHash = '';
 		if (isCachingEnabled($options)) {
-			$changedFileHash = getModifiedGitFileHash($gitFile, $git, $cat, [$shell, 'executeCommand'], $options, $debug);
-			$changedFilePhpcsOutput = $cache->getCacheForFile($gitFile, 'new', $changedFileHash, $phpcsStandard ?? '');
+			$modifiedFileHash = getModifiedGitFileHash($gitFile, $git, $cat, [$shell, 'executeCommand'], $options, $debug);
+			$modifiedFilePhpcsOutput = $cache->getCacheForFile($gitFile, 'new', $modifiedFileHash, $phpcsStandard ?? '');
 		}
-		if ($changedFilePhpcsOutput) {
-			$debug("Using cache for changed file '{$gitFile}' at hash '{$changedFileHash}', and standard '{$phpcsStandard}'");
+		if ($modifiedFilePhpcsOutput) {
+			$debug("Using cache for modified file '{$gitFile}' at hash '{$modifiedFileHash}', and standard '{$phpcsStandard}'");
 		}
-		if (! $changedFilePhpcsOutput) {
-			$debugMessage = (!empty($changedFileHash)) ? "Not using cache for changed file '{$gitFile}' at hash '{$changedFileHash}', and standard '{$phpcsStandard}'" : "Not using cache for changed file '{$gitFile}' with standard '{$phpcsStandard}'. No hash was calculated.";
+		if (! $modifiedFilePhpcsOutput) {
+			$debugMessage = (!empty($modifiedFileHash)) ? "Not using cache for modified file '{$gitFile}' at hash '{$modifiedFileHash}', and standard '{$phpcsStandard}'" : "Not using cache for modified file '{$gitFile}' with standard '{$phpcsStandard}'. No hash was calculated.";
 			$debug($debugMessage);
-			$changedFilePhpcsOutput = getGitModifiedPhpcsOutput($gitFile, $git, $phpcs, $cat, $phpcsStandardOption, [$shell, 'executeCommand'], $options, $debug);
+			$modifiedFilePhpcsOutput = getGitModifiedPhpcsOutput($gitFile, $git, $phpcs, $cat, $phpcsStandardOption, [$shell, 'executeCommand'], $options, $debug);
 			if (isCachingEnabled($options)) {
-				$cache->setCacheForFile($gitFile, 'new', $changedFileHash, $phpcsStandard ?? '', $changedFilePhpcsOutput);
+				$cache->setCacheForFile($gitFile, 'new', $modifiedFileHash, $phpcsStandard ?? '', $modifiedFilePhpcsOutput);
 			}
 		}
 
 		$fileName = $shell->getFileNameFromPath($gitFile);
-		$changedFilePhpcsMessages = PhpcsMessages::fromPhpcsJson($changedFilePhpcsOutput, $fileName);
-		$hasNewPhpcsMessages = !empty($changedFilePhpcsMessages->getMessages());
+		$modifiedFilePhpcsMessages = PhpcsMessages::fromPhpcsJson($modifiedFilePhpcsOutput, $fileName);
+		$hasNewPhpcsMessages = !empty($modifiedFilePhpcsMessages->getMessages());
 
 		$unifiedDiff = '';
 		$unmodifiedFilePhpcsOutput = '';
@@ -393,7 +393,7 @@ function runGitWorkflowForFile(string $gitFile, array $options, ShellOperator $s
 				$debug("Using cache for unmodified file '{$gitFile}' at hash '{$unmodifiedFileHash}' with standard '{$phpcsStandard}'");
 			}
 			if (! $unmodifiedFilePhpcsOutput) {
-				$debugMessage = (!empty($unmodifiedFileHash)) ? "Not using cache for changed file '{$gitFile}' at hash '{$unmodifiedFileHash}', and standard '{$phpcsStandard}'" : "Not using cache for changed file '{$gitFile}' with standard '{$phpcsStandard}'. No hash was calculated.";
+				$debugMessage = (!empty($unmodifiedFileHash)) ? "Not using cache for modified file '{$gitFile}' at hash '{$unmodifiedFileHash}', and standard '{$phpcsStandard}'" : "Not using cache for modified file '{$gitFile}' with standard '{$phpcsStandard}'. No hash was calculated.";
 				$debug($debugMessage);
 				$unmodifiedFilePhpcsOutput = getGitUnmodifiedPhpcsOutput($gitFile, $git, $phpcs, $phpcsStandardOption, [$shell, 'executeCommand'], $options, $debug);
 				if (isCachingEnabled($options)) {
@@ -405,7 +405,7 @@ function runGitWorkflowForFile(string $gitFile, array $options, ShellOperator $s
 		$debug($err->getMessage());
 		$unifiedDiff = '';
 		$unmodifiedFilePhpcsOutput = '';
-		$changedFilePhpcsMessages = PhpcsMessages::fromPhpcsJson('');
+		$modifiedFilePhpcsMessages = PhpcsMessages::fromPhpcsJson('');
 	} catch(\Exception $err) {
 		$shell->printError($err->getMessage());
 		$shell->exitWithCode(1);
@@ -414,7 +414,7 @@ function runGitWorkflowForFile(string $gitFile, array $options, ShellOperator $s
 
 	$debug('processing data...');
 	$fileName = $fileName ?? DiffLineMap::getFileNameFromDiff($unifiedDiff);
-	return getNewPhpcsMessages($unifiedDiff, PhpcsMessages::fromPhpcsJson($unmodifiedFilePhpcsOutput, $fileName), $changedFilePhpcsMessages);
+	return getNewPhpcsMessages($unifiedDiff, PhpcsMessages::fromPhpcsJson($unmodifiedFilePhpcsOutput, $fileName), $modifiedFilePhpcsMessages);
 }
 
 function reportMessagesAndExit(PhpcsMessages $messages, string $reportType, array $options): void {

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -270,7 +270,7 @@ function runSvnWorkflowForFile(string $svnFile, array $options, ShellOperator $s
 		$revisionId = getSvnRevisionId($svnFileInfo);
 		$isNewFile = isNewSvnFile($svnFileInfo);
 		if ($isNewFile) {
-			$debug('Skipping the linting of the unmodified file version as it is a new file.');
+			$debug('Skipping the linting of the unmodified file as it is a new file.');
 		}
 		$unmodifiedFilePhpcsOutput = '';
 		if (! $isNewFile) {
@@ -378,10 +378,10 @@ function runGitWorkflowForFile(string $gitFile, array $options, ShellOperator $s
 
 		$isNewFile = isNewGitFile($gitFile, $git, [$shell, 'executeCommand'], $options, $debug);
 		if ($isNewFile) {
-			$debug('Skipping the linting of the unmodified file version as it is a new file.');
+			$debug('Skipping the linting of the unmodified file as it is a new file.');
 		}
 		if (! $isNewFile) {
-			$debug('Checking the unmodified file version with PHPCS since the file is not new and contains some messages.');
+			$debug('Checking the unmodified file with PHPCS since the file is not new and contains some messages.');
 			$unifiedDiff = getGitUnifiedDiff($gitFile, $git, [$shell, 'executeCommand'], $options, $debug);
 			$unmodifiedFilePhpcsOutput = null;
 			$unmodifiedFileHash = '';

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -98,8 +98,8 @@ EOF;
 		'--diff <FILE>' => 'A file containing a unified diff of the changes.',
 		'--phpcs-orig <FILE>' => 'A file containing the JSON output of phpcs on the unchanged file (alias for --phpcs-unmodified).',
 		'--phpcs-unmodified <FILE>' => 'A file containing the JSON output of phpcs on the unchanged file.',
-		'--phpcs-new <FILE>' => 'A file containing the JSON output of phpcs on the changed file (alias for --phpcs-changed).',
-		'--phpcs-changed <FILE>' => 'A file containing the JSON output of phpcs on the changed file.',
+		'--phpcs-new <FILE>' => 'A file containing the JSON output of phpcs on the changed file (alias for --phpcs-modified).',
+		'--phpcs-modified <FILE>' => 'A file containing the JSON output of phpcs on the changed file.',
 	], "	");
 
 	echo <<<EOF

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -96,8 +96,10 @@ EOF;
 
 	printTwoColumns([
 		'--diff <FILE>' => 'A file containing a unified diff of the changes.',
-		'--phpcs-orig <FILE>' => 'A file containing the JSON output of phpcs on the unchanged file.',
-		'--phpcs-new <FILE>' => 'A file containing the JSON output of phpcs on the changed file.',
+		'--phpcs-orig <FILE>' => 'A file containing the JSON output of phpcs on the unchanged file (alias for --phpcs-previous).',
+		'--phpcs-previous <FILE>' => 'A file containing the JSON output of phpcs on the unchanged file.',
+		'--phpcs-new <FILE>' => 'A file containing the JSON output of phpcs on the changed file (alias for --phpcs-changed).',
+		'--phpcs-changed <FILE>' => 'A file containing the JSON output of phpcs on the changed file.',
 	], "	");
 
 	echo <<<EOF

--- a/PhpcsChanged/GitWorkflow.php
+++ b/PhpcsChanged/GitWorkflow.php
@@ -104,33 +104,33 @@ function isNewGitFileLocal(string $gitFile, string $git, callable $executeComman
 }
 
 function getGitBasePhpcsOutput(string $gitFile, string $git, string $phpcs, string $phpcsStandardOption, callable $executeCommand, array $options, callable $debug): string {
-	$oldFileContents = getOldGitRevisionContentsCommand($gitFile, $git, $options, $executeCommand, $debug);
+	$previousFileContents = getOldGitRevisionContentsCommand($gitFile, $git, $options, $executeCommand, $debug);
 
-	$oldFilePhpcsOutputCommand = "{$oldFileContents} | {$phpcs} --report=json -q" . $phpcsStandardOption . ' --stdin-path=' .  escapeshellarg($gitFile) . ' -';
-	$debug('running orig phpcs command:', $oldFilePhpcsOutputCommand);
-	$oldFilePhpcsOutput = $executeCommand($oldFilePhpcsOutputCommand);
-	if (! $oldFilePhpcsOutput) {
-		throw new ShellException("Cannot get old phpcs output for file '{$gitFile}'");
+	$previousFilePhpcsOutputCommand = "{$previousFileContents} | {$phpcs} --report=json -q" . $phpcsStandardOption . ' --stdin-path=' .  escapeshellarg($gitFile) . ' -';
+	$debug('running previous file phpcs command:', $previousFilePhpcsOutputCommand);
+	$previousFilePhpcsOutput = $executeCommand($previousFilePhpcsOutputCommand);
+	if (! $previousFilePhpcsOutput) {
+		throw new ShellException("Cannot get previous file phpcs output for file '{$gitFile}'");
 	}
-	$debug('orig phpcs command output:', $oldFilePhpcsOutput);
-	return $oldFilePhpcsOutput;
+	$debug('previous file phpcs command output:', $previousFilePhpcsOutput);
+	return $previousFilePhpcsOutput;
 }
 
 function getGitNewPhpcsOutput(string $gitFile, string $git, string $phpcs, string $cat, string $phpcsStandardOption, callable $executeCommand, array $options, callable $debug): string {
-	$newFileContents = getNewGitRevisionContentsCommand($gitFile, $git, $cat, $options, $executeCommand, $debug);
+	$changedFileContents = getNewGitRevisionContentsCommand($gitFile, $git, $cat, $options, $executeCommand, $debug);
 
-	$newFilePhpcsOutputCommand = "{$newFileContents} | {$phpcs} --report=json -q" . $phpcsStandardOption . ' --stdin-path=' .  escapeshellarg($gitFile) .' -';
-	$debug('running new phpcs command:', $newFilePhpcsOutputCommand);
-	$newFilePhpcsOutput = $executeCommand($newFilePhpcsOutputCommand);
-	if (! $newFilePhpcsOutput) {
-		throw new ShellException("Cannot get new phpcs output for file '{$gitFile}'");
+	$changedFilePhpcsOutputCommand = "{$changedFileContents} | {$phpcs} --report=json -q" . $phpcsStandardOption . ' --stdin-path=' .  escapeshellarg($gitFile) .' -';
+	$debug('running changed file phpcs command:', $changedFilePhpcsOutputCommand);
+	$changedFilePhpcsOutput = $executeCommand($changedFilePhpcsOutputCommand);
+	if (! $changedFilePhpcsOutput) {
+		throw new ShellException("Cannot get changed file phpcs output for file '{$gitFile}'");
 	}
-	$debug('new phpcs command output:', $newFilePhpcsOutput);
-	if (false !== strpos($newFilePhpcsOutput, 'You must supply at least one file or directory to process')) {
-		$debug('phpcs output implies file is empty');
+	$debug('changed file phpcs command output:', $changedFilePhpcsOutput);
+	if (false !== strpos($changedFilePhpcsOutput, 'You must supply at least one file or directory to process')) {
+		$debug('phpcs output implies changed file is empty');
 		return '';
 	}
-	return $newFilePhpcsOutput;
+	return $changedFilePhpcsOutput;
 }
 
 function getNewGitRevisionContentsCommand(string $gitFile, string $git, string $cat, array $options, callable $executeCommand, callable $debug): string {
@@ -171,23 +171,23 @@ function getOldGitRevisionContentsCommand(string $gitFile, string $git, array $o
 function getNewGitFileHash(string $gitFile, string $git, string $cat, callable $executeCommand, array $options, callable $debug): string {
 	$fileContents = getNewGitRevisionContentsCommand($gitFile, $git, $cat, $options, $executeCommand, $debug);
 	$command = "{$fileContents} | {$git} hash-object --stdin";
-	$debug('running new file git hash command:', $command);
+	$debug('running changed file git hash command:', $command);
 	$hash = $executeCommand($command);
 	if (! $hash) {
-		throw new ShellException("Cannot get new file hash for file '{$gitFile}'");
+		throw new ShellException("Cannot get changed file hash for file '{$gitFile}'");
 	}
-	$debug('new file git hash command output:', $hash);
+	$debug('changed file git hash command output:', $hash);
 	return $hash;
 }
 
 function getOldGitFileHash(string $gitFile, string $git, string $cat, callable $executeCommand, array $options, callable $debug): string {
 	$fileContents = getOldGitRevisionContentsCommand($gitFile, $git, $options, $executeCommand, $debug);
 	$command = "{$fileContents} | {$git} hash-object --stdin";
-	$debug('running old file git hash command:', $command);
+	$debug('running previous file git hash command:', $command);
 	$hash = $executeCommand($command);
 	if (! $hash) {
-		throw new ShellException("Cannot get old file hash for file '{$gitFile}'");
+		throw new ShellException("Cannot get previous file hash for file '{$gitFile}'");
 	}
-	$debug('old file git hash command output:', $hash);
+	$debug('previous file git hash command output:', $hash);
 	return $hash;
 }

--- a/PhpcsChanged/GitWorkflow.php
+++ b/PhpcsChanged/GitWorkflow.php
@@ -103,8 +103,8 @@ function isNewGitFileLocal(string $gitFile, string $git, callable $executeComman
 	return isset($gitStatusOutput[0]) && $gitStatusOutput[0] === 'A';
 }
 
-function getGitBasePhpcsOutput(string $gitFile, string $git, string $phpcs, string $phpcsStandardOption, callable $executeCommand, array $options, callable $debug): string {
-	$previousFileContents = getOldGitRevisionContentsCommand($gitFile, $git, $options, $executeCommand, $debug);
+function getGitPreviousPhpcsOutput(string $gitFile, string $git, string $phpcs, string $phpcsStandardOption, callable $executeCommand, array $options, callable $debug): string {
+	$previousFileContents = getPerviousGitRevisionContentsCommand($gitFile, $git, $options, $executeCommand, $debug);
 
 	$previousFilePhpcsOutputCommand = "{$previousFileContents} | {$phpcs} --report=json -q" . $phpcsStandardOption . ' --stdin-path=' .  escapeshellarg($gitFile) . ' -';
 	$debug('running previous file phpcs command:', $previousFilePhpcsOutputCommand);
@@ -116,8 +116,8 @@ function getGitBasePhpcsOutput(string $gitFile, string $git, string $phpcs, stri
 	return $previousFilePhpcsOutput;
 }
 
-function getGitNewPhpcsOutput(string $gitFile, string $git, string $phpcs, string $cat, string $phpcsStandardOption, callable $executeCommand, array $options, callable $debug): string {
-	$changedFileContents = getNewGitRevisionContentsCommand($gitFile, $git, $cat, $options, $executeCommand, $debug);
+function getGitChangedPhpcsOutput(string $gitFile, string $git, string $phpcs, string $cat, string $phpcsStandardOption, callable $executeCommand, array $options, callable $debug): string {
+	$changedFileContents = getChangedGitRevisionContentsCommand($gitFile, $git, $cat, $options, $executeCommand, $debug);
 
 	$changedFilePhpcsOutputCommand = "{$changedFileContents} | {$phpcs} --report=json -q" . $phpcsStandardOption . ' --stdin-path=' .  escapeshellarg($gitFile) .' -';
 	$debug('running changed file phpcs command:', $changedFilePhpcsOutputCommand);
@@ -133,7 +133,7 @@ function getGitNewPhpcsOutput(string $gitFile, string $git, string $phpcs, strin
 	return $changedFilePhpcsOutput;
 }
 
-function getNewGitRevisionContentsCommand(string $gitFile, string $git, string $cat, array $options, callable $executeCommand, callable $debug): string {
+function getChangedGitRevisionContentsCommand(string $gitFile, string $git, string $cat, array $options, callable $executeCommand, callable $debug): string {
 	if (isset($options['git-base']) && ! empty($options['git-base'])) {
 		// for git-base mode, we get the contents of the file from the HEAD version of the file in the current branch
 		if (isRunFromGitRoot($git, $executeCommand, $options, $debug)) {
@@ -151,7 +151,7 @@ function getNewGitRevisionContentsCommand(string $gitFile, string $git, string $
 	return "{$git} show :0:$(${git} ls-files --full-name " . escapeshellarg($gitFile) . ')';
 }
 
-function getOldGitRevisionContentsCommand(string $gitFile, string $git, array $options, callable $executeCommand, callable $debug): string {
+function getPerviousGitRevisionContentsCommand(string $gitFile, string $git, array $options, callable $executeCommand, callable $debug): string {
 	if (isset($options['git-base']) && ! empty($options['git-base'])) {
 		// git-base
 		$rev = escapeshellarg($options['git-base']);
@@ -168,8 +168,8 @@ function getOldGitRevisionContentsCommand(string $gitFile, string $git, array $o
 	return "${git} show {$rev}:$(${git} ls-files --full-name " . escapeshellarg($gitFile) . ")";
 }
 
-function getNewGitFileHash(string $gitFile, string $git, string $cat, callable $executeCommand, array $options, callable $debug): string {
-	$fileContents = getNewGitRevisionContentsCommand($gitFile, $git, $cat, $options, $executeCommand, $debug);
+function getChangedGitFileHash(string $gitFile, string $git, string $cat, callable $executeCommand, array $options, callable $debug): string {
+	$fileContents = getChangedGitRevisionContentsCommand($gitFile, $git, $cat, $options, $executeCommand, $debug);
 	$command = "{$fileContents} | {$git} hash-object --stdin";
 	$debug('running changed file git hash command:', $command);
 	$hash = $executeCommand($command);
@@ -180,8 +180,8 @@ function getNewGitFileHash(string $gitFile, string $git, string $cat, callable $
 	return $hash;
 }
 
-function getOldGitFileHash(string $gitFile, string $git, string $cat, callable $executeCommand, array $options, callable $debug): string {
-	$fileContents = getOldGitRevisionContentsCommand($gitFile, $git, $options, $executeCommand, $debug);
+function getPreviousGitFileHash(string $gitFile, string $git, string $cat, callable $executeCommand, array $options, callable $debug): string {
+	$fileContents = getPerviousGitRevisionContentsCommand($gitFile, $git, $options, $executeCommand, $debug);
 	$command = "{$fileContents} | {$git} hash-object --stdin";
 	$debug('running previous file git hash command:', $command);
 	$hash = $executeCommand($command);

--- a/PhpcsChanged/GitWorkflow.php
+++ b/PhpcsChanged/GitWorkflow.php
@@ -104,7 +104,7 @@ function isNewGitFileLocal(string $gitFile, string $git, callable $executeComman
 }
 
 function getGitUnmodifiedPhpcsOutput(string $gitFile, string $git, string $phpcs, string $phpcsStandardOption, callable $executeCommand, array $options, callable $debug): string {
-	$unmodifiedFileContents = getPerviousGitRevisionContentsCommand($gitFile, $git, $options, $executeCommand, $debug);
+	$unmodifiedFileContents = getUnmodifiedGitRevisionContentsCommand($gitFile, $git, $options, $executeCommand, $debug);
 
 	$unmodifiedFilePhpcsOutputCommand = "{$unmodifiedFileContents} | {$phpcs} --report=json -q" . $phpcsStandardOption . ' --stdin-path=' .  escapeshellarg($gitFile) . ' -';
 	$debug('running unmodified file phpcs command:', $unmodifiedFilePhpcsOutputCommand);
@@ -151,7 +151,7 @@ function getModifiedGitRevisionContentsCommand(string $gitFile, string $git, str
 	return "{$git} show :0:$(${git} ls-files --full-name " . escapeshellarg($gitFile) . ')';
 }
 
-function getPerviousGitRevisionContentsCommand(string $gitFile, string $git, array $options, callable $executeCommand, callable $debug): string {
+function getUnmodifiedGitRevisionContentsCommand(string $gitFile, string $git, array $options, callable $executeCommand, callable $debug): string {
 	if (isset($options['git-base']) && ! empty($options['git-base'])) {
 		// git-base
 		$rev = escapeshellarg($options['git-base']);
@@ -181,7 +181,7 @@ function getModifiedGitFileHash(string $gitFile, string $git, string $cat, calla
 }
 
 function getUnmodifiedGitFileHash(string $gitFile, string $git, string $cat, callable $executeCommand, array $options, callable $debug): string {
-	$fileContents = getPerviousGitRevisionContentsCommand($gitFile, $git, $options, $executeCommand, $debug);
+	$fileContents = getUnmodifiedGitRevisionContentsCommand($gitFile, $git, $options, $executeCommand, $debug);
 	$command = "{$fileContents} | {$git} hash-object --stdin";
 	$debug('running unmodified file git hash command:', $command);
 	$hash = $executeCommand($command);

--- a/PhpcsChanged/LintMessages.php
+++ b/PhpcsChanged/LintMessages.php
@@ -61,19 +61,19 @@ class LintMessages {
 	/**
 	 * @return static
 	 */
-	public static function getNewMessages(string $unifiedDiff, self $oldMessages, self $newMessages) {
+	public static function getNewMessages(string $unifiedDiff, self $previousMessages, self $changedMessages) {
 		$map = DiffLineMap::fromUnifiedDiff($unifiedDiff);
 		$fileName = DiffLineMap::getFileNameFromDiff($unifiedDiff);
-		return self::fromLintMessages(array_values(array_filter($newMessages->getMessages(), function($newMessage) use ($oldMessages, $map) {
+		return self::fromLintMessages(array_values(array_filter($changedMessages->getMessages(), function($newMessage) use ($previousMessages, $map) {
 			$lineNumber = $newMessage->getLineNumber();
 			if (! $lineNumber) {
 				return true;
 			}
-			$oldLineNumber = $map->getOldLineNumberForLine($lineNumber);
-			$oldMessagesContainingOldLineNumber = array_values(array_filter($oldMessages->getMessages(), function($oldMessage) use ($oldLineNumber) {
-				return $oldMessage->getLineNumber() === $oldLineNumber;
+			$previousLineNumber = $map->getOldLineNumberForLine($lineNumber);
+			$previousMessagesContainingPreviousLineNumber = array_values(array_filter($previousMessages->getMessages(), function($previousMessage) use ($previousLineNumber) {
+				return $previousMessage->getLineNumber() === $previousLineNumber;
 			}));
-			return ! count($oldMessagesContainingOldLineNumber) > 0;
+			return ! count($previousMessagesContainingPreviousLineNumber) > 0;
 		})), $fileName);
 	}
 }

--- a/PhpcsChanged/LintMessages.php
+++ b/PhpcsChanged/LintMessages.php
@@ -61,19 +61,19 @@ class LintMessages {
 	/**
 	 * @return static
 	 */
-	public static function getNewMessages(string $unifiedDiff, self $previousMessages, self $changedMessages) {
+	public static function getNewMessages(string $unifiedDiff, self $unmodifiedMessages, self $modifiedMessages) {
 		$map = DiffLineMap::fromUnifiedDiff($unifiedDiff);
 		$fileName = DiffLineMap::getFileNameFromDiff($unifiedDiff);
-		return self::fromLintMessages(array_values(array_filter($changedMessages->getMessages(), function($newMessage) use ($previousMessages, $map) {
+		return self::fromLintMessages(array_values(array_filter($modifiedMessages->getMessages(), function($newMessage) use ($unmodifiedMessages, $map) {
 			$lineNumber = $newMessage->getLineNumber();
 			if (! $lineNumber) {
 				return true;
 			}
-			$previousLineNumber = $map->getOldLineNumberForLine($lineNumber);
-			$previousMessagesContainingPreviousLineNumber = array_values(array_filter($previousMessages->getMessages(), function($previousMessage) use ($previousLineNumber) {
-				return $previousMessage->getLineNumber() === $previousLineNumber;
+			$unmodifiedLineNumber = $map->getOldLineNumberForLine($lineNumber);
+			$unmodifiedMessagesContainingUnmodifiedLineNumber = array_values(array_filter($unmodifiedMessages->getMessages(), function($unmodifiedMessage) use ($unmodifiedLineNumber) {
+				return $unmodifiedMessage->getLineNumber() === $unmodifiedLineNumber;
 			}));
-			return ! count($previousMessagesContainingPreviousLineNumber) > 0;
+			return ! count($unmodifiedMessagesContainingUnmodifiedLineNumber) > 0;
 		})), $fileName);
 	}
 }

--- a/PhpcsChanged/SvnWorkflow.php
+++ b/PhpcsChanged/SvnWorkflow.php
@@ -43,27 +43,27 @@ function getSvnRevisionId(string $svnFileInfo): string {
 }
 
 function getSvnBasePhpcsOutput(string $svnFile, string $svn, string $phpcs, string $phpcsStandardOption, callable $executeCommand, callable $debug): string {
-	$oldFilePhpcsOutputCommand = "${svn} cat " . escapeshellarg($svnFile) . " | {$phpcs} --report=json -q" . $phpcsStandardOption . ' --stdin-path=' .  escapeshellarg($svnFile) . ' -';
-	$debug('running orig phpcs command:', $oldFilePhpcsOutputCommand);
-	$oldFilePhpcsOutput = $executeCommand($oldFilePhpcsOutputCommand);
-	if (! $oldFilePhpcsOutput) {
-		throw new ShellException("Cannot get old phpcs output for file '{$svnFile}'");
+	$previousFilePhpcsOutputCommand = "${svn} cat " . escapeshellarg($svnFile) . " | {$phpcs} --report=json -q" . $phpcsStandardOption . ' --stdin-path=' .  escapeshellarg($svnFile) . ' -';
+	$debug('running previous file phpcs command:', $previousFilePhpcsOutputCommand);
+	$previousFilePhpcsOutput = $executeCommand($previousFilePhpcsOutputCommand);
+	if (! $previousFilePhpcsOutput) {
+		throw new ShellException("Cannot get previous file phpcs output for file '{$svnFile}'");
 	}
-	$debug('orig phpcs command output:', $oldFilePhpcsOutput);
-	return $oldFilePhpcsOutput;
+	$debug('previous file phpcs command output:', $previousFilePhpcsOutput);
+	return $previousFilePhpcsOutput;
 }
 
 function getSvnNewPhpcsOutput(string $svnFile, string $phpcs, string $cat, string $phpcsStandardOption, callable $executeCommand, callable $debug): string {
-	$newFilePhpcsOutputCommand = "{$cat} " . escapeshellarg($svnFile) . " | {$phpcs} --report=json -q" . $phpcsStandardOption . ' --stdin-path=' .  escapeshellarg($svnFile) . ' -';
-	$debug('running new phpcs command:', $newFilePhpcsOutputCommand);
-	$newFilePhpcsOutput = $executeCommand($newFilePhpcsOutputCommand);
-	if (! $newFilePhpcsOutput) {
-		throw new ShellException("Cannot get new phpcs output for file '{$svnFile}'");
+	$changedFilePhpcsOutputCommand = "{$cat} " . escapeshellarg($svnFile) . " | {$phpcs} --report=json -q" . $phpcsStandardOption . ' --stdin-path=' .  escapeshellarg($svnFile) . ' -';
+	$debug('running changed file phpcs command:', $changedFilePhpcsOutputCommand);
+	$changedFilePhpcsOutput = $executeCommand($changedFilePhpcsOutputCommand);
+	if (! $changedFilePhpcsOutput) {
+		throw new ShellException("Cannot get changed file phpcs output for file '{$svnFile}'");
 	}
-	$debug('new phpcs command output:', $newFilePhpcsOutput);
-	if (false !== strpos($newFilePhpcsOutput, 'You must supply at least one file or directory to process')) {
-		$debug('phpcs output implies file is empty');
+	$debug('changed file phpcs command output:', $changedFilePhpcsOutput);
+	if (false !== strpos($changedFilePhpcsOutput, 'You must supply at least one file or directory to process')) {
+		$debug('phpcs output implies changed file is empty');
 		return '';
 	}
-	return $newFilePhpcsOutput;
+	return $changedFilePhpcsOutput;
 }

--- a/PhpcsChanged/SvnWorkflow.php
+++ b/PhpcsChanged/SvnWorkflow.php
@@ -42,7 +42,7 @@ function getSvnRevisionId(string $svnFileInfo): string {
 	return $version;
 }
 
-function getSvnBasePhpcsOutput(string $svnFile, string $svn, string $phpcs, string $phpcsStandardOption, callable $executeCommand, callable $debug): string {
+function getSvnPreviousPhpcsOutput(string $svnFile, string $svn, string $phpcs, string $phpcsStandardOption, callable $executeCommand, callable $debug): string {
 	$previousFilePhpcsOutputCommand = "${svn} cat " . escapeshellarg($svnFile) . " | {$phpcs} --report=json -q" . $phpcsStandardOption . ' --stdin-path=' .  escapeshellarg($svnFile) . ' -';
 	$debug('running previous file phpcs command:', $previousFilePhpcsOutputCommand);
 	$previousFilePhpcsOutput = $executeCommand($previousFilePhpcsOutputCommand);
@@ -53,7 +53,7 @@ function getSvnBasePhpcsOutput(string $svnFile, string $svn, string $phpcs, stri
 	return $previousFilePhpcsOutput;
 }
 
-function getSvnNewPhpcsOutput(string $svnFile, string $phpcs, string $cat, string $phpcsStandardOption, callable $executeCommand, callable $debug): string {
+function getSvnChangedPhpcsOutput(string $svnFile, string $phpcs, string $cat, string $phpcsStandardOption, callable $executeCommand, callable $debug): string {
 	$changedFilePhpcsOutputCommand = "{$cat} " . escapeshellarg($svnFile) . " | {$phpcs} --report=json -q" . $phpcsStandardOption . ' --stdin-path=' .  escapeshellarg($svnFile) . ' -';
 	$debug('running changed file phpcs command:', $changedFilePhpcsOutputCommand);
 	$changedFilePhpcsOutput = $executeCommand($changedFilePhpcsOutputCommand);

--- a/PhpcsChanged/SvnWorkflow.php
+++ b/PhpcsChanged/SvnWorkflow.php
@@ -42,28 +42,28 @@ function getSvnRevisionId(string $svnFileInfo): string {
 	return $version;
 }
 
-function getSvnPreviousPhpcsOutput(string $svnFile, string $svn, string $phpcs, string $phpcsStandardOption, callable $executeCommand, callable $debug): string {
-	$previousFilePhpcsOutputCommand = "${svn} cat " . escapeshellarg($svnFile) . " | {$phpcs} --report=json -q" . $phpcsStandardOption . ' --stdin-path=' .  escapeshellarg($svnFile) . ' -';
-	$debug('running previous file phpcs command:', $previousFilePhpcsOutputCommand);
-	$previousFilePhpcsOutput = $executeCommand($previousFilePhpcsOutputCommand);
-	if (! $previousFilePhpcsOutput) {
-		throw new ShellException("Cannot get previous file phpcs output for file '{$svnFile}'");
+function getSvnUnmodifiedPhpcsOutput(string $svnFile, string $svn, string $phpcs, string $phpcsStandardOption, callable $executeCommand, callable $debug): string {
+	$unmodifiedFilePhpcsOutputCommand = "${svn} cat " . escapeshellarg($svnFile) . " | {$phpcs} --report=json -q" . $phpcsStandardOption . ' --stdin-path=' .  escapeshellarg($svnFile) . ' -';
+	$debug('running unmodified file phpcs command:', $unmodifiedFilePhpcsOutputCommand);
+	$unmodifiedFilePhpcsOutput = $executeCommand($unmodifiedFilePhpcsOutputCommand);
+	if (! $unmodifiedFilePhpcsOutput) {
+		throw new ShellException("Cannot get unmodified file phpcs output for file '{$svnFile}'");
 	}
-	$debug('previous file phpcs command output:', $previousFilePhpcsOutput);
-	return $previousFilePhpcsOutput;
+	$debug('unmodified file phpcs command output:', $unmodifiedFilePhpcsOutput);
+	return $unmodifiedFilePhpcsOutput;
 }
 
-function getSvnChangedPhpcsOutput(string $svnFile, string $phpcs, string $cat, string $phpcsStandardOption, callable $executeCommand, callable $debug): string {
-	$changedFilePhpcsOutputCommand = "{$cat} " . escapeshellarg($svnFile) . " | {$phpcs} --report=json -q" . $phpcsStandardOption . ' --stdin-path=' .  escapeshellarg($svnFile) . ' -';
-	$debug('running changed file phpcs command:', $changedFilePhpcsOutputCommand);
-	$changedFilePhpcsOutput = $executeCommand($changedFilePhpcsOutputCommand);
-	if (! $changedFilePhpcsOutput) {
-		throw new ShellException("Cannot get changed file phpcs output for file '{$svnFile}'");
+function getSvnModifiedPhpcsOutput(string $svnFile, string $phpcs, string $cat, string $phpcsStandardOption, callable $executeCommand, callable $debug): string {
+	$modifiedFilePhpcsOutputCommand = "{$cat} " . escapeshellarg($svnFile) . " | {$phpcs} --report=json -q" . $phpcsStandardOption . ' --stdin-path=' .  escapeshellarg($svnFile) . ' -';
+	$debug('running modified file phpcs command:', $modifiedFilePhpcsOutputCommand);
+	$modifiedFilePhpcsOutput = $executeCommand($modifiedFilePhpcsOutputCommand);
+	if (! $modifiedFilePhpcsOutput) {
+		throw new ShellException("Cannot get modified file phpcs output for file '{$svnFile}'");
 	}
-	$debug('changed file phpcs command output:', $changedFilePhpcsOutput);
-	if (false !== strpos($changedFilePhpcsOutput, 'You must supply at least one file or directory to process')) {
-		$debug('phpcs output implies changed file is empty');
+	$debug('modified file phpcs command output:', $modifiedFilePhpcsOutput);
+	if (false !== strpos($modifiedFilePhpcsOutput, 'You must supply at least one file or directory to process')) {
+		$debug('phpcs output implies modified file is empty');
 		return '';
 	}
-	return $changedFilePhpcsOutput;
+	return $modifiedFilePhpcsOutput;
 }

--- a/PhpcsChanged/functions.php
+++ b/PhpcsChanged/functions.php
@@ -10,20 +10,20 @@ function getVersion(): string {
 	return '2.9.0';
 }
 
-function getNewPhpcsMessages(string $unifiedDiff, PhpcsMessages $previousPhpcsMessages, PhpcsMessages $changedPhpcsMessages): PhpcsMessages {
-	return PhpcsMessages::getNewMessages($unifiedDiff, $previousPhpcsMessages, $changedPhpcsMessages);
+function getNewPhpcsMessages(string $unifiedDiff, PhpcsMessages $unmodifiedPhpcsMessages, PhpcsMessages $modifiedPhpcsMessages): PhpcsMessages {
+	return PhpcsMessages::getNewMessages($unifiedDiff, $unmodifiedPhpcsMessages, $modifiedPhpcsMessages);
 }
 
-function getNewPhpcsMessagesFromFiles(string $diffFile, string $phpcsPreviousFile, string $phpcsChangedFile): PhpcsMessages {
+function getNewPhpcsMessagesFromFiles(string $diffFile, string $phpcsUnmodifiedFile, string $phpcsModifiedFile): PhpcsMessages {
 	$unifiedDiff = file_get_contents($diffFile);
-	$previousFilePhpcsOutput = file_get_contents($phpcsPreviousFile);
-	$changedFilePhpcsOutput = file_get_contents($phpcsChangedFile);
-	if (! $unifiedDiff || ! $previousFilePhpcsOutput || ! $changedFilePhpcsOutput) {
+	$unmodifiedFilePhpcsOutput = file_get_contents($phpcsUnmodifiedFile);
+	$modifiedFilePhpcsOutput = file_get_contents($phpcsModifiedFile);
+	if (! $unifiedDiff || ! $unmodifiedFilePhpcsOutput || ! $modifiedFilePhpcsOutput) {
 		throw new ShellException('Cannot read input files.');
 	}
 	return getNewPhpcsMessages(
 		$unifiedDiff,
-		PhpcsMessages::fromPhpcsJson($previousFilePhpcsOutput),
-		PhpcsMessages::fromPhpcsJson($changedFilePhpcsOutput)
+		PhpcsMessages::fromPhpcsJson($unmodifiedFilePhpcsOutput),
+		PhpcsMessages::fromPhpcsJson($modifiedFilePhpcsOutput)
 	);
 }

--- a/PhpcsChanged/functions.php
+++ b/PhpcsChanged/functions.php
@@ -10,20 +10,20 @@ function getVersion(): string {
 	return '2.9.0';
 }
 
-function getNewPhpcsMessages(string $unifiedDiff, PhpcsMessages $oldPhpcsMessages, PhpcsMessages $newPhpcsMessages): PhpcsMessages {
-	return PhpcsMessages::getNewMessages($unifiedDiff, $oldPhpcsMessages, $newPhpcsMessages);
+function getNewPhpcsMessages(string $unifiedDiff, PhpcsMessages $previousPhpcsMessages, PhpcsMessages $changedPhpcsMessages): PhpcsMessages {
+	return PhpcsMessages::getNewMessages($unifiedDiff, $previousPhpcsMessages, $changedPhpcsMessages);
 }
 
-function getNewPhpcsMessagesFromFiles(string $diffFile, string $phpcsOldFile, string $phpcsNewFile): PhpcsMessages {
+function getNewPhpcsMessagesFromFiles(string $diffFile, string $phpcsPreviousFile, string $phpcsChangedFile): PhpcsMessages {
 	$unifiedDiff = file_get_contents($diffFile);
-	$oldFilePhpcsOutput = file_get_contents($phpcsOldFile);
-	$newFilePhpcsOutput = file_get_contents($phpcsNewFile);
-	if (! $unifiedDiff || ! $oldFilePhpcsOutput || ! $newFilePhpcsOutput) {
+	$previousFilePhpcsOutput = file_get_contents($phpcsPreviousFile);
+	$changedFilePhpcsOutput = file_get_contents($phpcsChangedFile);
+	if (! $unifiedDiff || ! $previousFilePhpcsOutput || ! $changedFilePhpcsOutput) {
 		throw new ShellException('Cannot read input files.');
 	}
 	return getNewPhpcsMessages(
 		$unifiedDiff,
-		PhpcsMessages::fromPhpcsJson($oldFilePhpcsOutput),
-		PhpcsMessages::fromPhpcsJson($newFilePhpcsOutput)
+		PhpcsMessages::fromPhpcsJson($previousFilePhpcsOutput),
+		PhpcsMessages::fromPhpcsJson($changedFilePhpcsOutput)
 	);
 }

--- a/README.md
+++ b/README.md
@@ -83,11 +83,11 @@ phpcs-changed --git --git-unstaged file.php
 
 When using `--git`, you should also specify `--git-staged`, `--git-unstaged`, or `--git-base`.
 
-`--git-staged` compares the currently staged changes (as the new version of the files) to the current HEAD (as the unmodified version of the files). This is the default.
+`--git-staged` compares the currently staged changes (as the modified version of the files) to the current HEAD (as the unmodified version of the files). This is the default.
 
-`--git-unstaged` compares the current (unstaged) working copy changes (as the new version of the files) to the either the currently staged changes, or if there are none, the current HEAD (as the unmodified version of the files).
+`--git-unstaged` compares the current (unstaged) working copy changes (as the modified version of the files) to the either the currently staged changes, or if there are none, the current HEAD (as the unmodified version of the files).
 
-`--git-base`, followed by a git object, compares the current HEAD (as the new version of the files) to the specified [git object](https://git-scm.com/book/en/v2/Git-Internals-Git-Objects) (as the unmodified version of the file) which can be a branch name, a commit, or some other valid git object.
+`--git-base`, followed by a git object, compares the current HEAD (as the modified version of the files) to the specified [git object](https://git-scm.com/book/en/v2/Git-Internals-Git-Objects) (as the unmodified version of the file) which can be a branch name, a commit, or some other valid git object.
 
 ```
 git checkout add-new-feature
@@ -106,7 +106,7 @@ You can use `--standard` to specify a specific phpcs standard to run. This match
 
 You can also use the `-s` option to Always show sniff codes after each error in the full reporter. This matches the phpcs option of the same name.
 
-The `--cache` option will enable caching of phpcs output and can significantly improve performance for slow phpcs standards or when running with high frequency. There are actually two caches: one for the phpcs scan of the unmodified version of the file and one for the phpcs scan of the modified version. The unmodified version phpcs output cache is invalidated when the version control revision changes or when the phpcs standard changes. The new version phpcs output cache is invalidated when the file hash changes or when the phpcs standard changes.
+The `--cache` option will enable caching of phpcs output and can significantly improve performance for slow phpcs standards or when running with high frequency. There are actually two caches: one for the phpcs scan of the unmodified version of the file and one for the phpcs scan of the modified version. The unmodified version phpcs output cache is invalidated when the version control revision changes or when the phpcs standard changes. The modified version phpcs output cache is invalidated when the file hash changes or when the phpcs standard changes.
 
 The `--no-cache` option will disable the cache if it's been enabled. (This may also be useful in the future if caching is made the default.)
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ If you wanted to use svn and phpcs manually, this produces the same output:
 svn diff file.php > file.php.diff
 svn cat file.php | phpcs --report=json -q > file.php.orig.phpcs
 cat file.php | phpcs --report=json -q > file.php.phpcs
-phpcs-changed --diff file.php.diff --phpcs-previous file.php.orig.phpcs --phpcs-changed file.php.phpcs
+phpcs-changed --diff file.php.diff --phpcs-unmodified file.php.orig.phpcs --phpcs-modified file.php.phpcs
 ```
 
 Both will output something like:
@@ -83,11 +83,11 @@ phpcs-changed --git --git-unstaged file.php
 
 When using `--git`, you should also specify `--git-staged`, `--git-unstaged`, or `--git-base`.
 
-`--git-staged` compares the currently staged changes (as the new version of the files) to the current HEAD (as the previous version of the files). This is the default.
+`--git-staged` compares the currently staged changes (as the new version of the files) to the current HEAD (as the unmodified version of the files). This is the default.
 
-`--git-unstaged` compares the current (unstaged) working copy changes (as the new version of the files) to the either the currently staged changes, or if there are none, the current HEAD (as the previous version of the files).
+`--git-unstaged` compares the current (unstaged) working copy changes (as the new version of the files) to the either the currently staged changes, or if there are none, the current HEAD (as the unmodified version of the files).
 
-`--git-base`, followed by a git object, compares the current HEAD (as the new version of the files) to the specified [git object](https://git-scm.com/book/en/v2/Git-Internals-Git-Objects) (as the previous version of the file) which can be a branch name, a commit, or some other valid git object.
+`--git-base`, followed by a git object, compares the current HEAD (as the new version of the files) to the specified [git object](https://git-scm.com/book/en/v2/Git-Internals-Git-Objects) (as the unmodified version of the file) which can be a branch name, a commit, or some other valid git object.
 
 ```
 git checkout add-new-feature
@@ -106,7 +106,7 @@ You can use `--standard` to specify a specific phpcs standard to run. This match
 
 You can also use the `-s` option to Always show sniff codes after each error in the full reporter. This matches the phpcs option of the same name.
 
-The `--cache` option will enable caching of phpcs output and can significantly improve performance for slow phpcs standards or when running with high frequency. There are actually two caches: one for the phpcs scan of the previous version of the file and one for the phpcs scan of the new version. The previous version phpcs output cache is invalidated when the version control revision changes or when the phpcs standard changes. The new version phpcs output cache is invalidated when the file hash changes or when the phpcs standard changes.
+The `--cache` option will enable caching of phpcs output and can significantly improve performance for slow phpcs standards or when running with high frequency. There are actually two caches: one for the phpcs scan of the unmodified version of the file and one for the phpcs scan of the modified version. The unmodified version phpcs output cache is invalidated when the version control revision changes or when the phpcs standard changes. The new version phpcs output cache is invalidated when the file hash changes or when the phpcs standard changes.
 
 The `--no-cache` option will disable the cache if it's been enabled. (This may also be useful in the future if caching is made the default.)
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ If you wanted to use svn and phpcs manually, this produces the same output:
 svn diff file.php > file.php.diff
 svn cat file.php | phpcs --report=json -q > file.php.orig.phpcs
 cat file.php | phpcs --report=json -q > file.php.phpcs
-phpcs-changed --diff file.php.diff --phpcs-orig file.php.orig.phpcs --phpcs-new file.php.phpcs
+phpcs-changed --diff file.php.diff --phpcs-previous file.php.orig.phpcs --phpcs-changed file.php.phpcs
 ```
 
 Both will output something like:

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -112,12 +112,12 @@ function run(array $options, array $fileNamesExpanded, callable $debug): void {
 	$debug('Options: ' . json_encode($options));
 	$reportType = $options['report'] ?? 'full';
 	$diffFile = $options['diff'] ?? null;
-	$phpcsOldFile = $options['phpcs-orig'] ?? null;
-	$phpcsNewFile = $options['phpcs-new'] ?? null;
+	$phpcsPreviousFile = $options['phpcs-orig'] ?? null;
+	$phpcsChangedFile = $options['phpcs-new'] ?? null;
 
-	if ($diffFile && $phpcsOldFile && $phpcsNewFile) {
+	if ($diffFile && $phpcsPreviousFile && $phpcsChangedFile) {
 		reportMessagesAndExit(
-			runManualWorkflow($diffFile, $phpcsOldFile, $phpcsNewFile),
+			runManualWorkflow($diffFile, $phpcsPreviousFile, $phpcsChangedFile),
 			$reportType,
 			$options
 		);

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -32,7 +32,9 @@ $options = getopt(
 		'version',
 		'diff:',
 		'phpcs-orig:',
+		'phpcs-previous:',
 		'phpcs-new:',
+		'phpcs-changed:',
 		'svn',
 		'git',
 		'git-unstaged',
@@ -104,6 +106,15 @@ if (isset($options['arc-lint'])) {
 	unset($options['arc-lint']);
 }
 
+if (isset($options['phpcs-orig'])) {
+	$options['phpcs-previous'] = $options['phpcs-orig'];
+	unset($options['phpcs-orig']);
+}
+if (isset($options['phpcs-new'])) {
+	$options['phpcs-changed'] = $options['phpcs-new'];
+	unset($options['phpcs-new']);
+}
+
 $debug = getDebug(isset($options['debug']));
 run($options, $fileNamesExpanded, $debug);
 
@@ -112,8 +123,8 @@ function run(array $options, array $fileNamesExpanded, callable $debug): void {
 	$debug('Options: ' . json_encode($options));
 	$reportType = $options['report'] ?? 'full';
 	$diffFile = $options['diff'] ?? null;
-	$phpcsPreviousFile = $options['phpcs-orig'] ?? null;
-	$phpcsChangedFile = $options['phpcs-new'] ?? null;
+	$phpcsPreviousFile = $options['phpcs-previous'] ?? null;
+	$phpcsChangedFile = $options['phpcs-changed'] ?? null;
 
 	if ($diffFile && $phpcsPreviousFile && $phpcsChangedFile) {
 		reportMessagesAndExit(

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -32,9 +32,9 @@ $options = getopt(
 		'version',
 		'diff:',
 		'phpcs-orig:',
-		'phpcs-previous:',
+		'phpcs-unmodified:',
 		'phpcs-new:',
-		'phpcs-changed:',
+		'phpcs-modified:',
 		'svn',
 		'git',
 		'git-unstaged',
@@ -107,11 +107,11 @@ if (isset($options['arc-lint'])) {
 }
 
 if (isset($options['phpcs-orig'])) {
-	$options['phpcs-previous'] = $options['phpcs-orig'];
+	$options['phpcs-unmodified'] = $options['phpcs-orig'];
 	unset($options['phpcs-orig']);
 }
 if (isset($options['phpcs-new'])) {
-	$options['phpcs-changed'] = $options['phpcs-new'];
+	$options['phpcs-modified'] = $options['phpcs-new'];
 	unset($options['phpcs-new']);
 }
 
@@ -123,12 +123,12 @@ function run(array $options, array $fileNamesExpanded, callable $debug): void {
 	$debug('Options: ' . json_encode($options));
 	$reportType = $options['report'] ?? 'full';
 	$diffFile = $options['diff'] ?? null;
-	$phpcsPreviousFile = $options['phpcs-previous'] ?? null;
-	$phpcsChangedFile = $options['phpcs-changed'] ?? null;
+	$phpcsUnmodifiedFile = $options['phpcs-unmodified'] ?? null;
+	$phpcsModifiedFile = $options['phpcs-modified'] ?? null;
 
-	if ($diffFile && $phpcsPreviousFile && $phpcsChangedFile) {
+	if ($diffFile && $phpcsUnmodifiedFile && $phpcsModifiedFile) {
 		reportMessagesAndExit(
-			runManualWorkflow($diffFile, $phpcsPreviousFile, $phpcsChangedFile),
+			runManualWorkflow($diffFile, $phpcsUnmodifiedFile, $phpcsModifiedFile),
 			$reportType,
 			$options
 		);


### PR DESCRIPTION
This updates the terminology used by the code (without changing any user-facing terms or APIs) to standardize terminology of the previous version of a file and the changed version of a file as **"unmodified"** and **"modified"**, respectively.

This will replace usage of the terms "new" (except to refer to newly added files or newly added phpcs messages for reporting), "old", "base" (except to refer to git base), "previous", "changed", and "orig" in most contexts.