### PR TITLE
First pass at passing in error and warning severity to phpcs

### DIFF
--- a/PhpcsChanged/CacheManager.php
+++ b/PhpcsChanged/CacheManager.php
@@ -9,6 +9,11 @@ use function PhpcsChanged\getVersion;
 
 class CacheManager {
 	/**
+	 * Default PHPCS's severity for both, errror and warning.
+	 */
+	const DEFAULT_SEVERITY = '5';
+
+	/**
 	 * A cache map with four levels of keys:
 	 *
 	 * 1. The file path
@@ -169,9 +174,9 @@ class CacheManager {
 	}
 
 	public function getPhpcsStandardCacheKey( string $phpcsStandard, string $warningSeverity, string $errorSeverity ): string {
-		$warningSeverity = '' === $warningSeverity ? '5' : $warningSeverity;
-		$errorSeverity = '' === $errorSeverity ? '5' : $errorSeverity;
-		if ('5' !== $warningSeverity || '5' !==$errorSeverity) {
+		$warningSeverity = '' === $warningSeverity ? self::DEFAULT_SEVERITY : $warningSeverity;
+		$errorSeverity = '' === $errorSeverity ? self::DEFAULT_SEVERITY : $errorSeverity;
+		if (self::DEFAULT_SEVERITY !== $warningSeverity || self::DEFAULT_SEVERITY !==$errorSeverity) {
 			$phpcsStandard .= $warningSeverity . $errorSeverity;
 		}
 		return $phpcsStandard;

--- a/PhpcsChanged/CacheManager.php
+++ b/PhpcsChanged/CacheManager.php
@@ -19,7 +19,7 @@ class CacheManager {
 	 * 1. The file path
 	 * 2. The cache type; either 'new' (modified version of a file) or 'old' (unmodified version of a file)
 	 * 3. The file hash (if needed; this is not used for old files)
-	 * 4. The phpcs standard plus error and warning severity option. The phpcs standard only in case no severity is set, or default value of 5 is used (makes the format backward compatible).
+	 * 4. The phpcs standard plus warning and error severity option (prefixed by w/e respectively, delimitered by colon). The phpcs standard only in case no severity is set, or default value of 5 is used (makes the format backward compatible). Eg.: `standard:w0e4`.
 	 *
 	 * @var array<string, array<string, array<string, array<string, CacheEntry>>>>
 	 */
@@ -177,7 +177,7 @@ class CacheManager {
 		$warningSeverity = '' === $warningSeverity ? self::DEFAULT_SEVERITY : $warningSeverity;
 		$errorSeverity = '' === $errorSeverity ? self::DEFAULT_SEVERITY : $errorSeverity;
 		if (self::DEFAULT_SEVERITY !== $warningSeverity || self::DEFAULT_SEVERITY !==$errorSeverity) {
-			$phpcsStandard .= $warningSeverity . $errorSeverity;
+			$phpcsStandard .= ':w' . $warningSeverity . 'e' . $errorSeverity;
 		}
 		return $phpcsStandard;
 	}

--- a/PhpcsChanged/CacheManager.php
+++ b/PhpcsChanged/CacheManager.php
@@ -127,7 +127,12 @@ class CacheManager {
 		$this->cacheObject->cacheVersion = $cacheVersion;
 	}
 
-	public function getCacheForFile(string $filePath, string $type, string $hash, string $phpcsStandard): ?string {
+	public function getCacheForFile(string $filePath, string $type, string $hash, string $phpcsStandard, string $warningSeverity, string $errorSeverity): ?string {
+		$warningSeverity = '' === $warningSeverity ? '5' : $warningSeverity;
+		$errorSeverity = '' === $errorSeverity ? '5' : $errorSeverity;
+		if ('5' !== $warningSeverity || '5' !==$errorSeverity) {
+			$phpcsStandard .= $warningSeverity . $errorSeverity;
+		}
 		$entry = $this->fileDataByPath[$filePath][$type][$hash][$phpcsStandard] ?? null;
 		if (! $entry) {
 			($this->debug)("Cache miss: file '{$filePath}', hash '{$hash}', standard '{$phpcsStandard}'");
@@ -136,7 +141,12 @@ class CacheManager {
 		return $entry->data;
 	}
 
-	public function setCacheForFile(string $filePath, string $type, string $hash, string $phpcsStandard, string $data): void {
+	public function setCacheForFile(string $filePath, string $type, string $hash, string $phpcsStandard, string $warningSeverity, string $errorSeverity, string $data): void {
+		$warningSeverity = '' === $warningSeverity ? '5' : $warningSeverity;
+		$errorSeverity = '' === $errorSeverity ? '5' : $errorSeverity;
+		if ('5' !== $warningSeverity || '5' !==$errorSeverity) {
+			$phpcsStandard .= $warningSeverity . $errorSeverity;
+		}
 		$this->hasBeenModified = true;
 		$entry = new CacheEntry();
 		$entry->phpcsStandard = $phpcsStandard;

--- a/PhpcsChanged/CacheManager.php
+++ b/PhpcsChanged/CacheManager.php
@@ -128,11 +128,8 @@ class CacheManager {
 	}
 
 	public function getCacheForFile(string $filePath, string $type, string $hash, string $phpcsStandard, string $warningSeverity, string $errorSeverity): ?string {
-		$warningSeverity = '' === $warningSeverity ? '5' : $warningSeverity;
-		$errorSeverity = '' === $errorSeverity ? '5' : $errorSeverity;
-		if ('5' !== $warningSeverity || '5' !==$errorSeverity) {
-			$phpcsStandard .= $warningSeverity . $errorSeverity;
-		}
+		$phpcsStandard = $this->getPhpcsStandardCacheKey( $phpcsStandard, $warningSeverity, $errorSeverity );
+
 		$entry = $this->fileDataByPath[$filePath][$type][$hash][$phpcsStandard] ?? null;
 		if (! $entry) {
 			($this->debug)("Cache miss: file '{$filePath}', hash '{$hash}', standard '{$phpcsStandard}'");
@@ -142,11 +139,9 @@ class CacheManager {
 	}
 
 	public function setCacheForFile(string $filePath, string $type, string $hash, string $phpcsStandard, string $warningSeverity, string $errorSeverity, string $data): void {
-		$warningSeverity = '' === $warningSeverity ? '5' : $warningSeverity;
-		$errorSeverity = '' === $errorSeverity ? '5' : $errorSeverity;
-		if ('5' !== $warningSeverity || '5' !==$errorSeverity) {
-			$phpcsStandard .= $warningSeverity . $errorSeverity;
-		}
+
+		$phpcsStandard = $this->getPhpcsStandardCacheKey( $phpcsStandard, $warningSeverity, $errorSeverity );
+
 		$this->hasBeenModified = true;
 		$entry = new CacheEntry();
 		$entry->phpcsStandard = $phpcsStandard;
@@ -171,6 +166,15 @@ class CacheManager {
 		}
 		$this->fileDataByPath[$entry->path][$entry->type][$entry->hash][$entry->phpcsStandard] = $entry;
 		($this->debug)("Cache add: file '{$entry->path}', type '{$entry->type}', hash '{$entry->hash}', standard '{$entry->phpcsStandard}'");
+	}
+
+	public function getPhpcsStandardCacheKey( string $phpcsStandard, string $warningSeverity, string $errorSeverity ): string {
+		$warningSeverity = '' === $warningSeverity ? '5' : $warningSeverity;
+		$errorSeverity = '' === $errorSeverity ? '5' : $errorSeverity;
+		if ('5' !== $warningSeverity || '5' !==$errorSeverity) {
+			$phpcsStandard .= $warningSeverity . $errorSeverity;
+		}
+		return $phpcsStandard;
 	}
 
 	private function pruneOldEntriesForFile(CacheEntry $newEntry): void {

--- a/PhpcsChanged/CacheManager.php
+++ b/PhpcsChanged/CacheManager.php
@@ -19,7 +19,7 @@ class CacheManager {
 	 * 1. The file path
 	 * 2. The cache type; either 'new' (modified version of a file) or 'old' (unmodified version of a file)
 	 * 3. The file hash (if needed; this is not used for old files)
-	 * 4. The phpcs standard
+	 * 4. The phpcs standard plus error and warning severity option. The phpcs standard only in case no severity is set, or default value of 5 is used (makes the format backward compatible).
 	 *
 	 * @var array<string, array<string, array<string, array<string, CacheEntry>>>>
 	 */

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -239,7 +239,7 @@ function runSvnWorkflowForFile(string $svnFile, array $options, ShellOperator $s
 	$warningSeverity = $options['warning-severity'] ?? null;
 	$phpcsStandardOption .= isset($warningSeverity) ? ' --warning-severity=' . escapeshellarg($warningSeverity) : '';
 	$errorSeverity = $options['error-severity'] ?? null;
-	$phpcsStandardOption .= $errorSeverity ? ' --error-severity=' . escapeshellarg($errorSeverity) : '';
+	$phpcsStandardOption .= isset($errorSeverity) ? ' --error-severity=' . escapeshellarg($errorSeverity) : '';
 
 	try {
 		if (! $shell->isReadable($svnFile)) {

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -285,7 +285,7 @@ function runSvnWorkflowForFile(string $svnFile, array $options, ShellOperator $s
 			if (! $unmodifiedFilePhpcsOutput) {
 				$unmodifiedFilePhpcsOutput = getSvnUnmodifiedPhpcsOutput($svnFile, $svn, $phpcs, $phpcsStandardOption, [$shell, 'executeCommand'], $debug);
 				if (isCachingEnabled($options)) {
-					$cache->setCacheForFile($svnFile, 'old', $revisionId, $phpcsStandard ?? '', $warningSeverity ?? '', $errorSeverity ?? '' $unmodifiedFilePhpcsOutput);
+					$cache->setCacheForFile($svnFile, 'old', $revisionId, $phpcsStandard ?? '', $warningSeverity ?? '', $errorSeverity ?? '', $unmodifiedFilePhpcsOutput);
 				}
 			}
 		}

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -238,7 +238,7 @@ function runSvnWorkflowForFile(string $svnFile, array $options, ShellOperator $s
 
 	$warningSeverity = $options['warning-severity'] ?? null;
 	$phpcsStandardOption .= isset($warningSeverity) ? ' --warning-severity=' . escapeshellarg($warningSeverity) : '';
-	$errorSeverity = isset($options['error-severity']) ?? null;
+	$errorSeverity = $options['error-severity'] ?? null;
 	$phpcsStandardOption .= $errorSeverity ? ' --error-severity=' . escapeshellarg($errorSeverity) : '';
 
 	try {

--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ You can use `--standard` to specify a specific phpcs standard to run. This match
 
 You can also use the `-s` option to Always show sniff codes after each error in the full reporter. This matches the phpcs option of the same name.
 
+The `--error-severity` and `--warning-severity` options can be used for instructing the `phpcs` command on what error and warning severity to report. Those values are being passed through to `phpcs` itself. Consult `phpcs` documentation for severity settings.
+
 The `--cache` option will enable caching of phpcs output and can significantly improve performance for slow phpcs standards or when running with high frequency. There are actually two caches: one for the phpcs scan of the unmodified version of the file and one for the phpcs scan of the modified version. The unmodified version phpcs output cache is invalidated when the version control revision changes or when the phpcs standard changes. The modified version phpcs output cache is invalidated when the file hash changes or when the phpcs standard changes.
 
 The `--no-cache` option will disable the cache if it's been enabled. (This may also be useful in the future if caching is made the default.)

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -52,6 +52,8 @@ $options = getopt(
 		'always-exit-zero',
 		'no-cache-git-root',
 		'no-verify-git-file',
+		'warning-severity:'
+		'error-severity:'
 	],
 	$optind
 );

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -52,8 +52,8 @@ $options = getopt(
 		'always-exit-zero',
 		'no-cache-git-root',
 		'no-verify-git-file',
-		'warning-severity:'
-		'error-severity:'
+		'warning-severity:',
+		'error-severity:',
 	],
 	$optind
 );

--- a/tests/CacheManagerTest.php
+++ b/tests/CacheManagerTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 use PhpcsChanged\CacheManager;
 use PhpcsChangedTests\TestCache;
 
-final class CAcheManagerTest extends TestCase {
+final class CacheManagerTest extends TestCase {
 
 	public function providePhpcsStandardCacheKeyGenerationData() {
 		return [

--- a/tests/CacheManagerTest.php
+++ b/tests/CacheManagerTest.php
@@ -21,19 +21,19 @@ final class CAcheManagerTest extends TestCase {
 				'standard',
 				'1',
 				'1',
-				'standard11'
+				'standard:w1e1'
 			],
 			'empty warning severity key gets replaced by default value of 5' => [
 				'standard',
 				'',
 				'1',
-				'standard51',
+				'standard:w5e1',
 			],
 			'empty error severity key gets replaced by default value of 5' => [
 				'standard',
 				'1',
 				'',
-				'standard15',
+				'standard:w1e5',
 			],
 			'empty error and warning severity key returns unchanged standard value' => [
 				'standard',

--- a/tests/CacheManagerTest.php
+++ b/tests/CacheManagerTest.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+require_once dirname(__DIR__) . '/index.php';
+
+use PHPUnit\Framework\TestCase;
+use PhpcsChanged\CacheManager;
+use PhpcsChangedTests\TestCache;
+
+final class CAcheManagerTest extends TestCase {
+
+	public function providePhpcsStandardCacheKeyGenerationData() {
+		return [
+			'default error and warning severity produces unchanged key' => [
+				'standard',
+				'5',
+				'5',
+				'standard'
+			],
+			'non-default error and warning severity produces changed key' => [
+				'standard',
+				'1',
+				'1',
+				'standard11'
+			],
+			'empty warning severity key gets replaced by default value of 5' => [
+				'standard',
+				'',
+				'1',
+				'standard51',
+			],
+			'empty error severity key gets replaced by default value of 5' => [
+				'standard',
+				'1',
+				'',
+				'standard15',
+			],
+			'empty error and warning severity key returns unchanged standard value' => [
+				'standard',
+				'',
+				'',
+				'standard'
+			]
+		];
+	}
+
+	/**
+	 * @dataProvider providePhpcsStandardCacheKeyGenerationData
+	 */
+	public function testPhpcsStandardCacheKeyGeneration( $phpcsStandard, $warningSeverity, $errorSeverity, $expected ) {
+		$cache = new CacheManager( new TestCache() );
+
+		$phpcsStandardCacheKey = $cache->getPhpcsStandardCacheKey( $phpcsStandard, $warningSeverity, $errorSeverity );
+
+		$this->assertEquals( $expected, $phpcsStandardCacheKey );
+	}
+}

--- a/tests/GitWorkflowTest.php
+++ b/tests/GitWorkflowTest.php
@@ -169,7 +169,7 @@ final class GitWorkflowTest extends TestCase {
 		$this->assertFalse($shell->wasCommandCalled("cat 'foobar.php' | phpcs"));
 
 		foreach( $cache->getEntries() as $entry ) {
-			$this->assertEquals( 'standard12', $entry->phpcsStandard );
+			$this->assertEquals( 'standard:w1e2', $entry->phpcsStandard );
 		}
 	}
 
@@ -207,7 +207,7 @@ final class GitWorkflowTest extends TestCase {
 		$cacheEntries = $cache->getEntries();
 		$this->assertNotEmpty($cacheEntries);
 		foreach( $cacheEntries as $entry ) {
-			$this->assertEquals( 'standard00', $entry->phpcsStandard );
+			$this->assertEquals( 'standard:w0e0', $entry->phpcsStandard );
 		}
 	}
 

--- a/tests/GitWorkflowTest.php
+++ b/tests/GitWorkflowTest.php
@@ -137,6 +137,76 @@ final class GitWorkflowTest extends TestCase {
 		$this->assertFalse($shell->wasCommandCalled("cat 'foobar.php' | phpcs"));
 	}
 
+	public function testFullGitWorkflowForOneFileUnstagedCachesDataThenUsesCacheWithSeveritySet() {
+		$gitFile = 'foobar.php';
+		$shell = new TestShell([$gitFile]);
+		$fixture = $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;');
+		$shell->registerCommand("git diff --no-prefix 'foobar.php'", $fixture);
+		$shell->registerCommand("git status --porcelain 'foobar.php'", $this->fixture->getModifiedFileInfo('foobar.php'));
+		$shell->registerCommand("git show :0:$(git ls-files --full-name 'foobar.php') | phpcs", $this->phpcs->getResults('STDIN', [20], 'Found unused symbol Foobar.')->toPhpcsJson());
+		$shell->registerCommand("cat 'foobar.php' | phpcs", $this->phpcs->getResults('STDIN', [21, 20], 'Found unused symbol Foobar.')->toPhpcsJson());
+		$shell->registerCommand("git show :0:$(git ls-files --full-name 'foobar.php') | git hash-object --stdin", 'previous-file-hash');
+		$shell->registerCommand("cat 'foobar.php' | git hash-object --stdin", 'new-file-hash');
+		$shell->registerCommand("git rev-parse --show-toplevel", 'run-from-git-root');
+		$options = [
+			'no-cache-git-root' => 1,
+			'git-unstaged' => '1',
+			'cache' => false, // getopt is weird and sets options to false
+			'standard' => 'standard',
+			'warning-severity' => '1',
+			'error-severity' => '2',
+		];
+		$cache = new CacheManager( new TestCache(), '\PhpcsChangedTests\Debug' );
+		$expected = $this->phpcs->getResults('bin/foobar.php', [20], 'Found unused symbol Foobar.');
+
+		runGitWorkflow([$gitFile], $options, $shell, $cache, '\PhpcsChangedTests\Debug');
+
+		$shell->resetCommandsCalled();
+		$messages = runGitWorkflow([$gitFile], $options, $shell, $cache, '\PhpcsChangedTests\Debug');
+
+		$this->assertEquals($expected->getMessages(), $messages->getMessages());
+		$this->assertFalse($shell->wasCommandCalled("git show :0:$(git ls-files --full-name 'foobar.php') | phpcs"));
+		$this->assertFalse($shell->wasCommandCalled("cat 'foobar.php' | phpcs"));
+
+		foreach( $cache->getEntries() as $entry ) {
+			$this->assertEquals( 'standard12', $entry->phpcsStandard );
+		}
+	}
+
+	public function testFullGitWorkflowForOneFileUnstagedCachesDataThenUsesCacheWithSeverityNotSet() {
+		$gitFile = 'foobar.php';
+		$shell = new TestShell([$gitFile]);
+		$fixture = $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;');
+		$shell->registerCommand("git diff --no-prefix 'foobar.php'", $fixture);
+		$shell->registerCommand("git status --porcelain 'foobar.php'", $this->fixture->getModifiedFileInfo('foobar.php'));
+		$shell->registerCommand("git show :0:$(git ls-files --full-name 'foobar.php') | phpcs", $this->phpcs->getResults('STDIN', [20], 'Found unused symbol Foobar.')->toPhpcsJson());
+		$shell->registerCommand("cat 'foobar.php' | phpcs", $this->phpcs->getResults('STDIN', [21, 20], 'Found unused symbol Foobar.')->toPhpcsJson());
+		$shell->registerCommand("git show :0:$(git ls-files --full-name 'foobar.php') | git hash-object --stdin", 'previous-file-hash');
+		$shell->registerCommand("cat 'foobar.php' | git hash-object --stdin", 'new-file-hash');
+		$shell->registerCommand("git rev-parse --show-toplevel", 'run-from-git-root');
+		$options = [
+			'no-cache-git-root' => 1,
+			'git-unstaged' => '1',
+			'cache' => false, // getopt is weird and sets options to false
+			'standard' => 'standard',
+		];
+		$cache = new CacheManager( new TestCache(), '\PhpcsChangedTests\Debug' );
+		$expected = $this->phpcs->getResults('bin/foobar.php', [20], 'Found unused symbol Foobar.');
+
+		runGitWorkflow([$gitFile], $options, $shell, $cache, '\PhpcsChangedTests\Debug');
+
+		$shell->resetCommandsCalled();
+		$messages = runGitWorkflow([$gitFile], $options, $shell, $cache, '\PhpcsChangedTests\Debug');
+
+		$this->assertEquals($expected->getMessages(), $messages->getMessages());
+		$this->assertFalse($shell->wasCommandCalled("git show :0:$(git ls-files --full-name 'foobar.php') | phpcs"));
+		$this->assertFalse($shell->wasCommandCalled("cat 'foobar.php' | phpcs"));
+
+		foreach( $cache->getEntries() as $entry ) {
+			$this->assertEquals( 'standard', $entry->phpcsStandard );
+		}
+	}
+
 	public function testFullGitWorkflowForOneFileUnstagedCachesDataThenClearsOldCacheWhenOldFileChanges() {
 		$gitFile = 'foobar.php';
 		$shell = new TestShell([$gitFile]);

--- a/tests/GitWorkflowTest.php
+++ b/tests/GitWorkflowTest.php
@@ -204,7 +204,9 @@ final class GitWorkflowTest extends TestCase {
 		$this->assertFalse($shell->wasCommandCalled("git show :0:$(git ls-files --full-name 'foobar.php') | phpcs"));
 		$this->assertFalse($shell->wasCommandCalled("cat 'foobar.php' | phpcs"));
 
-		foreach( $cache->getEntries() as $entry ) {
+		$cacheEntries = $cache->getEntries();
+		$this->assertNotEmpty($cacheEntries);
+		foreach( $cacheEntries as $entry ) {
 			$this->assertEquals( 'standard00', $entry->phpcsStandard );
 		}
 	}
@@ -238,7 +240,9 @@ final class GitWorkflowTest extends TestCase {
 		$this->assertFalse($shell->wasCommandCalled("git show :0:$(git ls-files --full-name 'foobar.php') | phpcs"));
 		$this->assertFalse($shell->wasCommandCalled("cat 'foobar.php' | phpcs"));
 
-		foreach( $cache->getEntries() as $entry ) {
+		$cacheEntries = $cache->getEntries();
+		$this->assertNotEmpty($cacheEntries);
+		foreach( $cacheEntries as $entry ) {
 			$this->assertEquals( 'standard', $entry->phpcsStandard );
 		}
 	}

--- a/tests/SvnWorkflowTest.php
+++ b/tests/SvnWorkflowTest.php
@@ -515,7 +515,7 @@ Run "phpcs --help" for usage information
 		$cacheEntries = $cache->getEntries();
 		$this->assertNotEmpty($cacheEntries);
 		foreach( $cacheEntries as $entry ) {
-			$this->assertEquals( 'standard00', $entry->phpcsStandard );
+			$this->assertEquals( 'standard:w0e0', $entry->phpcsStandard );
 		}
 	}
 }

--- a/tests/SvnWorkflowTest.php
+++ b/tests/SvnWorkflowTest.php
@@ -495,4 +495,25 @@ Run "phpcs --help" for usage information
 		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
+
+	public function testFullSvnWorkflowForOneFileWithSeveritySetToZero() {
+		$svnFile = 'foobar.php';
+		$shell = new TestShell([$svnFile]);
+		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
+		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php'));
+		$shell->registerCommand("svn cat 'foobar.php' | phpcs --report=json -q --standard='standard' --warning-severity='0' --error-severity='0'", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
+		$shell->registerCommand("cat 'foobar.php' | phpcs --report=json -q --standard='standard' --warning-severity='0' --error-severity='0'" , $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
+		$options = [
+			'warning-severity' => '0',
+			'error-severity' => '0',
+			'cache' => false, // getopt is weird and sets options to false
+			'standard' => 'standard'
+		];
+		$cache = new CacheManager(new TestCache());
+		runSvnWorkflow([$svnFile], $options, $shell, $cache, '\PhpcsChangedTests\debug' );
+		
+		foreach( $cache->getEntries() as $entry ) {
+			$this->assertEquals( 'standard00', $entry->phpcsStandard );
+		}
+	}
 }

--- a/tests/SvnWorkflowTest.php
+++ b/tests/SvnWorkflowTest.php
@@ -512,7 +512,9 @@ Run "phpcs --help" for usage information
 		$cache = new CacheManager(new TestCache());
 		runSvnWorkflow([$svnFile], $options, $shell, $cache, '\PhpcsChangedTests\debug' );
 		
-		foreach( $cache->getEntries() as $entry ) {
+		$cacheEntries = $cache->getEntries();
+		$this->assertNotEmpty($cacheEntries);
+		foreach( $cacheEntries as $entry ) {
 			$this->assertEquals( 'standard00', $entry->phpcsStandard );
 		}
 	}


### PR DESCRIPTION
Passing in the `--warning-severity` and `--error-severity` flags to phpcs is rather straightforward, however we need to take into consideration the caching layer.

It currently uses the standard as a cache key, and it definitelly should take into consideration different severity settings. To make sure the existing cache is backward compatible with the one created by previous version of phpcs-changed, we can map the default severity ('5') to a standard run w/o severity settings.

I _think_ that simply appending the warning and error severity value to the standard used in the key can make it work.

fixes #56 