### PR TITLE
Use full path command for git cat-file command

### DIFF
--- a/PhpcsChanged/GitWorkflow.php
+++ b/PhpcsChanged/GitWorkflow.php
@@ -134,13 +134,18 @@ function getGitModifiedPhpcsOutput(string $gitFile, string $git, string $phpcs, 
 	return $modifiedFilePhpcsOutput;
 }
 
+function getFullPathToFileCommand(string $gitFile, string $git): string {
+	return "{$git} ls-files --full-name " . escapeshellarg($gitFile);
+}
+
 function getModifiedGitRevisionContentsCommand(string $gitFile, string $git, string $cat, array $options, callable $executeCommand, callable $debug): string {
+	$fullPathCommand = getFullPathToFileCommand($gitFile, $git);
 	if (isset($options['git-base']) && ! empty($options['git-base'])) {
 		// for git-base mode, we get the contents of the file from the HEAD version of the file in the current branch
 		if (isRunFromGitRoot($git, $executeCommand, $options, $debug)) {
 			return "{$git} show HEAD:" . escapeshellarg($gitFile);
 		}
-		return "{$git} show HEAD:$({$git} ls-files --full-name " . escapeshellarg($gitFile) . ')';
+		return "{$git} show HEAD:$({$fullPathCommand})";
 	} else if (isset($options['git-unstaged'])) {
 		// for git-unstaged mode, we get the contents of the file from the current working copy
 		return "{$cat} " . escapeshellarg($gitFile);
@@ -149,7 +154,7 @@ function getModifiedGitRevisionContentsCommand(string $gitFile, string $git, str
 	if (isRunFromGitRoot($git, $executeCommand, $options, $debug)) {
 		return "{$git} show :0:" . escapeshellarg($gitFile);
 	}
-	return "{$git} show :0:$({$git} ls-files --full-name " . escapeshellarg($gitFile) . ')';
+	return "{$git} show :0:$({$fullPathCommand})";
 }
 
 function getUnmodifiedGitRevisionContentsCommand(string $gitFile, string $git, array $options, callable $executeCommand, callable $debug): string {
@@ -166,7 +171,8 @@ function getUnmodifiedGitRevisionContentsCommand(string $gitFile, string $git, a
 	if (isRunFromGitRoot($git, $executeCommand, $options, $debug)) {
 		return "{$git} show {$rev}:" . escapeshellarg($gitFile);
 	}
-	return "{$git} show {$rev}:$({$git} ls-files --full-name " . escapeshellarg($gitFile) . ")";
+	$fullPathCommand = getFullPathToFileCommand($gitFile, $git);
+	return "{$git} show {$rev}:$({$fullPathCommand})";
 }
 
 function getModifiedGitFileHash(string $gitFile, string $git, string $cat, callable $executeCommand, array $options, callable $debug): string {

--- a/PhpcsChanged/GitWorkflow.php
+++ b/PhpcsChanged/GitWorkflow.php
@@ -79,7 +79,7 @@ function isNewGitFile(string $gitFile, string $git, callable $executeCommand, ar
 }
 
 function isNewGitFileRemote(string $gitFile, string $git, callable $executeCommand, array $options, callable $debug): bool {
-	$gitStatusCommand = "{$git} cat-file -e " . escapeshellarg($options['git-base']) . ':' . escapeshellarg($gitFile) . ' 2>/dev/null';
+	$gitStatusCommand = "{$git} cat-file -e " . escapeshellarg($options['git-base']) . ':$(' . getFullPathToFileCommand($gitFile, $git) . ') 2>/dev/null';
 	$debug('checking status of file with command:', $gitStatusCommand);
 	/** @var int */
 	$return_val = 1;

--- a/tests/GitWorkflowTest.php
+++ b/tests/GitWorkflowTest.php
@@ -420,7 +420,7 @@ Run "phpcs --help" for usage information
 		$shell->registerCommand("git merge-base 'master' HEAD", "0123456789abcdef0123456789abcdef01234567\n");
 		$shell->registerCommand("git diff '0123456789abcdef0123456789abcdef01234567'... --no-prefix 'bin/foobar.php'", $fixture);
 		$shell->registerCommand("git status --porcelain 'bin/foobar.php'", '');
-		$shell->registerCommand("git cat-file -e '0123456789abcdef0123456789abcdef01234567':'bin/foobar.php'", '');
+		$shell->registerCommand("git cat-file -e '0123456789abcdef0123456789abcdef01234567':$(git ls-files --full-name 'bin/foobar.php')", '');
 		$shell->registerCommand("git show '0123456789abcdef0123456789abcdef01234567':$(git ls-files --full-name 'bin/foobar.php') | phpcs --report=json -q --stdin-path='bin/foobar.php' -", $this->phpcs->getResults('\/srv\/www\/wordpress-default\/public_html\/test\/bin\/foobar.php', [6], 'Found unused symbol Foobar.')->toPhpcsJson());
 		$shell->registerCommand("git show '0123456789abcdef0123456789abcdef01234567':$(git ls-files --full-name 'bin/foobar.php') | git hash-object --stdin", 'previous-file-hash');
 		$shell->registerCommand("git show HEAD:$(git ls-files --full-name 'bin/foobar.php') | phpcs --report=json -q --stdin-path='bin/foobar.php' -", $this->phpcs->getResults('\/srv\/www\/wordpress-default\/public_html\/test\/bin\/foobar.php', [6, 7], 'Found unused symbol Foobar.')->toPhpcsJson());
@@ -441,7 +441,7 @@ Run "phpcs --help" for usage information
 		$fixture = $this->fixture->getAltNewFileDiff('test.php');
 		$shell->registerCommand("git merge-base 'master' HEAD", "0123456789abcdef0123456789abcdef01234567\n");
 		$shell->registerCommand("git diff '0123456789abcdef0123456789abcdef01234567'... --no-prefix 'test.php'", $fixture);
-		$shell->registerCommand("git cat-file -e '0123456789abcdef0123456789abcdef01234567':'test.php'", '', 128);
+		$shell->registerCommand("git cat-file -e '0123456789abcdef0123456789abcdef01234567':$(git ls-files --full-name 'test.php')", '', 128);
 		$shell->registerCommand("git show HEAD:$(git ls-files --full-name 'test.php') | phpcs --report=json -q --stdin-path='test.php' -", $this->phpcs->getResults('\/srv\/www\/wordpress-default\/public_html\/test\/test.php', [6, 7, 8], "Found unused symbol 'Foobar'.")->toPhpcsJson());
 		$shell->registerCommand("git show '0123456789abcdef0123456789abcdef01234567':$(git ls-files --full-name 'test.php') | git hash-object --stdin", 'previous-file-hash');
 		$shell->registerCommand("git show HEAD:$(git ls-files --full-name 'test.php') | git hash-object --stdin", 'new-file-hash');


### PR DESCRIPTION
When referencing a file in the remote repository, git requires that you specify the full path to the file.

For example, if you are in the root of a repository and run the following commands:

```
> cd foo/bar/
> git show HEAD:file.php
> echo $?
128
```

This will return an error because it can't find a file with a relative path. Instead, you can run the command with the full path to the file relative to the repo root:

```
> cd foo/bar/
> git show HEAD:$(git ls-files --full-name file.php)
> echo $?
0
```

For the `git show` command, `phpcs-changed` already does this thanks to the work done in https://github.com/sirbrillig/phpcs-changed/pull/18. However, the `git cat-file` command, added later in https://github.com/sirbrillig/phpcs-changed/pull/28 does not use that strategy, which means it will not work outside of the repository root.

In this PR we alter `git cat-file` to also use the full path name.

Fixes https://github.com/sirbrillig/phpcs-changed/issues/66