### PR TITLE
Move git file existence check to ShellOperator

### DIFF
--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -177,14 +177,14 @@ Overrides:
 EOF;
 }
 
-function getReporter(string $reportType): Reporter {
+function getReporter(string $reportType, CliOptions $options): Reporter {
 	switch ($reportType) {
 		case 'full':
 			return new FullReporter();
 		case 'json':
 			return new JsonReporter();
 		case 'xml':
-			return new XmlReporter();
+			return new XmlReporter($options);
 	}
 	printErrorAndExit("Unknown Reporter '{$reportType}'");
 	throw new \Exception("Unknown Reporter '{$reportType}'"); // Just in case we don't exit for some reason.
@@ -420,7 +420,7 @@ function runGitWorkflowForFile(string $gitFile, CliOptions $options, ShellOperat
 }
 
 function reportMessagesAndExit(PhpcsMessages $messages, CliOptions $options): void {
-	$reporter = getReporter($options->reporter);
+	$reporter = getReporter($options->reporter, $options);
 	echo $reporter->getFormattedMessages($messages, $options->toArray());
 	if ($options->alwaysExitZero) {
 		exit(0);

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -335,7 +335,7 @@ function runGitWorkflow(CliOptions $options, ShellOperator $shell, CacheManager 
 	loadCache($cache, $shell, $options->toArray());
 
 	$phpcsMessages = array_map(function(string $gitFile) use ($options, $shell, $cache, $debug): PhpcsMessages {
-		return runGitWorkflowForFile($gitFile, $options->toArray(), $shell, $cache, $debug);
+		return runGitWorkflowForFile($gitFile, $options, $shell, $cache, $debug);
 	}, $options->files);
 
 	saveCache($cache, $shell, $options->toArray());
@@ -343,33 +343,33 @@ function runGitWorkflow(CliOptions $options, ShellOperator $shell, CacheManager 
 	return PhpcsMessages::merge($phpcsMessages);
 }
 
-function runGitWorkflowForFile(string $gitFile, array $options, ShellOperator $shell, CacheManager $cache, callable $debug): PhpcsMessages {
+function runGitWorkflowForFile(string $gitFile, CliOptions $options, ShellOperator $shell, CacheManager $cache, callable $debug): PhpcsMessages {
 	$git = getenv('GIT') ?: 'git';
 	$phpcs = getenv('PHPCS') ?: 'phpcs';
 	$cat = getenv('CAT') ?: 'cat';
 
-	$phpcsStandard = $options['standard'] ?? null;
+	$phpcsStandard = $options->phpcsStandard;
 	$phpcsStandardOption = $phpcsStandard ? ' --standard=' . escapeshellarg($phpcsStandard) : '';
 
-	$warningSeverity = $options['warning-severity'] ?? null;
+	$warningSeverity = $options->warningSeverity;
 	$phpcsStandardOption .= isset($warningSeverity) ? ' --warning-severity=' . escapeshellarg($warningSeverity) : '';
-	$errorSeverity = $options['error-severity'] ?? null;
+	$errorSeverity = $options->errorSeverity;
 	$phpcsStandardOption .= isset($errorSeverity) ? ' --error-severity=' . escapeshellarg($errorSeverity) : '';
 	$fileName = $shell->getFileNameFromPath($gitFile);
 
 	try {
-		validateGitFileExists($gitFile, $git, [$shell, 'isReadable'], [$shell, 'executeCommand'], $debug, $options);
+		validateGitFileExists($gitFile, $shell, $options);
 
 		$modifiedFilePhpcsOutput = null;
 		$modifiedFileHash = '';
-		if (isCachingEnabled($options)) {
-			$modifiedFileHash = getModifiedGitFileHash($gitFile, $git, $cat, [$shell, 'executeCommand'], $options, $debug);
+		if (isCachingEnabled($options->toArray())) {
+			$modifiedFileHash = getModifiedGitFileHash($gitFile, $git, $cat, [$shell, 'executeCommand'], $options->toArray(), $debug);
 			$modifiedFilePhpcsOutput = $cache->getCacheForFile($gitFile, 'new', $modifiedFileHash, $phpcsStandard ?? '', $warningSeverity ?? '', $errorSeverity ?? '');
 			$debug(($modifiedFilePhpcsOutput ? 'Using' : 'Not using') . " cache for modified file '{$gitFile}' at hash '{$modifiedFileHash}', and standard '{$phpcsStandard}'");
 		}
 		if (! $modifiedFilePhpcsOutput) {
-			$modifiedFilePhpcsOutput = getGitModifiedPhpcsOutput($gitFile, $git, $phpcs, $cat, $phpcsStandardOption, [$shell, 'executeCommand'], $options, $debug);
-			if (isCachingEnabled($options)) {
+			$modifiedFilePhpcsOutput = getGitModifiedPhpcsOutput($gitFile, $git, $phpcs, $cat, $phpcsStandardOption, [$shell, 'executeCommand'], $options->toArray(), $debug);
+			if (isCachingEnabled($options->toArray())) {
 				$cache->setCacheForFile($gitFile, 'new', $modifiedFileHash, $phpcsStandard ?? '', $warningSeverity ?? '', $errorSeverity ?? '', $modifiedFilePhpcsOutput);
 			}
 		}
@@ -383,23 +383,23 @@ function runGitWorkflowForFile(string $gitFile, array $options, ShellOperator $s
 			throw new NoChangesException("Modified file '{$gitFile}' has no PHPCS messages; skipping");
 		}
 
-		$isNewFile = isNewGitFile($gitFile, $git, [$shell, 'executeCommand'], $options, $debug);
+		$isNewFile = isNewGitFile($gitFile, $git, [$shell, 'executeCommand'], $options->toArray(), $debug);
 		if ($isNewFile) {
 			$debug('Skipping the linting of the unmodified file as it is a new file.');
 		}
 		if (! $isNewFile) {
 			$debug('Checking the unmodified file with PHPCS since the file is not new and contains some messages.');
-			$unifiedDiff = getGitUnifiedDiff($gitFile, $git, [$shell, 'executeCommand'], $options, $debug);
+			$unifiedDiff = getGitUnifiedDiff($gitFile, $git, [$shell, 'executeCommand'], $options->toArray(), $debug);
 			$unmodifiedFilePhpcsOutput = null;
 			$unmodifiedFileHash = '';
-			if (isCachingEnabled($options)) {
-				$unmodifiedFileHash = getUnmodifiedGitFileHash($gitFile, $git, $cat, [$shell, 'executeCommand'], $options, $debug);
+			if (isCachingEnabled($options->toArray())) {
+				$unmodifiedFileHash = getUnmodifiedGitFileHash($gitFile, $git, $cat, [$shell, 'executeCommand'], $options->toArray(), $debug);
 				$unmodifiedFilePhpcsOutput = $cache->getCacheForFile($gitFile, 'old', $unmodifiedFileHash, $phpcsStandard ?? '', $warningSeverity ?? '', $errorSeverity ?? '');
 				$debug(($unmodifiedFilePhpcsOutput ? 'Using' : 'Not using') . " cache for unmodified file '{$gitFile}' at hash '{$unmodifiedFileHash}', and standard '{$phpcsStandard}'");
 			}
 			if (! $unmodifiedFilePhpcsOutput) {
-				$unmodifiedFilePhpcsOutput = getGitUnmodifiedPhpcsOutput($gitFile, $git, $phpcs, $phpcsStandardOption, [$shell, 'executeCommand'], $options, $debug);
-				if (isCachingEnabled($options)) {
+				$unmodifiedFilePhpcsOutput = getGitUnmodifiedPhpcsOutput($gitFile, $git, $phpcs, $phpcsStandardOption, [$shell, 'executeCommand'], $options->toArray(), $debug);
+				if (isCachingEnabled($options->toArray())) {
 					$cache->setCacheForFile($gitFile, 'old', $unmodifiedFileHash, $phpcsStandard ?? '', $warningSeverity ?? '', $errorSeverity ?? '', $unmodifiedFilePhpcsOutput);
 				}
 			}

--- a/PhpcsChanged/GitWorkflow.php
+++ b/PhpcsChanged/GitWorkflow.php
@@ -3,22 +3,22 @@ declare(strict_types=1);
 
 namespace PhpcsChanged\GitWorkflow;
 
+use PhpcsChanged\CliOptions;
 use PhpcsChanged\NoChangesException;
 use PhpcsChanged\ShellException;
+use PhpcsChanged\ShellOperator;
+use function PhpcsChanged\Cli\getDebug;
 
-function validateGitFileExists(string $gitFile, string $git, callable $isReadable, callable $executeCommand, callable $debug, array $options): void {
-	if (isset($options['no-verify-git-file'])) {
+function validateGitFileExists(string $gitFile, ShellOperator $shell, CliOptions $options): void {
+	$debug = getDebug($options->debug);
+	if (isset($options->noVerifyGitFile)) {
 		$debug('skipping Git file exists check.');
 		return;
 	}
-	if (! $isReadable($gitFile)) {
+	if (! $shell->isReadable($gitFile)) {
 		throw new ShellException("Cannot read file '{$gitFile}'");
 	}
-	$gitStatusCommand = "{$git} status --porcelain " . escapeshellarg($gitFile);
-	$debug('checking git existence of file with command:', $gitStatusCommand);
-	$gitStatusOutput = $executeCommand($gitStatusCommand);
-	$debug('git status output:', $gitStatusOutput);
-	if (isset($gitStatusOutput[0]) && $gitStatusOutput[0] === '?') {
+	if (! $shell->doesFileExistInGit($gitFile)) {
 		throw new ShellException("File does not appear to be tracked by git: '{$gitFile}'");
 	}
 }

--- a/PhpcsChanged/ShellOperator.php
+++ b/PhpcsChanged/ShellOperator.php
@@ -3,13 +3,19 @@ declare(strict_types=1);
 
 namespace PhpcsChanged;
 
+use PhpcsChanged\CliOptions;
+
 /**
  * Interface to perform file and shell operations
  */
 interface ShellOperator {
+	public function __construct(CliOptions $options);
+
 	public function validateExecutableExists(string $name, string $command): void;
 
 	public function executeCommand(string $command, array &$output = null, int &$return_val = null): string;
+
+	public function doesFileExistInGit(string $fileName): bool;
 
 	public function isReadable(string $fileName): bool;
 

--- a/PhpcsChanged/ShellOperator.php
+++ b/PhpcsChanged/ShellOperator.php
@@ -9,8 +9,6 @@ use PhpcsChanged\CliOptions;
  * Interface to perform file and shell operations
  */
 interface ShellOperator {
-	public function __construct(CliOptions $options);
-
 	public function validateExecutableExists(string $name, string $command): void;
 
 	public function executeCommand(string $command, array &$output = null, int &$return_val = null): string;

--- a/PhpcsChanged/UnixShell.php
+++ b/PhpcsChanged/UnixShell.php
@@ -12,10 +12,13 @@ use function PhpcsChanged\Cli\getDebug;
  * Module to perform file and shell operations
  */
 class UnixShell implements ShellOperator {
-	private $debug;
+	/**
+	 * @var CliOptions
+	 */
+	private $options;
 
 	public function __construct(CliOptions $options) {
-		$this->debug = getDebug($options->debug);
+		$this->options = $options;
 	}
 
 	public function validateExecutableExists(string $name, string $command): void {
@@ -34,11 +37,12 @@ class UnixShell implements ShellOperator {
 		if (! $this->isReadable($fileName)) {
 			return false;
 		}
+		$debug = getDebug($this->options->debug);
 		$git = getenv('GIT') ?: 'git';
 		$gitStatusCommand = "{$git} status --porcelain " . escapeshellarg($fileName);
-		$this->debug('checking git existence of file with command:', $gitStatusCommand);
+		$debug('checking git existence of file with command:', $gitStatusCommand);
 		$gitStatusOutput = $this->executeCommand($gitStatusCommand);
-		$this->debug('git status output:', $gitStatusOutput);
+		$debug('git status output:', $gitStatusOutput);
 		if (isset($gitStatusOutput[0]) && $gitStatusOutput[0] === '?') {
 			return false;
 		}

--- a/PhpcsChanged/UnixShell.php
+++ b/PhpcsChanged/UnixShell.php
@@ -4,12 +4,20 @@ declare(strict_types=1);
 namespace PhpcsChanged;
 
 use PhpcsChanged\ShellOperator;
+use PhpcsChanged\CliOptions;
 use function PhpcsChanged\Cli\printError;
+use function PhpcsChanged\Cli\getDebug;
 
 /**
  * Module to perform file and shell operations
  */
 class UnixShell implements ShellOperator {
+	private $debug;
+
+	public function __construct(CliOptions $options) {
+		$this->debug = getDebug($options->debug);
+	}
+
 	public function validateExecutableExists(string $name, string $command): void {
 		exec(sprintf("type %s > /dev/null 2>&1", escapeshellarg($command)), $ignore, $returnVal);
 		if ($returnVal != 0) {
@@ -20,6 +28,21 @@ class UnixShell implements ShellOperator {
 	public function executeCommand(string $command, array &$output = null, int &$return_val = null): string {
 		exec($command, $output, $return_val);
 		return join(PHP_EOL, $output) . PHP_EOL;
+	}
+
+	public function doesFileExistInGit(string $fileName): bool {
+		if (! $this->isReadable($fileName)) {
+			return false;
+		}
+		$git = getenv('GIT') ?: 'git';
+		$gitStatusCommand = "{$git} status --porcelain " . escapeshellarg($fileName);
+		$this->debug('checking git existence of file with command:', $gitStatusCommand);
+		$gitStatusOutput = $this->executeCommand($gitStatusCommand);
+		$this->debug('git status output:', $gitStatusOutput);
+		if (isset($gitStatusOutput[0]) && $gitStatusOutput[0] === '?') {
+			return false;
+		}
+		return true;
 	}
 
 	public function isReadable(string $fileName): bool {

--- a/PhpcsChanged/UnixShell.php
+++ b/PhpcsChanged/UnixShell.php
@@ -34,9 +34,6 @@ class UnixShell implements ShellOperator {
 	}
 
 	public function doesFileExistInGit(string $fileName): bool {
-		if (! $this->isReadable($fileName)) {
-			return false;
-		}
 		$debug = getDebug($this->options->debug);
 		$git = getenv('GIT') ?: 'git';
 		$gitStatusCommand = "{$git} status --porcelain " . escapeshellarg($fileName);

--- a/PhpcsChanged/XmlReporter.php
+++ b/PhpcsChanged/XmlReporter.php
@@ -8,8 +8,18 @@ use PhpcsChanged\PhpcsMessages;
 use PhpcsChanged\LintMessage;
 use PhpcsChanged\UnixShell;
 use PhpcsChanged\ShellException;
+use PhpcsChanged\CliOptions;
 
 class XmlReporter implements Reporter {
+	/**
+	 * @var CliOptions
+	 */
+	private $options;
+
+	public function __construct(CliOptions $options) {
+		$this->options = $options;
+	}
+
 	public function getFormattedMessages(PhpcsMessages $messages, array $options): string { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		$files = array_unique(array_map(function(LintMessage $message): string {
 			return $message->getFile() ?? 'STDIN';
@@ -65,7 +75,7 @@ class XmlReporter implements Reporter {
 
 	protected function getPhpcsVersion(): string {
 		$phpcs = getenv('PHPCS') ?: 'phpcs';
-		$shell = new UnixShell();
+		$shell = new UnixShell($this->options);
 
 		$versionPhpcsOutputCommand = "{$phpcs} --version";
 		$versionPhpcsOutput = $shell->executeCommand($versionPhpcsOutputCommand);

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -144,7 +144,7 @@ function run(array $rawOptions, callable $debug): void {
 	}
 
 	if ($options->mode === Modes::SVN) {
-		$shell = new UnixShell();
+		$shell = new UnixShell($options);
 		reportMessagesAndExit(
 			runSvnWorkflow($options->files, $options->toArray(), $shell, new CacheManager(new FileCache(), $debug), $debug),
 			$options
@@ -153,7 +153,7 @@ function run(array $rawOptions, callable $debug): void {
 	}
 
 	if ($options->isGitMode()) {
-		$shell = new UnixShell();
+		$shell = new UnixShell($options);
 		reportMessagesAndExit(
 			runGitWorkflow($options, $shell, new CacheManager(new FileCache(), $debug), $debug),
 			$options

--- a/tests/GitWorkflowTest.php
+++ b/tests/GitWorkflowTest.php
@@ -381,6 +381,7 @@ final class GitWorkflowTest extends TestCase {
 		$shell->registerCommand("git status --porcelain 'foobar.php'", "?? foobar.php" );
 		$shell->registerCommand("git show HEAD:$(git ls-files --full-name 'foobar.php')", $this->fixture->getNonGitFileShow('foobar.php'), 128);
 		$shell->registerCommand("git show :0:$(git ls-files --full-name 'foobar.php')", $this->phpcs->getResults('STDIN', [20], 'Found unused symbol Foobar.')->toPhpcsJson());
+		$shell->registerCommand("git rev-parse --show-toplevel", 'run-from-git-root');
 		$options = CliOptions::fromArray(['no-cache-git-root' => 1, 'git-staged' => 1, 'files' => [$gitFile]]);
 		$cache = new CacheManager( new TestCache() );
 		runGitWorkflow($options, $shell, $cache, '\PhpcsChangedTests\Debug');

--- a/tests/XmlReporterTest.php
+++ b/tests/XmlReporterTest.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/helpers/helpers.php';
 
 use PHPUnit\Framework\TestCase;
 use PhpcsChanged\PhpcsMessages;
+use PhpcsChanged\CliOptions;
 use PhpcsChangedTests\TestXmlReporter;
 
 final class XmlReporterTest extends TestCase {
@@ -30,7 +31,8 @@ final class XmlReporterTest extends TestCase {
 </phpcs>
 
 EOF;
-		$reporter = new TestXmlReporter();
+		$options = new CliOptions();
+		$reporter = new TestXmlReporter($options);
 		$result = $reporter->getFormattedMessages($messages, []);
 		$this->assertEquals($expected, $result);
 	}
@@ -56,7 +58,8 @@ EOF;
 </phpcs>
 
 EOF;
-		$reporter = new TestXmlReporter();
+		$options = new CliOptions();
+		$reporter = new TestXmlReporter($options);
 		$result = $reporter->getFormattedMessages($messages, ['s' => 1]);
 		$this->assertEquals($expected, $result);
 	}
@@ -81,7 +84,8 @@ EOF;
 </phpcs>
 
 EOF;
-		$reporter = new TestXmlReporter();
+		$options = new CliOptions();
+		$reporter = new TestXmlReporter($options);
 		$result = $reporter->getFormattedMessages($messages, ['s' => 1]);
 		$this->assertEquals($expected, $result);
 	}
@@ -117,7 +121,8 @@ EOF;
 </phpcs>
 
 EOF;
-		$reporter = new TestXmlReporter();
+		$options = new CliOptions();
+		$reporter = new TestXmlReporter($options);
 		$result = $reporter->getFormattedMessages($messages, []);
 		$this->assertEquals($expected, $result);
 	}
@@ -188,7 +193,8 @@ EOF;
 </phpcs>
 
 EOF;
-		$reporter = new TestXmlReporter();
+		$options = new CliOptions();
+		$reporter = new TestXmlReporter($options);
 		$result = $reporter->getFormattedMessages($messages, ['s' => 1]);
 		$this->assertEquals($expected, $result);
 	}
@@ -203,7 +209,8 @@ EOF;
 </phpcs>
 
 EOF;
-		$reporter = new TestXmlReporter();
+		$options = new CliOptions();
+		$reporter = new TestXmlReporter($options);
 		$result = $reporter->getFormattedMessages($messages, []);
 		$this->assertEquals($expected, $result);
 	}
@@ -229,7 +236,8 @@ EOF;
 </phpcs>
 
 EOF;
-		$reporter = new TestXmlReporter();
+		$options = new CliOptions();
+		$reporter = new TestXmlReporter($options);
 		$result = $reporter->getFormattedMessages($messages, []);
 		$this->assertEquals($expected, $result);
 	}
@@ -246,13 +254,15 @@ EOF;
 				'message' => 'Found unused symbol Foo.',
 			],
 		], 'fileA.php');
-		$reporter = new TestXmlReporter();
+		$options = new CliOptions();
+		$reporter = new TestXmlReporter($options);
 		$this->assertEquals(1, $reporter->getExitCode($messages));
 	}
 
 	public function testGetExitCodeWithNoMessages() {
 		$messages = PhpcsMessages::fromArrays([], 'fileA.php');
-		$reporter = new TestXmlReporter();
+		$options = new CliOptions();
+		$reporter = new TestXmlReporter($options);
 		$this->assertEquals(0, $reporter->getExitCode($messages));
 	}
 }

--- a/tests/helpers/TestShell.php
+++ b/tests/helpers/TestShell.php
@@ -91,4 +91,17 @@ class TestShell implements ShellOperator {
 		$parts = explode('/', $path);
 		return end($parts);
 	}
+
+	public function doesFileExistInGit(string $fileName): bool {
+		if (! $this->isReadable($fileName)) {
+			return false;
+		}
+		$git = getenv('GIT') ?: 'git';
+		$gitStatusCommand = "{$git} status --porcelain " . escapeshellarg($fileName);
+		$gitStatusOutput = $this->executeCommand($gitStatusCommand);
+		if (isset($gitStatusOutput[0]) && $gitStatusOutput[0] === '?') {
+			return false;
+		}
+		return true;
+	}
 }


### PR DESCRIPTION
Part of implementing https://github.com/sirbrillig/phpcs-changed/issues/73, this moves the check for git file existence to the `ShellOperator` interface, allowing it to be abstracted for different shells.