### PR TITLE
Add explicit properties to GitWorkflowTest/SvnWorkflowTest

### DIFF
--- a/tests/GitWorkflowTest.php
+++ b/tests/GitWorkflowTest.php
@@ -16,6 +16,9 @@ use function PhpcsChanged\Cli\runGitWorkflow;
 use function PhpcsChanged\GitWorkflow\{isNewGitFile, getGitUnifiedDiff};
 
 final class GitWorkflowTest extends TestCase {
+	public $fixture;
+	public $phpcs;
+
 	public function setUp(): void {
 		parent::setUp();
 		$this->fixture = new GitFixture();

--- a/tests/SvnWorkflowTest.php
+++ b/tests/SvnWorkflowTest.php
@@ -16,6 +16,9 @@ use function PhpcsChanged\Cli\runSvnWorkflow;
 use function PhpcsChanged\SvnWorkflow\{getSvnFileInfo, isNewSvnFile, getSvnUnifiedDiff};
 
 final class SvnWorkflowTest extends TestCase {
+	public $phpcs;
+	public $fixture;
+
 	public function setUp(): void {
 		parent::setUp();
 		$this->fixture = new SvnFixture();


### PR DESCRIPTION
Dynamic properties are deprecated in PHP 8.2