### PR TITLE
Add options class, take 2

### DIFF
--- a/.github/workflows/csqa.yml
+++ b/.github/workflows/csqa.yml
@@ -49,8 +49,8 @@ jobs:
       - name: Show PHPCS results in PR
         run: cs2pr ./phpcs-report.xml
 
-  phpstan:
-    name: "PHP: 7.4 | PHPStan"
+  staticanalysis:
+    name: "PHP: 7.4 | Static analysis"
     runs-on: ubuntu-latest
 
     steps:
@@ -69,5 +69,5 @@ jobs:
       - name: Install Composer dependencies
         uses: "ramsey/composer-install@v2"
 
-      - name: Run PHPStan
-        run: composer phpstan
+      - name: Run Static analysis
+        run: composer static-analysis

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,8 +77,6 @@ jobs:
 
       - name: 'Composer: adjust dependencies'
         run: |
-          # Remove dev dependencies which are not compatible with all supported PHP versions.
-          composer remove --dev --no-update phpstan/phpstan
           # Set the PHPCS version for this test run.
           composer require --no-update squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}"
 

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -244,6 +244,7 @@ function runSvnWorkflowForFile(string $svnFile, array $options, ShellOperator $s
 	$phpcsStandardOption .= isset($warningSeverity) ? ' --warning-severity=' . escapeshellarg($warningSeverity) : '';
 	$errorSeverity = $options['error-severity'] ?? null;
 	$phpcsStandardOption .= isset($errorSeverity) ? ' --error-severity=' . escapeshellarg($errorSeverity) : '';
+	$fileName = $shell->getFileNameFromPath($svnFile);
 
 	try {
 		if (! $shell->isReadable($svnFile)) {
@@ -264,7 +265,6 @@ function runSvnWorkflowForFile(string $svnFile, array $options, ShellOperator $s
 			}
 		}
 
-		$fileName = $shell->getFileNameFromPath($svnFile);
 		$modifiedFilePhpcsMessages = PhpcsMessages::fromPhpcsJson($modifiedFilePhpcsOutput, $fileName);
 		$hasNewPhpcsMessages = !empty($modifiedFilePhpcsMessages->getMessages());
 
@@ -355,6 +355,7 @@ function runGitWorkflowForFile(string $gitFile, array $options, ShellOperator $s
 	$phpcsStandardOption .= isset($warningSeverity) ? ' --warning-severity=' . escapeshellarg($warningSeverity) : '';
 	$errorSeverity = $options['error-severity'] ?? null;
 	$phpcsStandardOption .= isset($errorSeverity) ? ' --error-severity=' . escapeshellarg($errorSeverity) : '';
+	$fileName = $shell->getFileNameFromPath($gitFile);
 
 	try {
 		validateGitFileExists($gitFile, $git, [$shell, 'isReadable'], [$shell, 'executeCommand'], $debug, $options);
@@ -373,7 +374,6 @@ function runGitWorkflowForFile(string $gitFile, array $options, ShellOperator $s
 			}
 		}
 
-		$fileName = $shell->getFileNameFromPath($gitFile);
 		$modifiedFilePhpcsMessages = PhpcsMessages::fromPhpcsJson($modifiedFilePhpcsOutput, $fileName);
 		$hasNewPhpcsMessages = !empty($modifiedFilePhpcsMessages->getMessages());
 

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace PhpcsChanged\Cli;
 
+use PhpcsChanged\CliOptions;
 use PhpcsChanged\NoChangesException;
 use PhpcsChanged\Reporter;
 use PhpcsChanged\JsonReporter;
@@ -418,10 +419,10 @@ function runGitWorkflowForFile(string $gitFile, array $options, ShellOperator $s
 	return getNewPhpcsMessages($unifiedDiff, PhpcsMessages::fromPhpcsJson($unmodifiedFilePhpcsOutput, $fileName), $modifiedFilePhpcsMessages);
 }
 
-function reportMessagesAndExit(PhpcsMessages $messages, string $reportType, array $options): void {
-	$reporter = getReporter($reportType);
-	echo $reporter->getFormattedMessages($messages, $options);
-	if ( isset($options['always-exit-zero']) ) {
+function reportMessagesAndExit(PhpcsMessages $messages, CliOptions $options): void {
+	$reporter = getReporter($options->reporter);
+	echo $reporter->getFormattedMessages($messages, $options->toArray());
+	if ($options->alwaysExitZero) {
 		exit(0);
 	}
 	exit($reporter->getExitCode($messages));

--- a/PhpcsChanged/CliOptions.php
+++ b/PhpcsChanged/CliOptions.php
@@ -100,6 +100,9 @@ class CliOptions {
 
 	public static function fromArray(array $options): self {
 		$cliOptions = new self();
+		// Note that this array is likely created by `getopt()` which sets any
+		// boolean option to `false`, meaning that we must use `isset()` to
+		// determine if these options are set.
 		if (isset($options['files'])) {
 			$cliOptions->files = $options['files'];
 		}
@@ -174,6 +177,7 @@ class CliOptions {
 	public function toArray(): array {
 		$options = [];
 		$options['report'] = $this->reporter;
+		$options['files'] = $this->files;
 		if ($this->phpcsStandard) {
 			$options['standard'] = $this->phpcsStandard;
 		}

--- a/PhpcsChanged/CliOptions.php
+++ b/PhpcsChanged/CliOptions.php
@@ -1,0 +1,258 @@
+<?php
+declare(strict_types=1);
+
+namespace PhpcsChanged;
+use PhpcsChanged\InvalidOptionException;
+
+class CliOptions {
+	/**
+	 * @var 'svn'|'manual'|'git-staged'|'git-unstaged'|'git-base'|null
+	 */
+	public $mode;
+
+	/**
+	 * @var string[]
+	 */
+	public $files = [];
+
+	/**
+	 * Requires mode to be 'base'
+	 *
+	 * @var string
+	 */
+	public $gitBase = '';
+
+	/**
+	 * Requires mode to be 'manual'
+	 *
+	 * @var string
+	 */
+	public $phpcsUnmodified = '';
+
+	/**
+	 * Requires mode to be 'manual'
+	 *
+	 * @var string
+	 */
+	public $phpcsModified = '';
+
+	/**
+	 * Requires mode to be 'manual'
+	 *
+	 * @var string
+	 */
+	public $diffFile = '';
+
+	/**
+	 * @var bool
+	 */
+	public $showMessageCodes = false;
+
+	/**
+	 * @var 'full'|'json'|'xml'
+	 */
+	public $reporter = 'full';
+
+	/**
+	 * @var bool
+	 */
+	public $debug = false;
+
+	/**
+	 * @var bool
+	 */
+	public $clearCache = false;
+
+	/**
+	 * @var bool
+	 */
+	public $useCache = false;
+
+	/**
+	 * @var string|null
+	 */
+	public $phpcsStandard = null;
+
+	/**
+	 * @var bool
+	 */
+	public $alwaysExitZero = false;
+
+	/**
+	 * @var bool
+	 */
+	public $noCacheGitRoot = false;
+
+	/**
+	 * @var bool
+	 */
+	public $noVerifyGitFile = false;
+
+	/**
+	 * @var string|null
+	 */
+	public $warningSeverity = null;
+
+	/**
+	 * @var string|null
+	 */
+	public $errorSeverity = null;
+
+	public static function fromArray(array $options): self {
+		$cliOptions = new self();
+		$cliOptions->reporter = $options['report'];
+		if (isset($options['files'])) {
+			$cliOptions->files = $options['files'];
+		}
+		if (isset($options['svn'])) {
+			$cliOptions->mode = 'svn';
+		}
+		if (isset($options['git'])) {
+			$cliOptions->mode = 'git-staged';
+		}
+		if (isset($options['git-unstaged'])) {
+			$cliOptions->mode = 'git-unstaged';
+		}
+		if (isset($options['git-staged'])) {
+			$cliOptions->mode = 'git-staged';
+		}
+		if (isset($options['git-base'])) {
+			$cliOptions->mode = 'git-base';
+			$cliOptions->gitBase = $options['git-base'];
+		}
+		if (isset($options['debug'])) {
+			$cliOptions->debug = true;
+		}
+		if (isset($options['clear-cache'])) {
+			$cliOptions->clearCache = true;
+		}
+		if (isset($options['cache'])) {
+			$cliOptions->useCache = true;
+		}
+		if (isset($options['no-cache'])) {
+			$cliOptions->useCache = false;
+		}
+		if (isset($options['diff'])) {
+			$cliOptions->mode = 'manual';
+			$cliOptions->diffFile = $options['diff'];
+		}
+		if (isset($options['phpcs-unmodified'])) {
+			$cliOptions->mode = 'manual';
+			$cliOptions->phpcsUnmodified = $options['phpcs-unmodified'];
+		}
+		if (isset($options['phpcs-modified'])) {
+			$cliOptions->mode = 'manual';
+			$cliOptions->phpcsModified = $options['phpcs-modified'];
+		}
+		if (isset($options['s'])) {
+			$cliOptions->showMessageCodes = true;
+		}
+		if (isset($options['standard'])) {
+			$cliOptions->phpcsStandard = $options['standard'];
+		}
+		if (isset($options['always-exit-zero'])) {
+			$cliOptions->alwaysExitZero = true;
+		}
+		if (isset($options['no-cache-git-root'])) {
+			$cliOptions->noCacheGitRoot = true;
+		}
+		if (isset($options['no-verify-git-file'])) {
+			$cliOptions->noVerifyGitFile = true;
+		}
+		if (isset($options['warning-severity'])) {
+			$cliOptions->warningSeverity = $options['warning-severity'];
+		}
+		if (isset($options['error-severity'])) {
+			$cliOptions->errorSeverity = $options['error-severity'];
+		}
+		$cliOptions->validate();
+		return $cliOptions;
+	}
+
+	public function toArray(): array {
+		$options = [];
+		$options['report'] = $this->reporter;
+		if ($this->phpcsStandard) {
+			$options['standard'] = $this->phpcsStandard;
+		}
+		if ($this->debug) {
+			$options['debug'] = true;
+		}
+		if ($this->showMessageCodes) {
+			$options['s'] = true;
+		}
+		if ($this->mode === Modes::SVN) {
+			$options['svn'] = true;
+		}
+		if ($this->mode === Modes::GIT_STAGED) {
+			$options['git'] = true;
+			$options['git-staged'] = true;
+		}
+		if ($this->mode === Modes::GIT_UNSTAGED) {
+			$options['git'] = true;
+			$options['git-unstaged'] = true;
+		}
+		if ($this->mode === Modes::GIT_BASE) {
+			$options['git'] = true;
+			$options['git-base'] = $this->gitBase;
+		}
+		if ($this->debug) {
+			$options['debug'] = true;
+		}
+		if ($this->useCache) {
+			$options['cache'] = true;
+		}
+		if (! $this->useCache) {
+			$options['no-cache'] = true;
+		}
+		if ($this->clearCache) {
+			$options['clear-cache'] = true;
+		}
+		if ($this->mode === Modes::MANUAL) {
+			$options['diff'] = $this->diffFile;
+			$options['phpcs-unmodified'] = $this->phpcsUnmodified;
+			$options['phpcs-modified'] = $this->phpcsModified;
+		}
+		if ($this->alwaysExitZero) {
+			$options['always-exit-zero'] = true;
+		}
+		if ($this->noCacheGitRoot) {
+			$options['no-cache-git-root'] = true;
+		}
+		if ($this->noVerifyGitFile) {
+			$options['no-verify-git-file'] = true;
+		}
+		if ($this->warningSeverity) {
+			$options['warning-severity'] = $this->warningSeverity;
+		}
+		if ($this->errorSeverity) {
+			$options['error-severity'] = $this->errorSeverity;
+		}
+		return $options;
+	}
+
+	public function isGitMode(): bool {
+		$gitModes = [Modes::GIT_BASE, Modes::GIT_UNSTAGED, Modes::GIT_STAGED];
+		return in_array($this->mode, $gitModes, true);
+	}
+
+	public function validate(): void {
+		if (empty($this->mode)) {
+			throw new InvalidOptionException('You must use either automatic or manual mode.');
+		}
+		if ($this->mode === Modes::MANUAL) {
+			if (empty($this->diff) || empty($this->phpcsUnmodified) || empty($this->phpcsModified)) {
+				throw new InvalidOptionException('Manual mode requires a diff, the unmodified file phpcs output, and the modified file phpcs output.');
+			}
+		}
+		if ($this->mode === Modes::GIT_BASE && empty($this->gitBase)) {
+			throw new InvalidOptionException('git-base mode requires a git object.');
+		}
+		if ($this->isGitMode() && empty($this->files)) {
+			throw new InvalidOptionException('You must supply at least one file or directory to run in git mode.');
+		}
+		if ($this->mode === Modes::SVN && empty($this->files)) {
+			throw new InvalidOptionException('You must supply at least one file or directory to run in svn mode.');
+		}
+	}
+}

--- a/PhpcsChanged/CliOptions.php
+++ b/PhpcsChanged/CliOptions.php
@@ -202,9 +202,6 @@ class CliOptions {
 			$options['git'] = true;
 			$options['git-base'] = $this->gitBase;
 		}
-		if ($this->debug) {
-			$options['debug'] = true;
-		}
 		if ($this->useCache) {
 			$options['cache'] = true;
 		}

--- a/PhpcsChanged/CliOptions.php
+++ b/PhpcsChanged/CliOptions.php
@@ -100,7 +100,6 @@ class CliOptions {
 
 	public static function fromArray(array $options): self {
 		$cliOptions = new self();
-		$cliOptions->reporter = $options['report'];
 		if (isset($options['files'])) {
 			$cliOptions->files = $options['files'];
 		}
@@ -119,6 +118,9 @@ class CliOptions {
 		if (isset($options['git-base'])) {
 			$cliOptions->mode = 'git-base';
 			$cliOptions->gitBase = $options['git-base'];
+		}
+		if (isset($options['report'])) {
+			$cliOptions->reporter = $options['report'];
 		}
 		if (isset($options['debug'])) {
 			$cliOptions->debug = true;

--- a/PhpcsChanged/InvalidOptionException.php
+++ b/PhpcsChanged/InvalidOptionException.php
@@ -1,0 +1,7 @@
+<?php
+declare(strict_types=1);
+
+namespace PhpcsChanged;
+
+class InvalidOptionException extends \Exception {
+}

--- a/PhpcsChanged/JsonReporter.php
+++ b/PhpcsChanged/JsonReporter.php
@@ -39,7 +39,7 @@ class JsonReporter implements Reporter {
 				'warnings' => count($warnings),
 				'fixable' => 0,
 			],
-			'files' => array_merge(...$outputByFile),
+			'files' => array_merge([], ...$outputByFile),
 		];
 		$output = json_encode($dataForJson, JSON_UNESCAPED_SLASHES);
 		if (! $output) {

--- a/PhpcsChanged/LintMessages.php
+++ b/PhpcsChanged/LintMessages.php
@@ -25,7 +25,7 @@ class LintMessages {
 	 * @return static
 	 */
 	public static function merge(array $messages) {
-		return self::fromLintMessages(array_merge(...array_map(function(self $message) {
+		return self::fromLintMessages(array_merge([], ...array_map(function(self $message) {
 			return $message->getMessages();
 		}, $messages)));
 	}

--- a/PhpcsChanged/Modes.php
+++ b/PhpcsChanged/Modes.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace PhpcsChanged;
+
+class Modes {
+	const SVN = 'svn';
+	const MANUAL = 'manual';
+	const GIT_STAGED = 'git-staged';
+	const GIT_UNSTAGED = 'git-unstaged';
+	const GIT_BASE = 'git-base';
+}

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ You can also run linting and static analysis:
 
 ```
 composer lint
-composer phpstan
+composer static-analysis
 ```
 
 ## Debugging

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ More than one file can be specified after a version control option, including gl
 
 You can use `--ignore` to ignore any directory, file, or paths matching provided pattern(s). For example.: `--ignore=bin/*,vendor/*` would ignore any files in bin directory, as well as in vendor.
 
-You can use `--report` to customize the output type. `full` (the default) is human-readable and `json` prints a JSON object as shown above. These match the phpcs reporters of the same names.
+You can use `--report` to customize the output type. `full` (the default) is human-readable, `json` prints a JSON object as shown above, and 'xml' can be used by IDEs. These match the phpcs reporters of the same names.
 
 You can use `--standard` to specify a specific phpcs standard to run. This matches the phpcs option of the same name.
 

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -128,10 +128,9 @@ if (count($options) === 0) {
 }
 
 $debug = getDebug(isset($options['debug']));
-run($options, $fileNamesExpanded, $debug);
+run($options, $debug);
 
-function run(array $rawOptions, array $fileNamesExpanded, callable $debug): void {
-	$debug('Running on filenames: ' . implode(', ', $fileNamesExpanded));
+function run(array $rawOptions, callable $debug): void {
 	$debug('Options: ' . json_encode($rawOptions));
 	try {
 		$options = CliOptions::fromArray($rawOptions);
@@ -139,6 +138,7 @@ function run(array $rawOptions, array $fileNamesExpanded, callable $debug): void
 		printErrorAndExit($err->getMessage());
 		exit(1);
 	}
+	$debug('Running on filenames: ' . implode(', ', $options->files));
 
 	if ($options->mode === Modes::MANUAL) {
 		reportMessagesAndExit(
@@ -152,7 +152,7 @@ function run(array $rawOptions, array $fileNamesExpanded, callable $debug): void
 	if ($options->mode === Modes::SVN) {
 		$shell = new UnixShell();
 		reportMessagesAndExit(
-			runSvnWorkflow($fileNamesExpanded, $options->toArray(), $shell, new CacheManager(new FileCache(), $debug), $debug),
+			runSvnWorkflow($options->files, $options->toArray(), $shell, new CacheManager(new FileCache(), $debug), $debug),
 			$options->reporter,
 			$options->toArray()
 		);
@@ -162,7 +162,7 @@ function run(array $rawOptions, array $fileNamesExpanded, callable $debug): void
 	if ($options->isGitMode()) {
 		$shell = new UnixShell();
 		reportMessagesAndExit(
-			runGitWorkflow($fileNamesExpanded, $options->toArray(), $shell, new CacheManager(new FileCache(), $debug), $debug),
+			runGitWorkflow($options->files, $options->toArray(), $shell, new CacheManager(new FileCache(), $debug), $debug),
 			$options->reporter,
 			$options->toArray()
 		);

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -143,8 +143,7 @@ function run(array $rawOptions, callable $debug): void {
 	if ($options->mode === Modes::MANUAL) {
 		reportMessagesAndExit(
 			runManualWorkflow($diffFile, $phpcsUnmodifiedFile, $phpcsModifiedFile),
-			$options->reporter,
-			$options->toArray()
+			$options
 		);
 		return;
 	}
@@ -153,8 +152,7 @@ function run(array $rawOptions, callable $debug): void {
 		$shell = new UnixShell();
 		reportMessagesAndExit(
 			runSvnWorkflow($options->files, $options->toArray(), $shell, new CacheManager(new FileCache(), $debug), $debug),
-			$options->reporter,
-			$options->toArray()
+			$options
 		);
 		return;
 	}
@@ -163,8 +161,7 @@ function run(array $rawOptions, callable $debug): void {
 		$shell = new UnixShell();
 		reportMessagesAndExit(
 			runGitWorkflow($options->files, $options->toArray(), $shell, new CacheManager(new FileCache(), $debug), $debug),
-			$options->reporter,
-			$options->toArray()
+			$options
 		);
 		return;
 	}

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -65,7 +65,7 @@ $fileNames = array_slice($argv, $optind);
 $fileNamesExpanded = [];
 foreach( $fileNames as $file ) {
 	if (is_dir($file)) {
-		if ( shouldIgnorePath($file, $options['ignore'] ?? null, '') ) {
+		if (shouldIgnorePath($file, is_string($options['ignore']) ? $options['ignore'] : null)) {
 			continue;
 		}
 		$iterator = new \RecursiveIteratorIterator(new \RecursiveCallbackFilterIterator(new \RecursiveDirectoryIterator($file, (\RecursiveDirectoryIterator::SKIP_DOTS | \FilesystemIterator::FOLLOW_SYMLINKS)), function($file, $key, $iterator){
@@ -75,12 +75,12 @@ foreach( $fileNames as $file ) {
 			return $iterator->hasChildren() || $file->isFile() ? true : false;
 		}));
 		foreach ($iterator as $file) {
-			if (shouldIgnorePath($file->getPathName(), $options['ignore'] ?? null,'')) {
+			if (shouldIgnorePath($file->getPathName(), is_string($options['ignore']) ? $options['ignore'] : null)) {
 				continue;
 			}
 			$fileNamesExpanded[] = $file->getPathName();
 		}
-	} elseif (!shouldIgnorePath($file, $options['ignore'] ?? null, '')) {
+	} elseif (!shouldIgnorePath($file, is_string($options['ignore']) ? $options['ignore'] : null)) {
 		$fileNamesExpanded[] = $file;
 	}
 }

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -137,7 +137,7 @@ function run(array $rawOptions, callable $debug): void {
 
 	if ($options->mode === Modes::MANUAL) {
 		reportMessagesAndExit(
-			runManualWorkflow($diffFile, $phpcsUnmodifiedFile, $phpcsModifiedFile),
+			runManualWorkflow($options->diffFile, $options->phpcsUnmodified, $options->phpcsModified),
 			$options
 		);
 		return;

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -143,7 +143,7 @@ function run(array $rawOptions, array $fileNamesExpanded, callable $debug): void
 	if ($options->mode === Modes::MANUAL) {
 		reportMessagesAndExit(
 			runManualWorkflow($diffFile, $phpcsUnmodifiedFile, $phpcsModifiedFile),
-			$reportType,
+			$options->reporter,
 			$options->toArray()
 		);
 		return;
@@ -153,7 +153,7 @@ function run(array $rawOptions, array $fileNamesExpanded, callable $debug): void
 		$shell = new UnixShell();
 		reportMessagesAndExit(
 			runSvnWorkflow($fileNamesExpanded, $options->toArray(), $shell, new CacheManager(new FileCache(), $debug), $debug),
-			$reportType,
+			$options->reporter,
 			$options->toArray()
 		);
 		return;
@@ -163,7 +163,7 @@ function run(array $rawOptions, array $fileNamesExpanded, callable $debug): void
 		$shell = new UnixShell();
 		reportMessagesAndExit(
 			runGitWorkflow($fileNamesExpanded, $options->toArray(), $shell, new CacheManager(new FileCache(), $debug), $debug),
-			$reportType,
+			$options->reporter,
 			$options->toArray()
 		);
 		return;

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -65,7 +65,7 @@ $fileNames = array_slice($argv, $optind);
 $fileNamesExpanded = [];
 foreach( $fileNames as $file ) {
 	if (is_dir($file)) {
-		if (shouldIgnorePath($file, is_string($options['ignore']) ? $options['ignore'] : null)) {
+		if (shouldIgnorePath($file, isset($options['ignore']) && is_string($options['ignore']) ? $options['ignore'] : null)) {
 			continue;
 		}
 		$iterator = new \RecursiveIteratorIterator(new \RecursiveCallbackFilterIterator(new \RecursiveDirectoryIterator($file, (\RecursiveDirectoryIterator::SKIP_DOTS | \FilesystemIterator::FOLLOW_SYMLINKS)), function($file, $key, $iterator){
@@ -75,12 +75,12 @@ foreach( $fileNames as $file ) {
 			return $iterator->hasChildren() || $file->isFile() ? true : false;
 		}));
 		foreach ($iterator as $file) {
-			if (shouldIgnorePath($file->getPathName(), is_string($options['ignore']) ? $options['ignore'] : null)) {
+			if (shouldIgnorePath($file->getPathName(), isset($options['ignore']) && is_string($options['ignore']) ? $options['ignore'] : null)) {
 				continue;
 			}
 			$fileNamesExpanded[] = $file->getPathName();
 		}
-	} elseif (!shouldIgnorePath($file, is_string($options['ignore']) ? $options['ignore'] : null)) {
+	} elseif (!shouldIgnorePath($file, isset($options['ignore']) && is_string($options['ignore']) ? $options['ignore'] : null)) {
 		$fileNamesExpanded[] = $file;
 	}
 }

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -23,6 +23,9 @@ use function PhpcsChanged\Cli\{
 use PhpcsChanged\UnixShell;
 use PhpcsChanged\CacheManager;
 use PhpcsChanged\FileCache;
+use PhpcsChanged\CliOptions;
+use PhpcsChanged\InvalidOptionException;
+use PhpcsChanged\Modes;
 
 $optind = 0;
 $options = getopt(
@@ -65,7 +68,7 @@ foreach( $fileNames as $file ) {
 		if ( shouldIgnorePath($file, $options['ignore'] ?? null, '') ) {
 			continue;
 		}
-		$iterator = new RecursiveIteratorIterator(new RecursiveCallbackFilterIterator(new RecursiveDirectoryIterator($file, (RecursiveDirectoryIterator::SKIP_DOTS | FilesystemIterator::FOLLOW_SYMLINKS)), function($file, $key, $iterator){
+		$iterator = new \RecursiveIteratorIterator(new \RecursiveCallbackFilterIterator(new \RecursiveDirectoryIterator($file, (\RecursiveDirectoryIterator::SKIP_DOTS | \FilesystemIterator::FOLLOW_SYMLINKS)), function($file, $key, $iterator){
 			if ($file->isFile() && !fileHasValidExtension($file)) {
 				return false;
 			}
@@ -117,55 +120,55 @@ if (isset($options['phpcs-new'])) {
 	unset($options['phpcs-new']);
 }
 
+$options['files'] = $fileNamesExpanded;
+
+if (count($options) === 0) {
+	printHelp();
+	exit(1);
+}
+
 $debug = getDebug(isset($options['debug']));
 run($options, $fileNamesExpanded, $debug);
 
-function run(array $options, array $fileNamesExpanded, callable $debug): void {
+function run(array $rawOptions, array $fileNamesExpanded, callable $debug): void {
 	$debug('Running on filenames: ' . implode(', ', $fileNamesExpanded));
-	$debug('Options: ' . json_encode($options));
-	$reportType = $options['report'] ?? 'full';
-	$diffFile = $options['diff'] ?? null;
-	$phpcsUnmodifiedFile = $options['phpcs-unmodified'] ?? null;
-	$phpcsModifiedFile = $options['phpcs-modified'] ?? null;
+	$debug('Options: ' . json_encode($rawOptions));
+	try {
+		$options = CliOptions::fromArray($rawOptions);
+	} catch ( InvalidOptionException $err ) {
+		printErrorAndExit($err->getMessage());
+		exit(1);
+	}
 
-	if ($diffFile && $phpcsUnmodifiedFile && $phpcsModifiedFile) {
+	if ($options->mode === Modes::MANUAL) {
 		reportMessagesAndExit(
 			runManualWorkflow($diffFile, $phpcsUnmodifiedFile, $phpcsModifiedFile),
 			$reportType,
-			$options
+			$options->toArray()
 		);
 		return;
 	}
 
-	if ((isset($options['svn']) || isset($options['git'])) && empty($fileNamesExpanded)) {
-		printErrorAndExit('You must supply at least one file or directory to process.');
-		return;
-	}
-
-	if (isset($options['svn'])) {
+	if ($options->mode === Modes::SVN) {
 		$shell = new UnixShell();
 		reportMessagesAndExit(
-			runSvnWorkflow($fileNamesExpanded, $options, $shell, new CacheManager(new FileCache(), $debug), $debug),
+			runSvnWorkflow($fileNamesExpanded, $options->toArray(), $shell, new CacheManager(new FileCache(), $debug), $debug),
 			$reportType,
-			$options
+			$options->toArray()
 		);
 		return;
 	}
 
-	if (isset($options['git'])) {
+	if ($options->isGitMode()) {
 		$shell = new UnixShell();
 		reportMessagesAndExit(
-			runGitWorkflow($fileNamesExpanded, $options, $shell, new CacheManager(new FileCache(), $debug), $debug),
+			runGitWorkflow($fileNamesExpanded, $options->toArray(), $shell, new CacheManager(new FileCache(), $debug), $debug),
 			$reportType,
-			$options
+			$options->toArray()
 		);
 		return;
 	}
 
-	if (count($options) > 0) {
-		printErrorAndExit('You must use either manual or automatic mode.');
-		return;
-	}
 	printHelp();
 	exit(1);
 }

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -122,11 +122,6 @@ if (isset($options['phpcs-new'])) {
 
 $options['files'] = $fileNamesExpanded;
 
-if (count($options) === 0) {
-	printHelp();
-	exit(1);
-}
-
 $debug = getDebug(isset($options['debug']));
 run($options, $debug);
 

--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,11 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "scripts": {
-        "precommit": "composer test && composer lint && composer phpstan",
+        "precommit": "composer test && composer lint && composer static-analysis",
         "test": "./vendor/bin/phpunit --color=always --verbose",
         "lint": "./vendor/bin/phpcs -s PhpcsChanged bin tests index.php",
-        "phpstan": "./vendor/bin/phpstan analyze PhpcsChanged/ bin/phpcs-changed",
-        "static-analysis": "composer phpstan"
+        "psalm": "./vendor/bin/psalm --no-cache bin/phpcs-changed",
+        "static-analysis": "composer psalm"
     },
     "bin": [
         "bin/phpcs-changed"
@@ -46,6 +46,6 @@
         "phpunit/phpunit": "^6.4 || ^9.5",
         "squizlabs/php_codesniffer": "^3.2.1",
         "sirbrillig/phpcs-variable-analysis": "^2.1.3",
-        "phpstan/phpstan": "1.4.10 || ^1.7"
+        "vimeo/psalm": "^0.2 || ^0.3 || ^1.1 || ^4.24 || ^5.0@beta"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "precommit": "composer test && composer lint && composer phpstan",
         "test": "./vendor/bin/phpunit --color=always --verbose",
         "lint": "./vendor/bin/phpcs -s PhpcsChanged bin tests index.php",
-        "phpstan": "./vendor/bin/phpstan analyze PhpcsChanged/"
+        "phpstan": "./vendor/bin/phpstan analyze PhpcsChanged/ bin/phpcs-changed",
+        "static-analysis": "composer phpstan"
     },
     "bin": [
         "bin/phpcs-changed"

--- a/index.php
+++ b/index.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 namespace PhpcsChanged;
 
 // Classes
+require_once __DIR__ . '/PhpcsChanged/Modes.php';
+require_once __DIR__ . '/PhpcsChanged/InvalidOptionException.php';
+require_once __DIR__ . '/PhpcsChanged/CliOptions.php';
 require_once __DIR__ . '/PhpcsChanged/DiffLine.php';
 require_once __DIR__ . '/PhpcsChanged/DiffLineType.php';
 require_once __DIR__ . '/PhpcsChanged/DiffLineMap.php';

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,0 @@
-parameters:
-	level: max
-	inferPrivatePropertyTypeFromConstructor: true
-	checkMissingIterableValueType: false

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<psalm
+    errorLevel="2"
+    resolveFromConfigFile="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+>
+    <projectFiles>
+        <file name="bin/phpcs-changed" />
+        <directory name="PhpcsChanged" />
+        <ignoreFiles>
+            <directory name="vendor" />
+        </ignoreFiles>
+    </projectFiles>
+    <issueHandlers>
+      <MissingConstructor errorLevel="suppress" />
+      <PropertyNotSetInConstructor errorLevel="suppress" />
+    </issueHandlers>
+</psalm>


### PR DESCRIPTION
This replaces the options array with a `CliOptions` class that has validation.

This is a second attempt, since https://github.com/sirbrillig/phpcs-changed/pull/48 took too long and was too big a refactor. This time, we create the `CliOptions` class but then convert it back into an array to allow for easier migration.

In later PRs we can migrate other functions to accept `CliOptions` instead of the array.