### PR TITLE
Move hash, phpcs, and root git commands to ShellOperator

### DIFF
--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -16,7 +16,7 @@ use PhpcsChanged\XmlReporter;
 use PhpcsChanged\CacheManager;
 use function PhpcsChanged\{getNewPhpcsMessages, getNewPhpcsMessagesFromFiles, getVersion};
 use function PhpcsChanged\SvnWorkflow\{getSvnUnifiedDiff, getSvnFileInfo, isNewSvnFile, getSvnUnmodifiedPhpcsOutput, getSvnModifiedPhpcsOutput, getSvnRevisionId};
-use function PhpcsChanged\GitWorkflow\{getGitMergeBase, getGitUnifiedDiff, validateGitFileExists};
+use function PhpcsChanged\GitWorkflow\{getGitMergeBase, getGitUnifiedDiff};
 
 function getDebug(bool $debugEnabled): callable {
 	return
@@ -352,8 +352,6 @@ function runGitWorkflowForFile(string $gitFile, CliOptions $options, ShellOperat
 	$fileName = $shell->getFileNameFromPath($gitFile);
 
 	try {
-		validateGitFileExists($gitFile, $shell, $options);
-
 		$modifiedFilePhpcsOutput = null;
 		$modifiedFileHash = '';
 		if (isCachingEnabled($options->toArray())) {

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -16,7 +16,7 @@ use PhpcsChanged\XmlReporter;
 use PhpcsChanged\CacheManager;
 use function PhpcsChanged\{getNewPhpcsMessages, getNewPhpcsMessagesFromFiles, getVersion};
 use function PhpcsChanged\SvnWorkflow\{getSvnUnifiedDiff, getSvnFileInfo, isNewSvnFile, getSvnUnmodifiedPhpcsOutput, getSvnModifiedPhpcsOutput, getSvnRevisionId};
-use function PhpcsChanged\GitWorkflow\{getGitMergeBase, getGitUnifiedDiff, isNewGitFile, validateGitFileExists};
+use function PhpcsChanged\GitWorkflow\{getGitMergeBase, getGitUnifiedDiff, validateGitFileExists};
 
 function getDebug(bool $debugEnabled): callable {
 	return
@@ -377,7 +377,7 @@ function runGitWorkflowForFile(string $gitFile, CliOptions $options, ShellOperat
 			throw new NoChangesException("Modified file '{$gitFile}' has no PHPCS messages; skipping");
 		}
 
-		$isNewFile = isNewGitFile($gitFile, $git, [$shell, 'executeCommand'], $options->toArray(), $debug);
+		$isNewFile = $shell->doesUnmodifiedFileExistInGit($gitFile);
 		if ($isNewFile) {
 			$debug('Skipping the linting of the unmodified file as it is a new file.');
 		}

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -352,6 +352,10 @@ function runGitWorkflowForFile(string $gitFile, CliOptions $options, ShellOperat
 	$fileName = $shell->getFileNameFromPath($gitFile);
 
 	try {
+		if (! $shell->isReadable($gitFile)) {
+			throw new ShellException("Cannot read file '{$gitFile}'");
+		}
+
 		$modifiedFilePhpcsOutput = null;
 		$modifiedFileHash = '';
 		if (isCachingEnabled($options->toArray())) {

--- a/PhpcsChanged/CliOptions.php
+++ b/PhpcsChanged/CliOptions.php
@@ -113,19 +113,19 @@ class CliOptions {
 			$cliOptions->files = $options['files'];
 		}
 		if (isset($options['svn'])) {
-			$cliOptions->mode = 'svn';
+			$cliOptions->mode = Modes::SVN;
 		}
 		if (isset($options['git'])) {
-			$cliOptions->mode = 'git-staged';
+			$cliOptions->mode = Modes::GIT_STAGED;
 		}
 		if (isset($options['git-unstaged'])) {
-			$cliOptions->mode = 'git-unstaged';
+			$cliOptions->mode = Modes::GIT_UNSTAGED;
 		}
 		if (isset($options['git-staged'])) {
-			$cliOptions->mode = 'git-staged';
+			$cliOptions->mode = Modes::GIT_STAGED;
 		}
 		if (isset($options['git-base'])) {
-			$cliOptions->mode = 'git-base';
+			$cliOptions->mode = Modes::GIT_BASE;
 			$cliOptions->gitBase = $options['git-base'];
 		}
 		if (isset($options['report'])) {
@@ -144,15 +144,15 @@ class CliOptions {
 			$cliOptions->useCache = false;
 		}
 		if (isset($options['diff'])) {
-			$cliOptions->mode = 'manual';
+			$cliOptions->mode = Modes::MANUAL;
 			$cliOptions->diffFile = $options['diff'];
 		}
 		if (isset($options['phpcs-unmodified'])) {
-			$cliOptions->mode = 'manual';
+			$cliOptions->mode = Modes::MANUAL;
 			$cliOptions->phpcsUnmodified = $options['phpcs-unmodified'];
 		}
 		if (isset($options['phpcs-modified'])) {
-			$cliOptions->mode = 'manual';
+			$cliOptions->mode = Modes::MANUAL;
 			$cliOptions->phpcsModified = $options['phpcs-modified'];
 		}
 		if (isset($options['s'])) {

--- a/PhpcsChanged/GitWorkflow.php
+++ b/PhpcsChanged/GitWorkflow.php
@@ -23,25 +23,6 @@ function validateGitFileExists(string $gitFile, ShellOperator $shell, CliOptions
 	}
 }
 
-function isRunFromGitRoot(ShellOperator $shell, CliOptions $options): bool {
-	// This should never change while the script runs so we cache it.
-	static $isRunFromGitRoot;
-
-	if (isset($options['no-cache-git-root'])) {
-		$isRunFromGitRoot = null;
-	}
-	if (null !== $isRunFromGitRoot) {
-		return $isRunFromGitRoot;
-	}
-	
-	$debug = getDebug($options->debug);
-	$gitRoot = $shell->getGitRootDirectory();
-	$isRunFromGitRoot = (getcwd() === $gitRoot);
-
-	$debug('is run from git root: ' . var_export($isRunFromGitRoot, true));
-	return $isRunFromGitRoot;
-}
-
 function getGitMergeBase(string $git, callable $executeCommand, array $options, callable $debug): string {
 	if ( empty($options['git-base']) ) {
 		return '';

--- a/PhpcsChanged/GitWorkflow.php
+++ b/PhpcsChanged/GitWorkflow.php
@@ -9,20 +9,6 @@ use PhpcsChanged\ShellException;
 use PhpcsChanged\ShellOperator;
 use function PhpcsChanged\Cli\getDebug;
 
-function validateGitFileExists(string $gitFile, ShellOperator $shell, CliOptions $options): void {
-	$debug = getDebug($options->debug);
-	if (isset($options->noVerifyGitFile)) {
-		$debug('skipping Git file exists check.');
-		return;
-	}
-	if (! $shell->isReadable($gitFile)) {
-		throw new ShellException("Cannot read file '{$gitFile}'");
-	}
-	if (! $shell->doesFileExistInGit($gitFile)) {
-		throw new ShellException("File does not appear to be tracked by git: '{$gitFile}'");
-	}
-}
-
 function getGitMergeBase(string $git, callable $executeCommand, array $options, callable $debug): string {
 	if ( empty($options['git-base']) ) {
 		return '';

--- a/PhpcsChanged/ShellOperator.php
+++ b/PhpcsChanged/ShellOperator.php
@@ -28,8 +28,6 @@ interface ShellOperator {
 
 	public function doesUnmodifiedFileExistInGit(string $fileName): bool;
 
-	public function getGitRootDirectory(): string;
-
 	public function getGitHashOfModifiedFile(string $fileName): string;
 
 	public function getGitHashOfUnmodifiedFile(string $fileName): string;

--- a/PhpcsChanged/ShellOperator.php
+++ b/PhpcsChanged/ShellOperator.php
@@ -11,9 +11,8 @@ use PhpcsChanged\CliOptions;
 interface ShellOperator {
 	public function validateExecutableExists(string $name, string $command): void;
 
+	// TODO: remove executeCommand from the interface and rely on the more specific methods.
 	public function executeCommand(string $command, array &$output = null, int &$return_val = null): string;
-
-	public function doesFileExistInGit(string $fileName): bool;
 
 	public function isReadable(string $fileName): bool;
 
@@ -24,4 +23,16 @@ interface ShellOperator {
 	public function printError(string $message): void;
 
 	public function getFileNameFromPath(string $path): string;
+
+	public function doesFileExistInGit(string $fileName): bool;
+
+	public function getGitRootDirectory(): string;
+
+	public function getGitHashOfModifiedFile(string $fileName): string;
+
+	public function getGitHashOfUnmodifiedFile(string $fileName): string;
+
+	public function getPhpcsOutputOfModifiedGitFile(string $fileName): string;
+
+	public function getPhpcsOutputOfUnmodifiedGitFile(string $fileName): string;
 }

--- a/PhpcsChanged/ShellOperator.php
+++ b/PhpcsChanged/ShellOperator.php
@@ -24,8 +24,6 @@ interface ShellOperator {
 
 	public function getFileNameFromPath(string $path): string;
 
-	public function doesFileExistInGit(string $fileName): bool;
-
 	public function doesUnmodifiedFileExistInGit(string $fileName): bool;
 
 	public function getGitHashOfModifiedFile(string $fileName): string;

--- a/PhpcsChanged/ShellOperator.php
+++ b/PhpcsChanged/ShellOperator.php
@@ -12,7 +12,7 @@ interface ShellOperator {
 	public function validateExecutableExists(string $name, string $command): void;
 
 	// TODO: remove executeCommand from the interface and rely on the more specific methods.
-	public function executeCommand(string $command, array &$output = null, int &$return_val = null): string;
+	public function executeCommand(string $command, int &$return_val = null): string;
 
 	public function isReadable(string $fileName): bool;
 
@@ -25,6 +25,8 @@ interface ShellOperator {
 	public function getFileNameFromPath(string $path): string;
 
 	public function doesFileExistInGit(string $fileName): bool;
+
+	public function doesUnmodifiedFileExistInGit(string $fileName): bool;
 
 	public function getGitRootDirectory(): string;
 

--- a/PhpcsChanged/UnixShell.php
+++ b/PhpcsChanged/UnixShell.php
@@ -82,7 +82,7 @@ class UnixShell implements ShellOperator {
 	}
 
 	private function getFullGitPathToFile(string $fileName): string {
-		if ($this->fullPaths[$fileName]) {
+		if (array_key_exists($fileName, $this->fullPaths)) {
 			return $this->fullPaths[$fileName];
 		}
 		$debug = getDebug($this->options->debug);

--- a/PhpcsChanged/UnixShell.php
+++ b/PhpcsChanged/UnixShell.php
@@ -129,7 +129,7 @@ class UnixShell implements ShellOperator {
 		$phpcsStandardOption .= isset($warningSeverity) ? ' --warning-severity=' . escapeshellarg($warningSeverity) : '';
 		$errorSeverity = $this->options->errorSeverity;
 		$phpcsStandardOption .= isset($errorSeverity) ? ' --error-severity=' . escapeshellarg($errorSeverity) : '';
-		return $phpcsStandardOption
+		return $phpcsStandardOption;
 	}
 
 	public function getPhpcsOutputOfModifiedGitFile(string $fileName): string {

--- a/PhpcsChanged/UnixShell.php
+++ b/PhpcsChanged/UnixShell.php
@@ -85,15 +85,6 @@ class UnixShell implements ShellOperator {
 		return $this->isFileStagedForAdding($fileName);
 	}
 
-	public function getGitRootDirectory(): string {
-		$debug = getDebug($this->options->debug);
-		$git = getenv('GIT') ?: 'git';
-		$gitRootCommand = "{$git} rev-parse --show-toplevel";
-		$debug('getting git root directory with command:', $gitRootCommand);
-		$gitRoot = $this->executeCommand($gitRootCommand);
-		return trim($gitRoot);
-	}
-
 	private function getFullGitPathToFile(string $fileName): string {
 		$debug = getDebug($this->options->debug);
 		$git = getenv('GIT') ?: 'git';

--- a/PhpcsChanged/UnixShell.php
+++ b/PhpcsChanged/UnixShell.php
@@ -87,12 +87,14 @@ class UnixShell implements ShellOperator {
 		}
 		$debug = getDebug($this->options->debug);
 		$git = getenv('GIT') ?: 'git';
-		$gitStatusOutput = $this->getGitStatusForFile($fileName);
-		if (! $gitStatusOutput || false === strpos($gitStatusOutput, $fileName)) {
-			throw new ShellException("File does not appear to be tracked by git: '{$fileName}'");
-		}
-		if (isset($gitStatusOutput[0]) && $gitStatusOutput[0] === '?') {
-			throw new ShellException("File does not appear to be tracked by git: '{$fileName}'");
+		if (! $this->options->noVerifyGitFile) {
+			$gitStatusOutput = $this->getGitStatusForFile($fileName);
+			if (! $gitStatusOutput || false === strpos($gitStatusOutput, $fileName)) {
+				throw new ShellException("File does not appear to be tracked by git: '{$fileName}'");
+			}
+			if (isset($gitStatusOutput[0]) && $gitStatusOutput[0] === '?') {
+				throw new ShellException("File does not appear to be tracked by git: '{$fileName}'");
+			}
 		}
 		$command = "{$git} ls-files --full-name " . escapeshellarg($fileName);
 		$debug('getting full path to file with command:', $command);

--- a/PhpcsChanged/UnixShell.php
+++ b/PhpcsChanged/UnixShell.php
@@ -5,6 +5,7 @@ namespace PhpcsChanged;
 
 use PhpcsChanged\ShellOperator;
 use PhpcsChanged\CliOptions;
+use PhpcsChanged\Modes;
 use function PhpcsChanged\Cli\printError;
 use function PhpcsChanged\Cli\getDebug;
 
@@ -68,7 +69,7 @@ class UnixShell implements ShellOperator {
 		$git = getenv('GIT') ?: 'git';
 		$cat = getenv('CAT') ?: 'cat';
 		$fullPath = $this->getFullGitPathToFile($fileName);
-		if ($this->options->mode === Mode::GIT_BASE) {
+		if ($this->options->mode === Modes::GIT_BASE) {
 			// for git-base mode, we get the contents of the file from the HEAD version of the file in the current branch
 			return "{$git} show HEAD:" . escapeshellarg($fullPath);
 		}
@@ -82,9 +83,9 @@ class UnixShell implements ShellOperator {
 
 	private function getUnmodifiedFileContentsCommand(string $fileName): string {
 		$git = getenv('GIT') ?: 'git';
-		if ($this->options->mode === Mode::GIT_BASE) {
+		if ($this->options->mode === Modes::GIT_BASE) {
 			$rev = escapeshellarg($this->options->gitBase);
-		} else if ($this->options->mode === Mode::GIT_UNSTAGED) {
+		} else if ($this->options->mode === Modes::GIT_UNSTAGED) {
 			$rev = ':0'; // :0 in this case means "staged version or HEAD if there is no staged version"
 		} else {
 			// git-staged is the default

--- a/PhpcsChanged/UnixShell.php
+++ b/PhpcsChanged/UnixShell.php
@@ -46,6 +46,124 @@ class UnixShell implements ShellOperator {
 		return true;
 	}
 
+	public function getGitRootDirectory(): string {
+		$debug = getDebug($this->options->debug);
+		$git = getenv('GIT') ?: 'git';
+		$gitRootCommand = "{$git} rev-parse --show-toplevel";
+		$debug('getting git root directory with command:', $gitRootCommand);
+		$gitRoot = $this->executeCommand($gitRootCommand);
+		return trim($gitRoot);
+	}
+
+	private function getFullGitPathToFile(string $fileName): string {
+		$debug = getDebug($this->options->debug);
+		$git = getenv('GIT') ?: 'git';
+		$command = "{$git} ls-files --full-name " . escapeshellarg($fileName);
+		$debug('getting full path to file with command:', $command);
+		$fullPath = $this->executeCommand($command);
+		return trim($fullPath);
+	}
+
+	private function getModifiedFileContentsCommand(string $fileName): string {
+		$git = getenv('GIT') ?: 'git';
+		$cat = getenv('CAT') ?: 'cat';
+		$fullPath = $this->getFullGitPathToFile($fileName);
+		if ($this->options->mode === Mode::GIT_BASE) {
+			// for git-base mode, we get the contents of the file from the HEAD version of the file in the current branch
+			return "{$git} show HEAD:" . escapeshellarg($fullPath);
+		}
+		if ($this->options->mode === Modes::GIT_UNSTAGED) {
+			// for git-unstaged mode, we get the contents of the file from the current working copy
+			return "{$cat} " . escapeshellarg($fileName);
+		}
+		// default mode is git-staged, so we get the contents from the staged version of the file
+		return "{$git} show :0:" . escapeshellarg($fullPath);
+	}
+
+	private function getUnmodifiedFileContentsCommand(string $fileName): string {
+		$git = getenv('GIT') ?: 'git';
+		if ($this->options->mode === Mode::GIT_BASE) {
+			$rev = escapeshellarg($this->options->gitBase);
+		} else if ($this->options->mode === Mode::GIT_UNSTAGED) {
+			$rev = ':0'; // :0 in this case means "staged version or HEAD if there is no staged version"
+		} else {
+			// git-staged is the default
+			$rev = 'HEAD';
+		}
+		$fullPath = $this->getFullGitPathToFile($fileName);
+		return "{$git} show {$rev}:" . escapeshellarg($fullPath);
+	}
+
+	public function getGitHashOfModifiedFile(string $fileName): string {
+		$debug = getDebug($this->options->debug);
+		$git = getenv('GIT') ?: 'git';
+		$fileContentsCommand = $this->getModifiedFileContentsCommand($fileName);
+		$command = "{$fileContentsCommand} | {$git} hash-object --stdin";
+		$debug('running modified file git hash command:', $command);
+		$hash = $this->executeCommand($command);
+		if (! $hash) {
+			throw new ShellException("Cannot get modified file hash for file '{$fileName}'");
+		}
+		$debug('modified file git hash command output:', $hash);
+		return $hash;
+	}
+
+	public function getGitHashOfUnmodifiedFile(string $fileName): string {
+		$debug = getDebug($this->options->debug);
+		$git = getenv('GIT') ?: 'git';
+		$fileContentsCommand = $this->getUnmodifiedFileContentsCommand($fileName);
+		$command = "{$fileContentsCommand} | {$git} hash-object --stdin";
+		$debug('running unmodified file git hash command:', $command);
+		$hash = $this->executeCommand($command);
+		if (! $hash) {
+			throw new ShellException("Cannot get unmodified file hash for file '{$fileName}'");
+		}
+		$debug('unmodified file git hash command output:', $hash);
+		return $hash;
+	}
+
+	private function getPhpcsStandardOption(): string {
+		$phpcsStandard = $this->options->phpcsStandard;
+		$phpcsStandardOption = $phpcsStandard ? ' --standard=' . escapeshellarg($phpcsStandard) : '';
+		$warningSeverity = $this->options->warningSeverity;
+		$phpcsStandardOption .= isset($warningSeverity) ? ' --warning-severity=' . escapeshellarg($warningSeverity) : '';
+		$errorSeverity = $this->options->errorSeverity;
+		$phpcsStandardOption .= isset($errorSeverity) ? ' --error-severity=' . escapeshellarg($errorSeverity) : '';
+		return $phpcsStandardOption
+	}
+
+	public function getPhpcsOutputOfModifiedGitFile(string $fileName): string {
+		$debug = getDebug($this->options->debug);
+		$phpcs = getenv('PHPCS') ?: 'phpcs';
+		$fileContentsCommand = $this->getModifiedFileContentsCommand($fileName);
+		$modifiedFilePhpcsOutputCommand = "{$fileContentsCommand} | {$phpcs} --report=json -q" . $this->getPhpcsStandardOption() . ' --stdin-path=' .  escapeshellarg($fileName) .' -';
+		$debug('running modified file phpcs command:', $modifiedFilePhpcsOutputCommand);
+		$modifiedFilePhpcsOutput = $this->executeCommand($modifiedFilePhpcsOutputCommand);
+		if (! $modifiedFilePhpcsOutput) {
+			throw new ShellException("Cannot get modified file phpcs output for file '{$fileName}'");
+		}
+		$debug('modified file phpcs command output:', $modifiedFilePhpcsOutput);
+		if (false !== strpos($modifiedFilePhpcsOutput, 'You must supply at least one file or directory to process')) {
+			$debug('phpcs output implies modified file is empty');
+			return '';
+		}
+		return $modifiedFilePhpcsOutput;
+	}
+
+	public function getPhpcsOutputOfUnmodifiedGitFile(string $fileName): string {
+		$debug = getDebug($this->options->debug);
+		$phpcs = getenv('PHPCS') ?: 'phpcs';
+		$unmodifiedFileContentsCommand = $this->getUnmodifiedFileContentsCommand($fileName);
+		$unmodifiedFilePhpcsOutputCommand = "{$unmodifiedFileContentsCommand} | {$phpcs} --report=json -q" . $this->getPhpcsStandardOption() . ' --stdin-path=' .  escapeshellarg($fileName) . ' -';
+		$debug('running unmodified file phpcs command:', $unmodifiedFilePhpcsOutputCommand);
+		$unmodifiedFilePhpcsOutput = $this->executeCommand($unmodifiedFilePhpcsOutputCommand);
+		if (! $unmodifiedFilePhpcsOutput) {
+			throw new ShellException("Cannot get unmodified file phpcs output for file '{$fileName}'");
+		}
+		$debug('unmodified file phpcs command output:', $unmodifiedFilePhpcsOutput);
+		return $unmodifiedFilePhpcsOutput;
+	}
+
 	public function isReadable(string $fileName): bool {
 		return is_readable($fileName);
 	}

--- a/tests/helpers/TestShell.php
+++ b/tests/helpers/TestShell.php
@@ -18,7 +18,7 @@ class TestShell implements ShellOperator {
 
 	private $fileHashes = [];
 
-	private CliOptions $options;
+	private $options;
 
 	public function __construct(array $readableFileNames) {
 		foreach ($readableFileNames as $fileName) {

--- a/tests/helpers/TestShell.php
+++ b/tests/helpers/TestShell.php
@@ -113,13 +113,6 @@ class TestShell implements ShellOperator {
 		return true;
 	}
 
-	public function getGitRootDirectory(): string {
-		$git = getenv('GIT') ?: 'git';
-		$gitRootCommand = "{$git} rev-parse --show-toplevel";
-		$gitRoot = $this->executeCommand($gitRootCommand);
-		return trim($gitRoot);
-	}
-
 	private function getFullGitPathToFile(string $fileName): string {
 		$git = getenv('GIT') ?: 'git';
 		$command = "{$git} ls-files --full-name " . escapeshellarg($fileName);

--- a/tests/helpers/TestShell.php
+++ b/tests/helpers/TestShell.php
@@ -100,19 +100,6 @@ class TestShell implements ShellOperator {
 		return end($parts);
 	}
 
-	public function doesFileExistInGit(string $fileName): bool {
-		if (! $this->isReadable($fileName)) {
-			return false;
-		}
-		$git = getenv('GIT') ?: 'git';
-		$gitStatusCommand = "{$git} status --porcelain " . escapeshellarg($fileName);
-		$gitStatusOutput = $this->executeCommand($gitStatusCommand);
-		if (isset($gitStatusOutput[0]) && $gitStatusOutput[0] === '?') {
-			return false;
-		}
-		return true;
-	}
-
 	private function getFullGitPathToFile(string $fileName): string {
 		$git = getenv('GIT') ?: 'git';
 		$command = "{$git} ls-files --full-name " . escapeshellarg($fileName);
@@ -216,7 +203,6 @@ class TestShell implements ShellOperator {
 		return 0 !== $return_val;
 	}
 
-	// TODO: this is very similar to doesFileExistInGit; can we combine them?
 	private function isFileStagedForAdding(string $fileName): bool {
 		$git = getenv('GIT') ?: 'git';
 		$gitStatusCommand = "{$git} status --porcelain " . escapeshellarg($fileName);


### PR DESCRIPTION
This moves a bunch of git commands to the ShellOperator interface so they can be customized for a different OS. Specifically this moves:

- The code to determine the hash of a git file.
- The code to get the phpcs output of a git file.
- The code to get the git root directory (this was removed actually because I think we can safely always use the git file's full path).
- The code to check if the unmodified file is in git.

This also removes the initial validation of the git file's existence in the repo since that can be handled when we try to fetch the file's full path.

Since this increases the number of times we get the git file's full path, we also cache the full path for the lifetime of the script.

This is part of https://github.com/sirbrillig/phpcs-changed/issues/73