### PR TITLE
Move getting unified git diff to shell

### DIFF
--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -344,8 +344,6 @@ function runGitWorkflow(CliOptions $options, ShellOperator $shell, CacheManager 
 }
 
 function runGitWorkflowForFile(string $gitFile, CliOptions $options, ShellOperator $shell, CacheManager $cache, callable $debug): PhpcsMessages {
-	$git = getenv('GIT') ?: 'git';
-
 	$phpcsStandard = $options->phpcsStandard;
 	$warningSeverity = $options->warningSeverity;
 	$errorSeverity = $options->errorSeverity;

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -16,7 +16,7 @@ use PhpcsChanged\XmlReporter;
 use PhpcsChanged\CacheManager;
 use function PhpcsChanged\{getNewPhpcsMessages, getNewPhpcsMessagesFromFiles, getVersion};
 use function PhpcsChanged\SvnWorkflow\{getSvnUnifiedDiff, getSvnFileInfo, isNewSvnFile, getSvnUnmodifiedPhpcsOutput, getSvnModifiedPhpcsOutput, getSvnRevisionId};
-use function PhpcsChanged\GitWorkflow\{getGitMergeBase, getGitUnifiedDiff};
+use function PhpcsChanged\GitWorkflow\getGitMergeBase;
 
 function getDebug(bool $debugEnabled): callable {
 	return
@@ -385,7 +385,7 @@ function runGitWorkflowForFile(string $gitFile, CliOptions $options, ShellOperat
 		}
 		if (! $isNewFile) {
 			$debug('Checking the unmodified file with PHPCS since the file is not new and contains some messages.');
-			$unifiedDiff = getGitUnifiedDiff($gitFile, $git, [$shell, 'executeCommand'], $options->toArray(), $debug);
+			$unifiedDiff = $shell->getGitUnifiedDiff($gitFile);
 			$unmodifiedFilePhpcsOutput = null;
 			$unmodifiedFileHash = '';
 			if (isCachingEnabled($options->toArray())) {

--- a/PhpcsChanged/GitWorkflow.php
+++ b/PhpcsChanged/GitWorkflow.php
@@ -23,16 +23,3 @@ function getGitMergeBase(string $git, callable $executeCommand, array $options, 
 	$debug('merge-base command output:', $mergeBase);
 	return trim($mergeBase);
 }
-
-function getGitUnifiedDiff(string $gitFile, string $git, callable $executeCommand, array $options, callable $debug): string {
-	$objectOption = isset($options['git-base']) && ! empty($options['git-base']) ? ' ' . escapeshellarg($options['git-base']) . '...' : '';
-	$stagedOption = empty( $objectOption ) && ! isset($options['git-unstaged']) ? ' --staged' : '';
-	$unifiedDiffCommand = "{$git} diff{$stagedOption}{$objectOption} --no-prefix " . escapeshellarg($gitFile);
-	$debug('running diff command:', $unifiedDiffCommand);
-	$unifiedDiff = $executeCommand($unifiedDiffCommand);
-	if (! $unifiedDiff) {
-		throw new NoChangesException("Cannot get git diff for file '{$gitFile}'; skipping");
-	}
-	$debug('diff command output:', $unifiedDiff);
-	return $unifiedDiff;
-}

--- a/PhpcsChanged/ShellOperator.php
+++ b/PhpcsChanged/ShellOperator.php
@@ -33,4 +33,6 @@ interface ShellOperator {
 	public function getPhpcsOutputOfModifiedGitFile(string $fileName): string;
 
 	public function getPhpcsOutputOfUnmodifiedGitFile(string $fileName): string;
+
+	public function getGitUnifiedDiff(string $fileName): string;
 }

--- a/PhpcsChanged/UnixShell.php
+++ b/PhpcsChanged/UnixShell.php
@@ -204,6 +204,21 @@ class UnixShell implements ShellOperator {
 		return $unmodifiedFilePhpcsOutput;
 	}
 
+	public function getGitUnifiedDiff(string $fileName): string {
+		$debug = getDebug($this->options->debug);
+		$git = getenv('GIT') ?: 'git';
+		$objectOption = $this->options->mode === Modes::GIT_BASE ? ' ' . escapeshellarg($this->options->gitBase) . '...' : '';
+		$stagedOption = empty($objectOption) && $this->options->mode !== Modes::GIT_UNSTAGED ? ' --staged' : '';
+		$unifiedDiffCommand = "{$git} diff{$stagedOption}{$objectOption} --no-prefix " . escapeshellarg($fileName);
+		$debug('running diff command:', $unifiedDiffCommand);
+		$unifiedDiff = $this->executeCommand($unifiedDiffCommand);
+		if (! $unifiedDiff) {
+			throw new NoChangesException("Cannot get git diff for file '{$fileName}'; skipping");
+		}
+		$debug('diff command output:', $unifiedDiff);
+		return $unifiedDiff;
+	}
+
 	public function isReadable(string $fileName): bool {
 		return is_readable($fileName);
 	}

--- a/tests/GitWorkflowTest.php
+++ b/tests/GitWorkflowTest.php
@@ -14,7 +14,6 @@ use PhpcsChangedTests\GitFixture;
 use PhpcsChangedTests\PhpcsFixture;
 use PhpcsChangedTests\TestCache;
 use function PhpcsChanged\Cli\runGitWorkflow;
-use function PhpcsChanged\GitWorkflow\getGitUnifiedDiff;
 
 final class GitWorkflowTest extends TestCase {
 	public $fixture;
@@ -24,19 +23,6 @@ final class GitWorkflowTest extends TestCase {
 		parent::setUp();
 		$this->fixture = new GitFixture();
 		$this->phpcs = new PhpcsFixture();
-	}
-
-	public function testGetGitUnifiedDiff() {
-		$gitFile = 'foobar.php';
-		$git = 'git';
-		$diff = $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;');
-		$executeCommand = function($command) use ($diff) {
-			if (! $command || false === strpos($command, "git diff --staged --no-prefix 'foobar.php'")) {
-				return '';
-			}
-			return $diff;
-		};
-		$this->assertEquals($diff, getGitUnifiedDiff($gitFile, $git, $executeCommand, [], '\PhpcsChangedTests\Debug'));
 	}
 
 	public function testFullGitWorkflowForOneFileStaged() {

--- a/tests/helpers/TestShell.php
+++ b/tests/helpers/TestShell.php
@@ -227,7 +227,7 @@ class TestShell implements ShellOperator {
 	public function getGitUnifiedDiff(string $fileName): string {
 		$git = getenv('GIT') ?: 'git';
 		$objectOption = $this->options->mode === Modes::GIT_BASE ? ' ' . escapeshellarg($this->options->gitBase) . '...' : '';
-		$stagedOption = empty($objectOption) && $this->options->mode === Modes::GIT_UNSTAGED ? ' --staged' : '';
+		$stagedOption = empty($objectOption) && $this->options->mode !== Modes::GIT_UNSTAGED ? ' --staged' : '';
 		$unifiedDiffCommand = "{$git} diff{$stagedOption}{$objectOption} --no-prefix " . escapeshellarg($fileName);
 		$unifiedDiff = $this->executeCommand($unifiedDiffCommand);
 		if (! $unifiedDiff) {


### PR DESCRIPTION
This moves the code that fetches the git unified diff into `ShellOperator` so it can be localized for an OS.

This is part of https://github.com/sirbrillig/phpcs-changed/issues/73