### PR TITLE
Add executable paths to options

### DIFF
--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -202,9 +202,9 @@ function runManualWorkflow(string $diffFile, string $phpcsUnmodifiedFile, string
 }
 
 function runSvnWorkflow(array $svnFiles, CliOptions $options, ShellOperator $shell, CacheManager $cache, callable $debug): PhpcsMessages {
-	$svn = getenv('SVN') ?: 'svn';
+	$svn = $options->getExecutablePath('svn');
 	$phpcs = $options->getExecutablePath('phpcs');
-	$cat = getenv('CAT') ?: 'cat';
+	$cat = $options->getExecutablePath('cat');
 
 	try {
 		$debug('validating executables');
@@ -230,9 +230,9 @@ function runSvnWorkflow(array $svnFiles, CliOptions $options, ShellOperator $she
 }
 
 function runSvnWorkflowForFile(string $svnFile, CliOptions $options, ShellOperator $shell, CacheManager $cache, callable $debug): PhpcsMessages {
-	$svn = getenv('SVN') ?: 'svn';
+	$svn = $options->getExecutablePath('svn');
 	$phpcs = $options->getExecutablePath('phpcs');
-	$cat = getenv('CAT') ?: 'cat';
+	$cat = $options->getExecutablePath('cat');
 
 	$phpcsStandard = $options->phpcsStandard;
 	$phpcsStandardOption = $phpcsStandard ? ' --standard=' . escapeshellarg($phpcsStandard) : '';
@@ -312,7 +312,7 @@ function runSvnWorkflowForFile(string $svnFile, CliOptions $options, ShellOperat
 function runGitWorkflow(CliOptions $options, ShellOperator $shell, CacheManager $cache, callable $debug): PhpcsMessages {
 	$git = $options->getExecutablePath('git');
 	$phpcs = $options->getExecutablePath('phpcs');
-	$cat = getenv('CAT') ?: 'cat';
+	$cat = $options->getExecutablePath('cat');
 
 	try {
 		$debug('validating executables');

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -68,11 +68,9 @@ EOF;
 }
 
 function printInstalledCodingStandards(): void {
-	$phpcs = getenv('PHPCS') ?: 'phpcs';
 	$shell = new UnixShell();
 
-	$installedCodingStandardsPhpcsOutputCommand = "{$phpcs} -i";
-	$installedCodingStandardsPhpcsOutput = $shell->executeCommand($installedCodingStandardsPhpcsOutputCommand);
+	$installedCodingStandardsPhpcsOutput = $shell->getPhpcsStandards();
 	if (! $installedCodingStandardsPhpcsOutput) {
 		$errorMessage = "Cannot get installed coding standards";
 		$shell->printError($errorMessage);
@@ -203,9 +201,9 @@ function runManualWorkflow(string $diffFile, string $phpcsUnmodifiedFile, string
 	return $messages;
 }
 
-function runSvnWorkflow(array $svnFiles, array $options, ShellOperator $shell, CacheManager $cache, callable $debug): PhpcsMessages {
+function runSvnWorkflow(array $svnFiles, CliOptions $options, ShellOperator $shell, CacheManager $cache, callable $debug): PhpcsMessages {
 	$svn = getenv('SVN') ?: 'svn';
-	$phpcs = getenv('PHPCS') ?: 'phpcs';
+	$phpcs = $options->getExecutablePath('phpcs');
 	$cat = getenv('CAT') ?: 'cat';
 
 	try {
@@ -220,28 +218,28 @@ function runSvnWorkflow(array $svnFiles, array $options, ShellOperator $shell, C
 		throw $err; // Just in case we do not actually exit, like in tests
 	}
 
-	loadCache($cache, $shell, $options);
+	loadCache($cache, $shell, $options->toArray());
 
 	$phpcsMessages = array_map(function(string $svnFile) use ($options, $shell, $cache, $debug): PhpcsMessages {
 		return runSvnWorkflowForFile($svnFile, $options, $shell, $cache, $debug);
 	}, $svnFiles);
 
-	saveCache($cache, $shell, $options);
+	saveCache($cache, $shell, $options->toArray());
 
 	return PhpcsMessages::merge($phpcsMessages);
 }
 
-function runSvnWorkflowForFile(string $svnFile, array $options, ShellOperator $shell, CacheManager $cache, callable $debug): PhpcsMessages {
+function runSvnWorkflowForFile(string $svnFile, CliOptions $options, ShellOperator $shell, CacheManager $cache, callable $debug): PhpcsMessages {
 	$svn = getenv('SVN') ?: 'svn';
-	$phpcs = getenv('PHPCS') ?: 'phpcs';
+	$phpcs = $options->getExecutablePath('phpcs');
 	$cat = getenv('CAT') ?: 'cat';
 
-	$phpcsStandard = $options['standard'] ?? null;
+	$phpcsStandard = $options->phpcsStandard;
 	$phpcsStandardOption = $phpcsStandard ? ' --standard=' . escapeshellarg($phpcsStandard) : '';
 
-	$warningSeverity = $options['warning-severity'] ?? null;
+	$warningSeverity = $options->warningSeverity;
 	$phpcsStandardOption .= isset($warningSeverity) ? ' --warning-severity=' . escapeshellarg($warningSeverity) : '';
-	$errorSeverity = $options['error-severity'] ?? null;
+	$errorSeverity = $options->errorSeverity;
 	$phpcsStandardOption .= isset($errorSeverity) ? ' --error-severity=' . escapeshellarg($errorSeverity) : '';
 	$fileName = $shell->getFileNameFromPath($svnFile);
 
@@ -252,14 +250,14 @@ function runSvnWorkflowForFile(string $svnFile, array $options, ShellOperator $s
 
 		$modifiedFileHash = '';
 		$modifiedFilePhpcsOutput = null;
-		if (isCachingEnabled($options)) {
+		if (isCachingEnabled($options->toArray())) {
 			$modifiedFileHash = $shell->getFileHash($svnFile);
 			$modifiedFilePhpcsOutput = $cache->getCacheForFile($svnFile, 'new', $modifiedFileHash, $phpcsStandard ?? '', $warningSeverity ?? '', $errorSeverity ?? '');
 			$debug(($modifiedFilePhpcsOutput ? 'Using' : 'Not using') . " cache for modified file '{$svnFile}' at hash '{$modifiedFileHash}', and standard '{$phpcsStandard}'");
 		}
 		if (! $modifiedFilePhpcsOutput) {
 			$modifiedFilePhpcsOutput = getSvnModifiedPhpcsOutput($svnFile, $phpcs, $cat, $phpcsStandardOption, [$shell, 'executeCommand'], $debug);
-			if (isCachingEnabled($options)) {
+			if (isCachingEnabled($options->toArray())) {
 				$cache->setCacheForFile($svnFile, 'new', $modifiedFileHash, $phpcsStandard ?? '', $warningSeverity ?? '', $errorSeverity ?? '', $modifiedFilePhpcsOutput);
 			}
 		}
@@ -281,13 +279,13 @@ function runSvnWorkflowForFile(string $svnFile, array $options, ShellOperator $s
 		}
 		$unmodifiedFilePhpcsOutput = '';
 		if (! $isNewFile) {
-			if (isCachingEnabled($options)) {
+			if (isCachingEnabled($options->toArray())) {
 				$unmodifiedFilePhpcsOutput = $cache->getCacheForFile($svnFile, 'old', $revisionId, $phpcsStandard ?? '', $warningSeverity ?? '', $errorSeverity ?? '');
 				$debug(($unmodifiedFilePhpcsOutput ? 'Using' : 'Not using') . " cache for unmodified file '{$svnFile}' at revision '{$revisionId}', and standard '{$phpcsStandard}'");
 			}
 			if (! $unmodifiedFilePhpcsOutput) {
 				$unmodifiedFilePhpcsOutput = getSvnUnmodifiedPhpcsOutput($svnFile, $svn, $phpcs, $phpcsStandardOption, [$shell, 'executeCommand'], $debug);
-				if (isCachingEnabled($options)) {
+				if (isCachingEnabled($options->toArray())) {
 					$cache->setCacheForFile($svnFile, 'old', $revisionId, $phpcsStandard ?? '', $warningSeverity ?? '', $errorSeverity ?? '', $unmodifiedFilePhpcsOutput);
 				}
 			}
@@ -312,8 +310,8 @@ function runSvnWorkflowForFile(string $svnFile, array $options, ShellOperator $s
 }
 
 function runGitWorkflow(CliOptions $options, ShellOperator $shell, CacheManager $cache, callable $debug): PhpcsMessages {
-	$git = getenv('GIT') ?: 'git';
-	$phpcs = getenv('PHPCS') ?: 'phpcs';
+	$git = $options->getExecutablePath('git');
+	$phpcs = $options->getExecutablePath('phpcs');
 	$cat = getenv('CAT') ?: 'cat';
 
 	try {

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -162,14 +162,20 @@ EOF;
 		'--always-exit-zero' => 'Always exit the script with a 0 return code. Otherwise, a 1 return code indicates phpcs messages.',
 		'--no-cache-git-root' => 'Prevent caching the git root used by the git workflow.',
 		'--no-verify-git-file' => 'Prevent checking if a file is tracked by git in the git workflow.',
+		'--phpcs-path <PATH>' => 'The path to the phpcs executable. Overrides env variables.',
+		'--svn-path <PATH>' => 'The path to the svn executable. Overrides env variables.',
+		'--git-path <PATH>' => 'The path to the git executable. Overrides env variables.',
+		'--cat-path <PATH>' => 'The path to the cat executable. Overrides env variables.',
 	], "	");
 	echo <<<EOF
 Overrides:
 
 	If using automatic mode, this script requires three shell commands: 'svn' or
-	'git', 'cat', and 'phpcs'. If those commands are not in your PATH or you would
-	like to override them, you can use the environment variables 'SVN', 'GIT',
-	'CAT', and 'PHPCS', respectively, to specify the full path for each one.
+	'git', 'cat', and 'phpcs'. If those commands are not in your PATH or you
+	would like to override them, you can use the environment variables 'SVN',
+	'GIT', 'CAT', and 'PHPCS', respectively, to specify the full path for each
+	one. You can alternatively use the `--svn-path`, `--git-path`, `--cat-path`,
+	or `--phpcs-path` CLI options.
 
 EOF;
 }

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -318,13 +318,11 @@ function runSvnWorkflowForFile(string $svnFile, CliOptions $options, ShellOperat
 function runGitWorkflow(CliOptions $options, ShellOperator $shell, CacheManager $cache, callable $debug): PhpcsMessages {
 	$git = $options->getExecutablePath('git');
 	$phpcs = $options->getExecutablePath('phpcs');
-	$cat = $options->getExecutablePath('cat');
 
 	try {
 		$debug('validating executables');
 		$shell->validateExecutableExists('git', $git);
 		$shell->validateExecutableExists('phpcs', $phpcs);
-		$shell->validateExecutableExists('cat', $cat);
 		$debug('executables are valid');
 		if ($options->gitBase) {
 			$options->gitBase = $shell->getGitMergeBase();

--- a/PhpcsChanged/CliOptions.php
+++ b/PhpcsChanged/CliOptions.php
@@ -25,6 +25,16 @@ class CliOptions {
 	public $phpcsPath = null;
 
 	/**
+	 * The path to the git executable.
+	 *
+	 * If null, it will default to the `GIT` environment variable. If that is
+	 * not set, it will be just `git`.
+	 *
+	 * @var string|null
+	 */
+	public $gitPath = null;
+
+	/**
 	 * The file paths to be scanned.
 	 *
 	 * @var string[]
@@ -131,6 +141,9 @@ class CliOptions {
 		if (isset($options['phpcs-path'])) {
 			$cliOptions->phpcsPath = $options['phpcs-path'];
 		}
+		if (isset($options['git-path'])) {
+			$cliOptions->gitPath = $options['git-path'];
+		}
 		if (isset($options['svn'])) {
 			$cliOptions->mode = Modes::SVN;
 		}
@@ -209,6 +222,9 @@ class CliOptions {
 		if ($this->phpcsPath) {
 			$options['phpcs-path'] = $this->phpcsPath;
 		}
+		if ($this->gitPath) {
+			$options['git-path'] = $this->gitPath;
+		}
 		if ($this->debug) {
 			$options['debug'] = true;
 		}
@@ -271,6 +287,8 @@ class CliOptions {
 		switch ($executableName) {
 			case 'phpcs':
 				return $this->phpcsPath ?: getenv('PHPCS') ?: 'phpcs';
+			case 'git':
+				return $this->gitPath ?: getenv('GIT') ?: 'git';
 			default:
 				throw new \Exception("No executable found called '{$executableName}'.");
 		}

--- a/PhpcsChanged/CliOptions.php
+++ b/PhpcsChanged/CliOptions.php
@@ -6,11 +6,27 @@ use PhpcsChanged\InvalidOptionException;
 
 class CliOptions {
 	/**
+	 * The mode to operate in: manual or automatic.
+	 *
+	 * Use the `Modes` constants for this purpose rather than the strings.
+	 *
 	 * @var 'svn'|'manual'|'git-staged'|'git-unstaged'|'git-base'|null
 	 */
 	public $mode;
 
 	/**
+	 * The path to the phpcs executable.
+	 *
+	 * If null, it will default to the `PHPCS` environment variable. If that is
+	 * not set, it will be just `phpcs`.
+	 *
+	 * @var string|null
+	 */
+	public $phpcsPath = null;
+
+	/**
+	 * The file paths to be scanned.
+	 *
 	 * @var string[]
 	 */
 	public $files = [];
@@ -112,6 +128,9 @@ class CliOptions {
 		if (isset($options['files'])) {
 			$cliOptions->files = $options['files'];
 		}
+		if (isset($options['phpcs-path'])) {
+			$cliOptions->phpcsPath = $options['phpcs-path'];
+		}
 		if (isset($options['svn'])) {
 			$cliOptions->mode = Modes::SVN;
 		}
@@ -187,6 +206,9 @@ class CliOptions {
 		if ($this->phpcsStandard) {
 			$options['standard'] = $this->phpcsStandard;
 		}
+		if ($this->phpcsPath) {
+			$options['phpcs-path'] = $this->phpcsPath;
+		}
 		if ($this->debug) {
 			$options['debug'] = true;
 		}
@@ -243,6 +265,15 @@ class CliOptions {
 	public function isGitMode(): bool {
 		$gitModes = [Modes::GIT_BASE, Modes::GIT_UNSTAGED, Modes::GIT_STAGED];
 		return in_array($this->mode, $gitModes, true);
+	}
+
+	public function getExecutablePath(string $executableName): string {
+		switch ($executableName) {
+			case 'phpcs':
+				return $this->phpcsPath ?: getenv('PHPCS') ?: 'phpcs';
+			default:
+				throw new \Exception("No executable found called '{$executableName}'.");
+		}
 	}
 
 	public function validate(): void {

--- a/PhpcsChanged/CliOptions.php
+++ b/PhpcsChanged/CliOptions.php
@@ -35,6 +35,26 @@ class CliOptions {
 	public $gitPath = null;
 
 	/**
+	 * The path to the cat executable.
+	 *
+	 * If null, it will default to the `CAT` environment variable. If that is
+	 * not set, it will be just `cat`.
+	 *
+	 * @var string|null
+	 */
+	public $catPath = null;
+
+	/**
+	 * The path to the svn executable.
+	 *
+	 * If null, it will default to the `SVN` environment variable. If that is
+	 * not set, it will be just `svn`.
+	 *
+	 * @var string|null
+	 */
+	public $svnPath = null;
+
+	/**
 	 * The file paths to be scanned.
 	 *
 	 * @var string[]
@@ -144,6 +164,12 @@ class CliOptions {
 		if (isset($options['git-path'])) {
 			$cliOptions->gitPath = $options['git-path'];
 		}
+		if (isset($options['cat-path'])) {
+			$cliOptions->catPath = $options['cat-path'];
+		}
+		if (isset($options['svn-path'])) {
+			$cliOptions->svnPath = $options['svn-path'];
+		}
 		if (isset($options['svn'])) {
 			$cliOptions->mode = Modes::SVN;
 		}
@@ -225,6 +251,12 @@ class CliOptions {
 		if ($this->gitPath) {
 			$options['git-path'] = $this->gitPath;
 		}
+		if ($this->catPath) {
+			$options['cat-path'] = $this->catPath;
+		}
+		if ($this->svnPath) {
+			$options['svn-path'] = $this->svnPath;
+		}
 		if ($this->debug) {
 			$options['debug'] = true;
 		}
@@ -289,6 +321,10 @@ class CliOptions {
 				return $this->phpcsPath ?: getenv('PHPCS') ?: 'phpcs';
 			case 'git':
 				return $this->gitPath ?: getenv('GIT') ?: 'git';
+			case 'cat':
+				return $this->catPath ?: getenv('CAT') ?: 'cat';
+			case 'svn':
+				return $this->svnPath ?: getenv('SVN') ?: 'svn';
 			default:
 				throw new \Exception("No executable found called '{$executableName}'.");
 		}

--- a/PhpcsChanged/ShellOperator.php
+++ b/PhpcsChanged/ShellOperator.php
@@ -22,6 +22,8 @@ interface ShellOperator {
 
 	public function printError(string $message): void;
 
+	public function getPhpcsStandards(): string;
+
 	public function getFileNameFromPath(string $path): string;
 
 	public function doesUnmodifiedFileExistInGit(string $fileName): bool;

--- a/PhpcsChanged/UnixShell.php
+++ b/PhpcsChanged/UnixShell.php
@@ -40,6 +40,12 @@ class UnixShell implements ShellOperator {
 		return implode(PHP_EOL, $output) . PHP_EOL;
 	}
 
+	public function getPhpcsStandards(): string {
+		$phpcs = $this->options->getExecutablePath('phpcs');
+		$installedCodingStandardsPhpcsOutputCommand = "{$phpcs} -i";
+		return $this->executeCommand($installedCodingStandardsPhpcsOutputCommand);
+	}
+
 	private function doesFileExistInGitBase(string $fileName): bool {
 		$debug = getDebug($this->options->debug);
 		$git = getenv('GIT') ?: 'git';

--- a/PhpcsChanged/UnixShell.php
+++ b/PhpcsChanged/UnixShell.php
@@ -48,7 +48,7 @@ class UnixShell implements ShellOperator {
 
 	private function doesFileExistInGitBase(string $fileName): bool {
 		$debug = getDebug($this->options->debug);
-		$git = getenv('GIT') ?: 'git';
+		$git = $this->options->getExecutablePath('git');
 		$gitStatusCommand = "{$git} cat-file -e " . escapeshellarg($this->options->gitBase) . ':' . escapeshellarg($this->getFullGitPathToFile($fileName)) . ' 2>/dev/null';
 		$debug('checking status of file with command:', $gitStatusCommand);
 		/** @var int */
@@ -61,7 +61,7 @@ class UnixShell implements ShellOperator {
 
 	private function getGitStatusForFile(string $fileName): string {
 		$debug = getDebug($this->options->debug);
-		$git = getenv('GIT') ?: 'git';
+		$git = $this->options->getExecutablePath('git');
 		$gitStatusCommand = "{$git} status --porcelain " . escapeshellarg($fileName);
 		$debug('checking git status of file with command:', $gitStatusCommand);
 		$gitStatusOutput = $this->executeCommand($gitStatusCommand);
@@ -92,7 +92,7 @@ class UnixShell implements ShellOperator {
 			return $this->fullPaths[$fileName];
 		}
 		$debug = getDebug($this->options->debug);
-		$git = getenv('GIT') ?: 'git';
+		$git = $this->options->getExecutablePath('git');
 		if (! $this->options->noVerifyGitFile) {
 			$gitStatusOutput = $this->getGitStatusForFile($fileName);
 			if (! $gitStatusOutput || false === strpos($gitStatusOutput, $fileName)) {
@@ -111,8 +111,8 @@ class UnixShell implements ShellOperator {
 	}
 
 	private function getModifiedFileContentsCommand(string $fileName): string {
-		$git = getenv('GIT') ?: 'git';
-		$cat = getenv('CAT') ?: 'cat';
+		$git = $this->options->getExecutablePath('git');
+		$cat = $this->options->getExecutablePath('cat');
 		$fullPath = $this->getFullGitPathToFile($fileName);
 		if ($this->options->mode === Modes::GIT_BASE) {
 			// for git-base mode, we get the contents of the file from the HEAD version of the file in the current branch
@@ -127,7 +127,7 @@ class UnixShell implements ShellOperator {
 	}
 
 	private function getUnmodifiedFileContentsCommand(string $fileName): string {
-		$git = getenv('GIT') ?: 'git';
+		$git = $this->options->getExecutablePath('git');
 		if ($this->options->mode === Modes::GIT_BASE) {
 			$rev = escapeshellarg($this->options->gitBase);
 		} else if ($this->options->mode === Modes::GIT_UNSTAGED) {
@@ -142,7 +142,7 @@ class UnixShell implements ShellOperator {
 
 	public function getGitHashOfModifiedFile(string $fileName): string {
 		$debug = getDebug($this->options->debug);
-		$git = getenv('GIT') ?: 'git';
+		$git = $this->options->getExecutablePath('git');
 		$fileContentsCommand = $this->getModifiedFileContentsCommand($fileName);
 		$command = "{$fileContentsCommand} | {$git} hash-object --stdin";
 		$debug('running modified file git hash command:', $command);
@@ -156,7 +156,7 @@ class UnixShell implements ShellOperator {
 
 	public function getGitHashOfUnmodifiedFile(string $fileName): string {
 		$debug = getDebug($this->options->debug);
-		$git = getenv('GIT') ?: 'git';
+		$git = $this->options->getExecutablePath('git');
 		$fileContentsCommand = $this->getUnmodifiedFileContentsCommand($fileName);
 		$command = "{$fileContentsCommand} | {$git} hash-object --stdin";
 		$debug('running unmodified file git hash command:', $command);
@@ -212,7 +212,7 @@ class UnixShell implements ShellOperator {
 
 	public function getGitUnifiedDiff(string $fileName): string {
 		$debug = getDebug($this->options->debug);
-		$git = getenv('GIT') ?: 'git';
+		$git = $this->options->getExecutablePath('git');
 		$objectOption = $this->options->mode === Modes::GIT_BASE ? ' ' . escapeshellarg($this->options->gitBase) . '...' : '';
 		$stagedOption = empty($objectOption) && $this->options->mode !== Modes::GIT_UNSTAGED ? ' --staged' : '';
 		$unifiedDiffCommand = "{$git} diff{$stagedOption}{$objectOption} --no-prefix " . escapeshellarg($fileName);
@@ -230,7 +230,7 @@ class UnixShell implements ShellOperator {
 			return '';
 		}
 		$debug = getDebug($this->options->debug);
-		$git = getenv('GIT') ?: 'git';
+		$git = $this->options->getExecutablePath('git');
 		$mergeBaseCommand = "{$git} merge-base " . escapeshellarg($this->options->gitBase) . ' HEAD';
 		$debug('running merge-base command:', $mergeBaseCommand);
 		$mergeBase = $this->executeCommand($mergeBaseCommand);

--- a/PhpcsChanged/UnixShell.php
+++ b/PhpcsChanged/UnixShell.php
@@ -174,7 +174,7 @@ class UnixShell implements ShellOperator {
 
 	public function getPhpcsOutputOfModifiedGitFile(string $fileName): string {
 		$debug = getDebug($this->options->debug);
-		$phpcs = getenv('PHPCS') ?: 'phpcs';
+		$phpcs = $this->options->getExecutablePath('phpcs');
 		$fileContentsCommand = $this->getModifiedFileContentsCommand($fileName);
 		$modifiedFilePhpcsOutputCommand = "{$fileContentsCommand} | {$phpcs} --report=json -q" . $this->getPhpcsStandardOption() . ' --stdin-path=' .  escapeshellarg($fileName) .' -';
 		$debug('running modified file phpcs command:', $modifiedFilePhpcsOutputCommand);
@@ -192,7 +192,7 @@ class UnixShell implements ShellOperator {
 
 	public function getPhpcsOutputOfUnmodifiedGitFile(string $fileName): string {
 		$debug = getDebug($this->options->debug);
-		$phpcs = getenv('PHPCS') ?: 'phpcs';
+		$phpcs = $this->options->getExecutablePath('phpcs');
 		$unmodifiedFileContentsCommand = $this->getUnmodifiedFileContentsCommand($fileName);
 		$unmodifiedFilePhpcsOutputCommand = "{$unmodifiedFileContentsCommand} | {$phpcs} --report=json -q" . $this->getPhpcsStandardOption() . ' --stdin-path=' .  escapeshellarg($fileName) . ' -';
 		$debug('running unmodified file phpcs command:', $unmodifiedFilePhpcsOutputCommand);

--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ The `--no-cache-git-root` option will prevent caching the check used by the git 
 
 The `--arc-lint` option can be used when the phpcs-changed is run via arcanist, as it skips some checks, which are performed by arcanist itself. It leads to better performance when used with arcanist. (Equivalent to `--no-verify-git-file --always-exit-zero`.)
 
+The `--svn-path`, `--git-path`, `--cat-path`, and `--phpcs-path` options can be used to specify the paths to the executables of the same names. If these options are not set, the program will try to use the `SVN`, `GIT`, `CAT`, and `PHPCS` env variables. If those are also not set, the program will default to `svn`, `git`, `cat`, and `phpcs`, respectively, assuming that each command will be in the system's `PATH`.
+
 The `--debug` option will show every step taken by the script.
 
 ## PHP Library

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -35,6 +35,7 @@ $options = getopt(
 		'version',
 		'diff:',
 		'phpcs-path:',
+		'git-path:',
 		'phpcs-orig:',
 		'phpcs-unmodified:',
 		'phpcs-new:',
@@ -147,7 +148,7 @@ function run(array $rawOptions, callable $debug): void {
 	if ($options->mode === Modes::SVN) {
 		$shell = new UnixShell($options);
 		reportMessagesAndExit(
-			runSvnWorkflow($options->files, $options->toArray(), $shell, new CacheManager(new FileCache(), $debug), $debug),
+			runSvnWorkflow($options->files, $options, $shell, new CacheManager(new FileCache(), $debug), $debug),
 			$options
 		);
 		return;

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -36,6 +36,8 @@ $options = getopt(
 		'diff:',
 		'phpcs-path:',
 		'git-path:',
+		'cat-path:',
+		'svn-path:',
 		'phpcs-orig:',
 		'phpcs-unmodified:',
 		'phpcs-new:',

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -34,6 +34,7 @@ $options = getopt(
 		'help',
 		'version',
 		'diff:',
+		'phpcs-path:',
 		'phpcs-orig:',
 		'phpcs-unmodified:',
 		'phpcs-new:',

--- a/tests/GitWorkflowTest.php
+++ b/tests/GitWorkflowTest.php
@@ -33,8 +33,8 @@ final class GitWorkflowTest extends TestCase {
 		$shell->registerCommand("git diff --staged --no-prefix 'foobar.php'", $fixture);
 		$shell->registerCommand("git status --porcelain 'foobar.php'", $this->fixture->getModifiedFileInfo('foobar.php'));
 		$shell->registerCommand("git ls-files --full-name 'foobar.php'", "files/foobar.php");
-		$shell->registerCommand("git show HEAD:'files/foobar.php'", $this->phpcs->getResults('STDIN', [20])->toPhpcsJson());
-		$shell->registerCommand("git show :0:'files/foobar.php'", $this->phpcs->getResults('STDIN', [20, 21], 'Found unused symbol Foobar.')->toPhpcsJson());
+		$shell->registerCommand("git show HEAD:'files/foobar.php' | phpcs", $this->phpcs->getResults('STDIN', [20])->toPhpcsJson());
+		$shell->registerCommand("git show :0:'files/foobar.php' | phpcs", $this->phpcs->getResults('STDIN', [20, 21], 'Found unused symbol Foobar.')->toPhpcsJson());
 		$shell->registerCommand("git rev-parse --show-toplevel", 'run-from-git-root');
 		$cache = new CacheManager( new TestCache() );
 		$expected = $this->phpcs->getResults('bin/foobar.php', [20], 'Found unused symbol Foobar.');

--- a/tests/SvnWorkflowTest.php
+++ b/tests/SvnWorkflowTest.php
@@ -76,6 +76,7 @@ final class SvnWorkflowTest extends TestCase {
 			'svn' => true,
 			'files' => [$svnFile],
 		]);
+		$shell->setOptions($options);
 		$expected = $this->phpcs->getResults('bin/foobar.php', [20]);
 		$messages = runSvnWorkflow([$svnFile], $options->toArray(), $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
@@ -91,6 +92,7 @@ final class SvnWorkflowTest extends TestCase {
 			'svn' => true,
 			'files' => [$svnFile],
 		]);
+		$shell->setOptions($options);
 		$expected = $this->phpcs->getEmptyResults();
 		$messages = runSvnWorkflow([$svnFile], $options->toArray(), $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
@@ -109,6 +111,7 @@ final class SvnWorkflowTest extends TestCase {
 			'cache' => false, // getopt is weird and sets options to false
 			'files' => [$svnFile],
 		]);
+		$shell->setOptions($options);
 		$expected = $this->phpcs->getResults('bin/foobar.php', [20]);
 		$messages = runSvnWorkflow([$svnFile], $options->toArray(), $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
@@ -125,6 +128,7 @@ final class SvnWorkflowTest extends TestCase {
 			'cache' => false, // getopt is weird and sets options to false
 			'files' => [$svnFile],
 		]);
+		$shell->setOptions($options);
 		$expected = $this->phpcs->getResults('bin/foobar.php', [20]);
 		$cache = new TestCache();
 		$cache->setEntry('foobar.php', 'old', '188280', '', $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
@@ -146,6 +150,7 @@ final class SvnWorkflowTest extends TestCase {
 			'cache' => false, // getopt is weird and sets options to false
 			'files' => [$svnFile],
 		]);
+		$shell->setOptions($options);
 		$expected = $this->phpcs->getResults('bin/foobar.php', [20]);
 
 		$cache = new TestCache();
@@ -173,6 +178,7 @@ final class SvnWorkflowTest extends TestCase {
 			'cache' => false, // getopt is weird and sets options to false
 			'files' => [$svnFile],
 		]);
+		$shell->setOptions($options);
 		$expected = $this->phpcs->getResults('bin/foobar.php', [20]);
 
 		$cache = new TestCache();
@@ -211,6 +217,7 @@ final class SvnWorkflowTest extends TestCase {
 			'cache' => false, // getopt is weird and sets options to false
 			'files' => [$svnFile],
 		]);
+		$shell->setOptions($options);
 		$expected = $this->phpcs->getResults('bin/foobar.php', [20]);
 		$original_hash = $shell->getFileHash('foobar.php');
 
@@ -257,6 +264,7 @@ final class SvnWorkflowTest extends TestCase {
 			'cache' => false, // getopt is weird and sets options to false
 			'files' => [$svnFile],
 		]);
+		$shell->setOptions($options);
 		$expected = $this->phpcs->getResults('bin/foobar.php', [20]);
 
 		$cache = new TestCache();
@@ -264,6 +272,7 @@ final class SvnWorkflowTest extends TestCase {
 
 		// Run once to cache results
 		$options->phpcsStandard = 'one';
+		$shell->setOptions($options);
 		runSvnWorkflow([$svnFile], $options->toArray(), $shell, $manager, '\PhpcsChangedTests\debug');
 		$this->assertTrue($shell->wasCommandCalled("svn cat 'foobar.php'"));
 		$this->assertTrue($shell->wasCommandCalled("cat 'foobar.php'"));
@@ -277,6 +286,7 @@ final class SvnWorkflowTest extends TestCase {
 
 		// Run a third time, with the standard changed, and make sure we don't use the cache
 		$options->phpcsStandard = 'two';
+		$shell->setOptions($options);
 		$shell->resetCommandsCalled();
 		$messages = runSvnWorkflow([$svnFile], $options->toArray(), $shell, $manager, '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
@@ -285,6 +295,7 @@ final class SvnWorkflowTest extends TestCase {
 
 		// Run a fourth time, restoring the standard, and make sure we do use the cache
 		$options->phpcsStandard = 'one';
+		$shell->setOptions($options);
 		$shell->resetCommandsCalled();
 		$messages = runSvnWorkflow([$svnFile], $options->toArray(), $shell, $manager, '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
@@ -304,6 +315,7 @@ final class SvnWorkflowTest extends TestCase {
 			'no-cache' => false, // getopt is weird and sets options to false
 			'files' => [$svnFile],
 		]);
+		$shell->setOptions($options);
 		$expected = $this->phpcs->getResults('bin/foobar.php', [20]);
 		$cache = new TestCache();
 		$cache->disabled = true;
@@ -325,6 +337,7 @@ final class SvnWorkflowTest extends TestCase {
 			'cache' => false, // getopt is weird and sets options to false
 			'files' => [$svnFile],
 		]);
+		$shell->setOptions($options);
 		$expected = $this->phpcs->getResults('bin/foobar.php', [20]);
 		$cache = new TestCache();
 		$cache->setCacheVersion('0.1-something-else');
@@ -350,6 +363,7 @@ final class SvnWorkflowTest extends TestCase {
 			'standard' => 'TestStandard1',
 			'files' => [$svnFile],
 		]);
+		$shell->setOptions($options);
 		$expected = $this->phpcs->getResults('bin/foobar.php', [20]);
 		$cache = new TestCache();
 		$cache->setEntry('foobar.php', 'old', '188280', 'TestStandard2', 'blah'); // This invalid JSON will throw if the cache is used
@@ -370,6 +384,7 @@ final class SvnWorkflowTest extends TestCase {
 			'cache' => false, // getopt is weird and sets options to false
 			'files' => [$svnFile],
 		]);
+		$shell->setOptions($options);
 		$expected = $this->phpcs->getResults('bin/foobar.php', [20]);
 		$cache = new TestCache();
 
@@ -398,6 +413,7 @@ final class SvnWorkflowTest extends TestCase {
 			'cache' => false, // getopt is weird and sets options to false
 			'files' => [$svnFile],
 		]);
+		$shell->setOptions($options);
 		$expected = PhpcsMessages::fromArrays([], 'bin/foobar.php');
 		$cache = new TestCache();
 		$cache->setEntry('foobar.php', 'new', 'foobar.php', '', $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
@@ -419,6 +435,7 @@ final class SvnWorkflowTest extends TestCase {
 			'cache' => false, // getopt is weird and sets options to false
 			'files' => [$svnFile],
 		]);
+		$shell->setOptions($options);
 		$expected = PhpcsMessages::fromArrays([], 'bin/foobar.php');
 		$cache = new TestCache();
 		$cache->setEntry('foobar.php', 'old', '188280', '', $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
@@ -445,6 +462,7 @@ final class SvnWorkflowTest extends TestCase {
 			'svn' => true,
 			'files' => $svnFiles,
 		]);
+		$shell->setOptions($options);
 		$expected = PhpcsMessages::merge([
 			$this->phpcs->getResults('bin/foobar.php', [20]),
 			$this->phpcs->getResults('bin/baz.php', [20], 'Found unused symbol Baz.'),
@@ -464,6 +482,7 @@ final class SvnWorkflowTest extends TestCase {
 			'svn' => true,
 			'files' => [$svnFile],
 		]);
+		$shell->setOptions($options);
 		$expected = PhpcsMessages::fromArrays([], 'STDIN');
 		$messages = runSvnWorkflow([$svnFile], $options->toArray(), $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
@@ -480,6 +499,7 @@ final class SvnWorkflowTest extends TestCase {
 			'svn' => true,
 			'files' => [$svnFile],
 		]);
+		$shell->setOptions($options);
 		$expected = PhpcsMessages::fromArrays([], 'STDIN');
 		$messages = runSvnWorkflow([$svnFile], $options->toArray(), $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
@@ -496,6 +516,7 @@ final class SvnWorkflowTest extends TestCase {
 			'svn' => true,
 			'files' => [$svnFile],
 		]);
+		$shell->setOptions($options);
 		runSvnWorkflow([$svnFile], $options->toArray(), $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
 		$this->assertFalse($shell->wasCommandCalled("svn diff 'foobar.php'"));
 		$this->assertFalse($shell->wasCommandCalled("svn cat 'foobar.php'"));
@@ -514,6 +535,7 @@ final class SvnWorkflowTest extends TestCase {
 			'svn' => true,
 			'files' => [$svnFile],
 		]);
+		$shell->setOptions($options);
 		runSvnWorkflow([$svnFile], $options->toArray(), $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
 	}
 
@@ -527,6 +549,7 @@ final class SvnWorkflowTest extends TestCase {
 			'svn' => true,
 			'files' => [$svnFile],
 		]);
+		$shell->setOptions($options);
 		$expected = $this->phpcs->getResults('foobar.php', [20, 21]);
 		$messages = runSvnWorkflow([$svnFile], $options->toArray(), $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
@@ -546,6 +569,7 @@ Run "phpcs --help" for usage information
 			'svn' => true,
 			'files' => [$svnFile],
 		]);
+		$shell->setOptions($options);
 		$expected = PhpcsMessages::fromArrays([], 'STDIN');
 		$messages = runSvnWorkflow([$svnFile], $options->toArray(), $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
@@ -566,6 +590,7 @@ Run "phpcs --help" for usage information
 			'standard' => 'standard',
 			'files' => [$svnFile],
 		]);
+		$shell->setOptions($options);
 		$cache = new CacheManager(new TestCache());
 		runSvnWorkflow([$svnFile], $options->toArray(), $shell, $cache, '\PhpcsChangedTests\debug' );
 		

--- a/tests/SvnWorkflowTest.php
+++ b/tests/SvnWorkflowTest.php
@@ -74,8 +74,8 @@ final class SvnWorkflowTest extends TestCase {
 		$shell = new TestShell($options, [$svnFile]);
 		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
 		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php'));
-		$shell->registerCommand("svn cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
-		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
+		$shell->registerCommand("svn cat 'foobar.php' | phpcs", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
+		$shell->registerCommand("cat 'foobar.php' | phpcs", $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
 		$expected = $this->phpcs->getResults('bin/foobar.php', [20]);
 		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());

--- a/tests/SvnWorkflowTest.php
+++ b/tests/SvnWorkflowTest.php
@@ -81,6 +81,42 @@ final class SvnWorkflowTest extends TestCase {
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 
+	public function testFullSvnWorkflowForOneFileWithReplacedSvn() {
+		$svnFile = 'foobar.php';
+		$svnPath = 'bin/foo/svn';
+		$options = CliOptions::fromArray([
+			'svn' => true,
+			'files' => [$svnFile],
+			'svn-path' => $svnPath,
+		]);
+		$shell = new TestShell($options, [$svnFile]);
+		$shell->registerCommand("{$svnPath} diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
+		$shell->registerCommand("{$svnPath} info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php'));
+		$shell->registerCommand("{$svnPath} cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
+		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
+		$expected = $this->phpcs->getResults('bin/foobar.php', [20]);
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
+		$this->assertEquals($expected->getMessages(), $messages->getMessages());
+	}
+
+	public function testFullSvnWorkflowForOneFileWithReplacedCat() {
+		$svnFile = 'foobar.php';
+		$catPath = 'bin/foo/cat';
+		$options = CliOptions::fromArray([
+			'svn' => true,
+			'files' => [$svnFile],
+			'cat-path' => $catPath,
+		]);
+		$shell = new TestShell($options, [$svnFile]);
+		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
+		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php'));
+		$shell->registerCommand("svn cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
+		$shell->registerCommand("{$catPath} 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
+		$expected = $this->phpcs->getResults('bin/foobar.php', [20]);
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
+		$this->assertEquals($expected->getMessages(), $messages->getMessages());
+	}
+
 	public function testFullSvnWorkflowForOneFileWithNoMessages() {
 		$svnFile = 'foobar.php';
 		$options = CliOptions::fromArray([

--- a/tests/SvnWorkflowTest.php
+++ b/tests/SvnWorkflowTest.php
@@ -67,16 +67,15 @@ final class SvnWorkflowTest extends TestCase {
 
 	public function testFullSvnWorkflowForOneFile() {
 		$svnFile = 'foobar.php';
-		$shell = new TestShell([$svnFile]);
-		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
-		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php'));
-		$shell->registerCommand("svn cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
-		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
 		$options = CliOptions::fromArray([
 			'svn' => true,
 			'files' => [$svnFile],
 		]);
-		$shell->setOptions($options);
+		$shell = new TestShell($options, [$svnFile]);
+		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
+		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php'));
+		$shell->registerCommand("svn cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
+		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
 		$expected = $this->phpcs->getResults('bin/foobar.php', [20]);
 		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
@@ -84,15 +83,14 @@ final class SvnWorkflowTest extends TestCase {
 
 	public function testFullSvnWorkflowForOneFileWithNoMessages() {
 		$svnFile = 'foobar.php';
-		$shell = new TestShell([$svnFile]);
-		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
-		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php'));
-		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getEmptyResults()->toPhpcsJson());
 		$options = CliOptions::fromArray([
 			'svn' => true,
 			'files' => [$svnFile],
 		]);
-		$shell->setOptions($options);
+		$shell = new TestShell($options, [$svnFile]);
+		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
+		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php'));
+		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getEmptyResults()->toPhpcsJson());
 		$expected = $this->phpcs->getEmptyResults();
 		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
@@ -101,17 +99,16 @@ final class SvnWorkflowTest extends TestCase {
 
 	public function testFullSvnWorkflowForOneFileWithCachingEnabledButNoCache() {
 		$svnFile = 'foobar.php';
-		$shell = new TestShell([$svnFile]);
-		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
-		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php'));
-		$shell->registerCommand("svn cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
-		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
 		$options = CliOptions::fromArray([
 			'svn' => true,
 			'cache' => false, // getopt is weird and sets options to false
 			'files' => [$svnFile],
 		]);
-		$shell->setOptions($options);
+		$shell = new TestShell($options, [$svnFile]);
+		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
+		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php'));
+		$shell->registerCommand("svn cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
+		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
 		$expected = $this->phpcs->getResults('bin/foobar.php', [20]);
 		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
@@ -119,16 +116,15 @@ final class SvnWorkflowTest extends TestCase {
 
 	public function testFullSvnWorkflowForOneFileWithOldFileCached() {
 		$svnFile = 'foobar.php';
-		$shell = new TestShell([$svnFile]);
-		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
-		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php', '188280'));
-		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
 		$options = CliOptions::fromArray([
 			'svn' => true,
 			'cache' => false, // getopt is weird and sets options to false
 			'files' => [$svnFile],
 		]);
-		$shell->setOptions($options);
+		$shell = new TestShell($options, [$svnFile]);
+		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
+		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php', '188280'));
+		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
 		$expected = $this->phpcs->getResults('bin/foobar.php', [20]);
 		$cache = new TestCache();
 		$cache->setEntry('foobar.php', 'old', '188280', '', $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
@@ -140,17 +136,16 @@ final class SvnWorkflowTest extends TestCase {
 
 	public function testFullSvnWorkflowForOneFileUncachedThenCachesBothVersionsOfTheFile() {
 		$svnFile = 'foobar.php';
-		$shell = new TestShell([$svnFile]);
-		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
-		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php', '188280'));
-		$shell->registerCommand("svn cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
-		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
 		$options = CliOptions::fromArray([
 			'svn' => true,
 			'cache' => false, // getopt is weird and sets options to false
 			'files' => [$svnFile],
 		]);
-		$shell->setOptions($options);
+		$shell = new TestShell($options, [$svnFile]);
+		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
+		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php', '188280'));
+		$shell->registerCommand("svn cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
+		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
 		$expected = $this->phpcs->getResults('bin/foobar.php', [20]);
 
 		$cache = new TestCache();
@@ -168,17 +163,16 @@ final class SvnWorkflowTest extends TestCase {
 
 	public function testFullSvnWorkflowForOneDoesNotUseNewFileCacheWhenHashChanges() {
 		$svnFile = 'foobar.php';
-		$shell = new TestShell([$svnFile]);
-		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
-		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php', '188280'));
-		$shell->registerCommand("svn cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
-		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
 		$options = CliOptions::fromArray([
 			'svn' => true,
 			'cache' => false, // getopt is weird and sets options to false
 			'files' => [$svnFile],
 		]);
-		$shell->setOptions($options);
+		$shell = new TestShell($options, [$svnFile]);
+		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
+		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php', '188280'));
+		$shell->registerCommand("svn cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
+		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
 		$expected = $this->phpcs->getResults('bin/foobar.php', [20]);
 
 		$cache = new TestCache();
@@ -207,17 +201,16 @@ final class SvnWorkflowTest extends TestCase {
 
 	public function testFullSvnWorkflowForOneClearsCacheForFileWhenHashChanges() {
 		$svnFile = 'foobar.php';
-		$shell = new TestShell([$svnFile]);
-		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
-		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php', '188280'));
-		$shell->registerCommand("svn cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
-		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
 		$options = CliOptions::fromArray([
 			'svn' => true,
 			'cache' => false, // getopt is weird and sets options to false
 			'files' => [$svnFile],
 		]);
-		$shell->setOptions($options);
+		$shell = new TestShell($options, [$svnFile]);
+		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
+		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php', '188280'));
+		$shell->registerCommand("svn cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
+		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
 		$expected = $this->phpcs->getResults('bin/foobar.php', [20]);
 		$original_hash = $shell->getFileHash('foobar.php');
 
@@ -254,17 +247,16 @@ final class SvnWorkflowTest extends TestCase {
 
 	public function testFullSvnWorkflowForOneDoesNotClearCacheWhenStandardChanges() {
 		$svnFile = 'foobar.php';
-		$shell = new TestShell([$svnFile]);
-		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
-		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php', '188280'));
-		$shell->registerCommand("svn cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
-		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
 		$options = CliOptions::fromArray([
 			'svn' => true,
 			'cache' => false, // getopt is weird and sets options to false
 			'files' => [$svnFile],
 		]);
-		$shell->setOptions($options);
+		$shell = new TestShell($options, [$svnFile]);
+		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
+		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php', '188280'));
+		$shell->registerCommand("svn cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
+		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
 		$expected = $this->phpcs->getResults('bin/foobar.php', [20]);
 
 		$cache = new TestCache();
@@ -272,7 +264,6 @@ final class SvnWorkflowTest extends TestCase {
 
 		// Run once to cache results
 		$options->phpcsStandard = 'one';
-		$shell->setOptions($options);
 		runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\debug');
 		$this->assertTrue($shell->wasCommandCalled("svn cat 'foobar.php'"));
 		$this->assertTrue($shell->wasCommandCalled("cat 'foobar.php'"));
@@ -286,7 +277,6 @@ final class SvnWorkflowTest extends TestCase {
 
 		// Run a third time, with the standard changed, and make sure we don't use the cache
 		$options->phpcsStandard = 'two';
-		$shell->setOptions($options);
 		$shell->resetCommandsCalled();
 		$messages = runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
@@ -295,7 +285,6 @@ final class SvnWorkflowTest extends TestCase {
 
 		// Run a fourth time, restoring the standard, and make sure we do use the cache
 		$options->phpcsStandard = 'one';
-		$shell->setOptions($options);
 		$shell->resetCommandsCalled();
 		$messages = runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
@@ -305,17 +294,16 @@ final class SvnWorkflowTest extends TestCase {
 
 	public function testFullSvnWorkflowForOneFileUncachedWhenCachingIsDisabled() {
 		$svnFile = 'foobar.php';
-		$shell = new TestShell([$svnFile]);
-		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
-		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php'));
-		$shell->registerCommand("svn cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
-		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
 		$options = CliOptions::fromArray([
 			'svn' => true,
 			'no-cache' => false, // getopt is weird and sets options to false
 			'files' => [$svnFile],
 		]);
-		$shell->setOptions($options);
+		$shell = new TestShell($options, [$svnFile]);
+		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
+		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php'));
+		$shell->registerCommand("svn cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
+		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
 		$expected = $this->phpcs->getResults('bin/foobar.php', [20]);
 		$cache = new TestCache();
 		$cache->disabled = true;
@@ -327,17 +315,16 @@ final class SvnWorkflowTest extends TestCase {
 
 	public function testFullSvnWorkflowForOneFileWithOldCacheVersion() {
 		$svnFile = 'foobar.php';
-		$shell = new TestShell([$svnFile]);
-		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
-		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php', '188280'));
-		$shell->registerCommand("svn cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
-		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
 		$options = CliOptions::fromArray([
 			'svn' => true,
 			'cache' => false, // getopt is weird and sets options to false
 			'files' => [$svnFile],
 		]);
-		$shell->setOptions($options);
+		$shell = new TestShell($options, [$svnFile]);
+		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
+		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php', '188280'));
+		$shell->registerCommand("svn cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
+		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
 		$expected = $this->phpcs->getResults('bin/foobar.php', [20]);
 		$cache = new TestCache();
 		$cache->setCacheVersion('0.1-something-else');
@@ -350,20 +337,19 @@ final class SvnWorkflowTest extends TestCase {
 
 	public function testFullSvnWorkflowForOneFileWithCacheThatHasDifferentStandard() {
 		$svnFile = 'foobar.php';
-		$shell = new TestShell([$svnFile]);
-		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
-		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php', '188280'));
-		$oldFileOutput = $this->phpcs->getResults('STDIN', [20, 99]);
-		$newFileOutput = $this->phpcs->getResults('STDIN', [20, 21]);
-		$shell->registerCommand("svn cat 'foobar.php'", $oldFileOutput->toPhpcsJson());
-		$shell->registerCommand("cat 'foobar.php'", $newFileOutput->toPhpcsJson());
 		$options = CliOptions::fromArray([
 			'svn' => true,
 			'cache' => false, // getopt is weird and sets options to false
 			'standard' => 'TestStandard1',
 			'files' => [$svnFile],
 		]);
-		$shell->setOptions($options);
+		$shell = new TestShell($options, [$svnFile]);
+		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
+		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php', '188280'));
+		$oldFileOutput = $this->phpcs->getResults('STDIN', [20, 99]);
+		$newFileOutput = $this->phpcs->getResults('STDIN', [20, 21]);
+		$shell->registerCommand("svn cat 'foobar.php'", $oldFileOutput->toPhpcsJson());
+		$shell->registerCommand("cat 'foobar.php'", $newFileOutput->toPhpcsJson());
 		$expected = $this->phpcs->getResults('bin/foobar.php', [20]);
 		$cache = new TestCache();
 		$cache->setEntry('foobar.php', 'old', '188280', 'TestStandard2', 'blah'); // This invalid JSON will throw if the cache is used
@@ -375,16 +361,15 @@ final class SvnWorkflowTest extends TestCase {
 
 	public function testFullSvnWorkflowForOneFileWithCacheOfOldFileVersionDoesNotUseCache() {
 		$svnFile = 'foobar.php';
-		$shell = new TestShell([$svnFile]);
-		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
-		$shell->registerCommand("svn cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
-		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
 		$options = CliOptions::fromArray([
 			'svn' => true,
 			'cache' => false, // getopt is weird and sets options to false
 			'files' => [$svnFile],
 		]);
-		$shell->setOptions($options);
+		$shell = new TestShell($options, [$svnFile]);
+		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
+		$shell->registerCommand("svn cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
+		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
 		$expected = $this->phpcs->getResults('bin/foobar.php', [20]);
 		$cache = new TestCache();
 
@@ -404,16 +389,15 @@ final class SvnWorkflowTest extends TestCase {
 
 	public function testFullSvnWorkflowForUnchangedFileWithBothFilesCached() {
 		$svnFile = 'foobar.php';
-		$shell = new TestShell([$svnFile]);
-		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getEmptyFileDiff());
-		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php', '188280'));
-		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
 		$options = CliOptions::fromArray([
 			'svn' => true,
 			'cache' => false, // getopt is weird and sets options to false
 			'files' => [$svnFile],
 		]);
-		$shell->setOptions($options);
+		$shell = new TestShell($options, [$svnFile]);
+		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getEmptyFileDiff());
+		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php', '188280'));
+		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
 		$expected = PhpcsMessages::fromArrays([], 'bin/foobar.php');
 		$cache = new TestCache();
 		$cache->setEntry('foobar.php', 'new', 'foobar.php', '', $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
@@ -426,16 +410,15 @@ final class SvnWorkflowTest extends TestCase {
 
 	public function testFullSvnWorkflowForUnchangedFileWithOldFileCached() {
 		$svnFile = 'foobar.php';
-		$shell = new TestShell([$svnFile]);
-		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getEmptyFileDiff());
-		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php', '188280'));
-		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
 		$options = CliOptions::fromArray([
 			'svn' => true,
 			'cache' => false, // getopt is weird and sets options to false
 			'files' => [$svnFile],
 		]);
-		$shell->setOptions($options);
+		$shell = new TestShell($options, [$svnFile]);
+		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getEmptyFileDiff());
+		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php', '188280'));
+		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
 		$expected = PhpcsMessages::fromArrays([], 'bin/foobar.php');
 		$cache = new TestCache();
 		$cache->setEntry('foobar.php', 'old', '188280', '', $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
@@ -447,7 +430,11 @@ final class SvnWorkflowTest extends TestCase {
 
 	public function testFullSvnWorkflowForMultipleFiles() {
 		$svnFiles = ['foobar.php', 'baz.php'];
-		$shell = new TestShell($svnFiles);
+		$options = CliOptions::fromArray([
+			'svn' => true,
+			'files' => $svnFiles,
+		]);
+		$shell = new TestShell($options, $svnFiles);
 		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
 		$shell->registerCommand("svn diff 'baz.php'", $this->fixture->getAddedLineDiff('baz.php', 'use Baz;'));
 		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php'));
@@ -458,11 +445,6 @@ final class SvnWorkflowTest extends TestCase {
 		$shell->registerCommand("svn cat 'baz.php'", $this->phpcs->getResults('STDIN', [20, 99], 'Found unused symbol Baz.')->toPhpcsJson());
 		$shell->registerCommand("cat 'baz.php'", $this->phpcs->getResults('STDIN', [20, 21], 'Found unused symbol Baz.')->toPhpcsJson());
 
-		$options = CliOptions::fromArray([
-			'svn' => true,
-			'files' => $svnFiles,
-		]);
-		$shell->setOptions($options);
 		$expected = PhpcsMessages::merge([
 			$this->phpcs->getResults('bin/foobar.php', [20]),
 			$this->phpcs->getResults('bin/baz.php', [20], 'Found unused symbol Baz.'),
@@ -473,16 +455,15 @@ final class SvnWorkflowTest extends TestCase {
 
 	public function testFullSvnWorkflowForUnchangedFileWithPhpCsMessages() {
 		$svnFile = 'foobar.php';
-		$shell = new TestShell([$svnFile]);
-		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getEmptyFileDiff());
-		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php'));
-		$shell->registerCommand("svn cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
-		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
 		$options = CliOptions::fromArray([
 			'svn' => true,
 			'files' => [$svnFile],
 		]);
-		$shell->setOptions($options);
+		$shell = new TestShell($options, [$svnFile]);
+		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getEmptyFileDiff());
+		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php'));
+		$shell->registerCommand("svn cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
+		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
 		$expected = PhpcsMessages::fromArrays([], 'STDIN');
 		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
@@ -490,16 +471,15 @@ final class SvnWorkflowTest extends TestCase {
 
 	public function testFullSvnWorkflowForUnchangedFileWithoutPhpCsMessages() {
 		$svnFile = 'foobar.php';
-		$shell = new TestShell([$svnFile]);
-		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getEmptyFileDiff());
-		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php'));
-		$shell->registerCommand("svn cat 'foobar.php'", '{"totals":{"errors":0,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":0,"warnings":0,"messages":[]}}}');
-		$shell->registerCommand("cat 'foobar.php'", '{"totals":{"errors":0,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":0,"warnings":0,"messages":[]}}}');
 		$options = CliOptions::fromArray([
 			'svn' => true,
 			'files' => [$svnFile],
 		]);
-		$shell->setOptions($options);
+		$shell = new TestShell($options, [$svnFile]);
+		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getEmptyFileDiff());
+		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php'));
+		$shell->registerCommand("svn cat 'foobar.php'", '{"totals":{"errors":0,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":0,"warnings":0,"messages":[]}}}');
+		$shell->registerCommand("cat 'foobar.php'", '{"totals":{"errors":0,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":0,"warnings":0,"messages":[]}}}');
 		$expected = PhpcsMessages::fromArrays([], 'STDIN');
 		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
@@ -507,16 +487,15 @@ final class SvnWorkflowTest extends TestCase {
 
 	public function testFullSvnWorkflowForChangedFileWithoutPhpCsMessagesLintsOnlyNewFile() {
 		$svnFile = 'foobar.php';
-		$shell = new TestShell([$svnFile]);
-		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getEmptyFileDiff());
-		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php'));
-		$shell->registerCommand("svn cat 'foobar.php'", '{"totals":{"errors":0,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":0,"warnings":0,"messages":[]}}}');
-		$shell->registerCommand("cat 'foobar.php'", '{"totals":{"errors":0,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":0,"warnings":0,"messages":[]}}}');
 		$options = CliOptions::fromArray([
 			'svn' => true,
 			'files' => [$svnFile],
 		]);
-		$shell->setOptions($options);
+		$shell = new TestShell($options, [$svnFile]);
+		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getEmptyFileDiff());
+		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php'));
+		$shell->registerCommand("svn cat 'foobar.php'", '{"totals":{"errors":0,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":0,"warnings":0,"messages":[]}}}');
+		$shell->registerCommand("cat 'foobar.php'", '{"totals":{"errors":0,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":0,"warnings":0,"messages":[]}}}');
 		runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
 		$this->assertFalse($shell->wasCommandCalled("svn diff 'foobar.php'"));
 		$this->assertFalse($shell->wasCommandCalled("svn cat 'foobar.php'"));
@@ -526,30 +505,28 @@ final class SvnWorkflowTest extends TestCase {
 	public function testFullSvnWorkflowForNonSvnFile() {
 		$this->expectException(ShellException::class);
 		$svnFile = 'foobar.php';
-		$shell = new TestShell([$svnFile]);
-		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getNonSvnFileDiff('foobar.php'), 1);
-		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfoNonSvnFile('foobar.php'), 1);
-		$shell->registerCommand("svn cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
-		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
 		$options = CliOptions::fromArray([
 			'svn' => true,
 			'files' => [$svnFile],
 		]);
-		$shell->setOptions($options);
+		$shell = new TestShell($options, [$svnFile]);
+		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getNonSvnFileDiff('foobar.php'), 1);
+		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfoNonSvnFile('foobar.php'), 1);
+		$shell->registerCommand("svn cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
+		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
 		runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
 	}
 
 	public function testFullSvnWorkflowForNewFile() {
 		$svnFile = 'foobar.php';
-		$shell = new TestShell([$svnFile]);
-		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getNewFileDiff('foobar.php'));
-		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfoNewFile('foobar.php'));
-		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
 		$options = CliOptions::fromArray([
 			'svn' => true,
 			'files' => [$svnFile],
 		]);
-		$shell->setOptions($options);
+		$shell = new TestShell($options, [$svnFile]);
+		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getNewFileDiff('foobar.php'));
+		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfoNewFile('foobar.php'));
+		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
 		$expected = $this->phpcs->getResults('foobar.php', [20, 21]);
 		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
@@ -557,7 +534,11 @@ final class SvnWorkflowTest extends TestCase {
 
 	public function testFullSvnWorkflowForEmptyNewFile() {
 		$svnFile = 'foobar.php';
-		$shell = new TestShell([$svnFile]);
+		$options = CliOptions::fromArray([
+			'svn' => true,
+			'files' => [$svnFile],
+		]);
+		$shell = new TestShell($options, [$svnFile]);
 		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getNewFileDiff('foobar.php'));
 		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfoNewFile('foobar.php'));
 		$fixture = 'ERROR: You must supply at least one file or directory to process.
@@ -565,11 +546,6 @@ final class SvnWorkflowTest extends TestCase {
 Run "phpcs --help" for usage information
 ';
 		$shell->registerCommand( "cat 'foobar.php'", $fixture);
-		$options = CliOptions::fromArray([
-			'svn' => true,
-			'files' => [$svnFile],
-		]);
-		$shell->setOptions($options);
 		$expected = PhpcsMessages::fromArrays([], 'STDIN');
 		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
@@ -577,11 +553,6 @@ Run "phpcs --help" for usage information
 
 	public function testFullSvnWorkflowForOneFileWithSeveritySetToZero() {
 		$svnFile = 'foobar.php';
-		$shell = new TestShell([$svnFile]);
-		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
-		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php'));
-		$shell->registerCommand("svn cat 'foobar.php' | phpcs --report=json -q --standard='standard' --warning-severity='0' --error-severity='0'", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
-		$shell->registerCommand("cat 'foobar.php' | phpcs --report=json -q --standard='standard' --warning-severity='0' --error-severity='0'" , $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
 		$options = CliOptions::fromArray([
 			'svn' => true,
 			'warning-severity' => '0',
@@ -590,7 +561,11 @@ Run "phpcs --help" for usage information
 			'standard' => 'standard',
 			'files' => [$svnFile],
 		]);
-		$shell->setOptions($options);
+		$shell = new TestShell($options, [$svnFile]);
+		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
+		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php'));
+		$shell->registerCommand("svn cat 'foobar.php' | phpcs --report=json -q --standard='standard' --warning-severity='0' --error-severity='0'", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
+		$shell->registerCommand("cat 'foobar.php' | phpcs --report=json -q --standard='standard' --warning-severity='0' --error-severity='0'" , $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
 		$cache = new CacheManager(new TestCache());
 		runSvnWorkflow([$svnFile], $options, $shell, $cache, '\PhpcsChangedTests\debug' );
 		

--- a/tests/SvnWorkflowTest.php
+++ b/tests/SvnWorkflowTest.php
@@ -78,7 +78,7 @@ final class SvnWorkflowTest extends TestCase {
 		]);
 		$shell->setOptions($options);
 		$expected = $this->phpcs->getResults('bin/foobar.php', [20]);
-		$messages = runSvnWorkflow([$svnFile], $options->toArray(), $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 
@@ -94,7 +94,7 @@ final class SvnWorkflowTest extends TestCase {
 		]);
 		$shell->setOptions($options);
 		$expected = $this->phpcs->getEmptyResults();
-		$messages = runSvnWorkflow([$svnFile], $options->toArray(), $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 		$this->assertFalse($shell->wasCommandCalled("svn cat 'foobar.php'"));
 	}
@@ -113,7 +113,7 @@ final class SvnWorkflowTest extends TestCase {
 		]);
 		$shell->setOptions($options);
 		$expected = $this->phpcs->getResults('bin/foobar.php', [20]);
-		$messages = runSvnWorkflow([$svnFile], $options->toArray(), $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 
@@ -132,7 +132,7 @@ final class SvnWorkflowTest extends TestCase {
 		$expected = $this->phpcs->getResults('bin/foobar.php', [20]);
 		$cache = new TestCache();
 		$cache->setEntry('foobar.php', 'old', '188280', '', $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
-		$messages = runSvnWorkflow([$svnFile], $options->toArray(), $shell, new CacheManager($cache), '\PhpcsChangedTests\debug');
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager($cache), '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 		$this->assertFalse($shell->wasCommandCalled("svn cat 'foobar.php'"));
 		$this->assertTrue($shell->wasCommandCalled("cat 'foobar.php'"));
@@ -157,12 +157,12 @@ final class SvnWorkflowTest extends TestCase {
 		$manager = new CacheManager($cache);
 
 		// Run once to cache results
-		runSvnWorkflow([$svnFile], $options->toArray(), $shell, $manager, '\PhpcsChangedTests\debug');
+		runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\debug');
 
 		// Run again to prove results have been cached
 		$shell->deregisterCommand("svn cat 'foobar.php'");
 		$shell->deregisterCommand("cat 'foobar.php'");
-		$messages = runSvnWorkflow([$svnFile], $options->toArray(), $shell, $manager, '\PhpcsChangedTests\debug');
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 
@@ -185,14 +185,14 @@ final class SvnWorkflowTest extends TestCase {
 		$manager = new CacheManager($cache);
 
 		// Run once to cache results
-		runSvnWorkflow([$svnFile], $options->toArray(), $shell, $manager, '\PhpcsChangedTests\debug');
+		runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\debug');
 		$this->assertTrue($shell->wasCommandCalled("cat 'foobar.php'"));
 
 		// Run again to prove results have been cached
 		$shell->deregisterCommand("svn cat 'foobar.php'");
 		$shell->deregisterCommand("cat 'foobar.php'");
 		$shell->resetCommandsCalled();
-		$messages = runSvnWorkflow([$svnFile], $options->toArray(), $shell, $manager, '\PhpcsChangedTests\debug');
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 		$this->assertFalse($shell->wasCommandCalled("cat 'foobar.php'"));
 
@@ -200,7 +200,7 @@ final class SvnWorkflowTest extends TestCase {
 		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
 		$shell->setFileHash('foobar.php', 'different-hash');
 		$shell->resetCommandsCalled();
-		$messages = runSvnWorkflow([$svnFile], $options->toArray(), $shell, $manager, '\PhpcsChangedTests\debug');
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 		$this->assertTrue($shell->wasCommandCalled("cat 'foobar.php'"));
 	}
@@ -225,14 +225,14 @@ final class SvnWorkflowTest extends TestCase {
 		$manager = new CacheManager($cache);
 
 		// Run once to cache results
-		runSvnWorkflow([$svnFile], $options->toArray(), $shell, $manager, '\PhpcsChangedTests\debug');
+		runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\debug');
 		$this->assertTrue($shell->wasCommandCalled("cat 'foobar.php'"));
 
 		// Run again to prove results have been cached
 		$shell->deregisterCommand("svn cat 'foobar.php'");
 		$shell->deregisterCommand("cat 'foobar.php'");
 		$shell->resetCommandsCalled();
-		$messages = runSvnWorkflow([$svnFile], $options->toArray(), $shell, $manager, '\PhpcsChangedTests\debug');
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 		$this->assertFalse($shell->wasCommandCalled("cat 'foobar.php'"));
 
@@ -240,14 +240,14 @@ final class SvnWorkflowTest extends TestCase {
 		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
 		$shell->setFileHash('foobar.php', 'different-hash');
 		$shell->resetCommandsCalled();
-		$messages = runSvnWorkflow([$svnFile], $options->toArray(), $shell, $manager, '\PhpcsChangedTests\debug');
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 		$this->assertTrue($shell->wasCommandCalled("cat 'foobar.php'"));
 
 		// Run a fourth time, restoring the old hash, and make sure we still don't use the (new file) cache
 		$shell->setFileHash('foobar.php', $original_hash);
 		$shell->resetCommandsCalled();
-		$messages = runSvnWorkflow([$svnFile], $options->toArray(), $shell, $manager, '\PhpcsChangedTests\debug');
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 		$this->assertTrue($shell->wasCommandCalled("cat 'foobar.php'"));
 	}
@@ -273,13 +273,13 @@ final class SvnWorkflowTest extends TestCase {
 		// Run once to cache results
 		$options->phpcsStandard = 'one';
 		$shell->setOptions($options);
-		runSvnWorkflow([$svnFile], $options->toArray(), $shell, $manager, '\PhpcsChangedTests\debug');
+		runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\debug');
 		$this->assertTrue($shell->wasCommandCalled("svn cat 'foobar.php'"));
 		$this->assertTrue($shell->wasCommandCalled("cat 'foobar.php'"));
 
 		// Run again to prove results have been cached
 		$shell->resetCommandsCalled();
-		$messages = runSvnWorkflow([$svnFile], $options->toArray(), $shell, $manager, '\PhpcsChangedTests\debug');
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 		$this->assertFalse($shell->wasCommandCalled("svn cat 'foobar.php'"));
 		$this->assertFalse($shell->wasCommandCalled("cat 'foobar.php'"));
@@ -288,7 +288,7 @@ final class SvnWorkflowTest extends TestCase {
 		$options->phpcsStandard = 'two';
 		$shell->setOptions($options);
 		$shell->resetCommandsCalled();
-		$messages = runSvnWorkflow([$svnFile], $options->toArray(), $shell, $manager, '\PhpcsChangedTests\debug');
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 		$this->assertTrue($shell->wasCommandCalled("svn cat 'foobar.php'"));
 		$this->assertTrue($shell->wasCommandCalled("cat 'foobar.php'"));
@@ -297,7 +297,7 @@ final class SvnWorkflowTest extends TestCase {
 		$options->phpcsStandard = 'one';
 		$shell->setOptions($options);
 		$shell->resetCommandsCalled();
-		$messages = runSvnWorkflow([$svnFile], $options->toArray(), $shell, $manager, '\PhpcsChangedTests\debug');
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 		$this->assertFalse($shell->wasCommandCalled("svn cat 'foobar.php'"));
 		$this->assertFalse($shell->wasCommandCalled("cat 'foobar.php'"));
@@ -320,8 +320,8 @@ final class SvnWorkflowTest extends TestCase {
 		$cache = new TestCache();
 		$cache->disabled = true;
 		$manager = new CacheManager($cache);
-		runSvnWorkflow([$svnFile], $options->toArray(), $shell, $manager, '\PhpcsChangedTests\debug');
-		$messages = runSvnWorkflow([$svnFile], $options->toArray(), $shell, $manager, '\PhpcsChangedTests\debug');
+		runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\debug');
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, $manager, '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 
@@ -342,7 +342,7 @@ final class SvnWorkflowTest extends TestCase {
 		$cache = new TestCache();
 		$cache->setCacheVersion('0.1-something-else');
 		$cache->setEntry('foobar.php', 'old', '188280', '', 'blah'); // This invalid JSON will throw if the cache is used
-		$messages = runSvnWorkflow([$svnFile], $options->toArray(), $shell, new CacheManager($cache), '\PhpcsChangedTests\debug');
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager($cache), '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 		$this->assertTrue($shell->wasCommandCalled("svn cat 'foobar.php'"));
 		$this->assertTrue($shell->wasCommandCalled("cat 'foobar.php'"));
@@ -367,7 +367,7 @@ final class SvnWorkflowTest extends TestCase {
 		$expected = $this->phpcs->getResults('bin/foobar.php', [20]);
 		$cache = new TestCache();
 		$cache->setEntry('foobar.php', 'old', '188280', 'TestStandard2', 'blah'); // This invalid JSON will throw if the cache is used
-		$messages = runSvnWorkflow([$svnFile], $options->toArray(), $shell, new CacheManager($cache), '\PhpcsChangedTests\debug');
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager($cache), '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 		$this->assertTrue($shell->wasCommandCalled("svn cat 'foobar.php'"));
 		$this->assertTrue($shell->wasCommandCalled("cat 'foobar.php'"));
@@ -390,13 +390,13 @@ final class SvnWorkflowTest extends TestCase {
 
 		// Set the saved cached revisionId to 1000
 		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php', '188280', '1000'));
-		runSvnWorkflow([$svnFile], $options->toArray(), $shell, new CacheManager($cache), '\PhpcsChangedTests\debug');
+		runSvnWorkflow([$svnFile], $options, $shell, new CacheManager($cache), '\PhpcsChangedTests\debug');
 
 		// The revisionId of the previous version of the file will be 188000
 		$shell->deregisterCommand("svn info 'foobar.php'");
 		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php', '188280', '188000'));
 		$shell->resetCommandsCalled();
-		$messages = runSvnWorkflow([$svnFile], $options->toArray(), $shell, new CacheManager($cache), '\PhpcsChangedTests\debug');
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager($cache), '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 		$this->assertTrue($shell->wasCommandCalled("svn cat 'foobar.php'"));
 		$this->assertFalse($shell->wasCommandCalled("cat 'foobar.php'"));
@@ -418,7 +418,7 @@ final class SvnWorkflowTest extends TestCase {
 		$cache = new TestCache();
 		$cache->setEntry('foobar.php', 'new', 'foobar.php', '', $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
 		$cache->setEntry('foobar.php', 'old', '188280', '', $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
-		$messages = runSvnWorkflow([$svnFile], $options->toArray(), $shell, new CacheManager($cache), '\PhpcsChangedTests\debug');
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager($cache), '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 		$this->assertFalse($shell->wasCommandCalled("svn cat 'foobar.php'"));
 		$this->assertFalse($shell->wasCommandCalled("cat 'foobar.php'"));
@@ -439,7 +439,7 @@ final class SvnWorkflowTest extends TestCase {
 		$expected = PhpcsMessages::fromArrays([], 'bin/foobar.php');
 		$cache = new TestCache();
 		$cache->setEntry('foobar.php', 'old', '188280', '', $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
-		$messages = runSvnWorkflow([$svnFile], $options->toArray(), $shell, new CacheManager($cache), '\PhpcsChangedTests\debug');
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager($cache), '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 		$this->assertFalse($shell->wasCommandCalled("svn cat 'foobar.php'"));
 		$this->assertTrue($shell->wasCommandCalled("cat 'foobar.php'"));
@@ -467,7 +467,7 @@ final class SvnWorkflowTest extends TestCase {
 			$this->phpcs->getResults('bin/foobar.php', [20]),
 			$this->phpcs->getResults('bin/baz.php', [20], 'Found unused symbol Baz.'),
 		]);
-		$messages = runSvnWorkflow($svnFiles, $options->toArray(), $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
+		$messages = runSvnWorkflow($svnFiles, $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 
@@ -484,7 +484,7 @@ final class SvnWorkflowTest extends TestCase {
 		]);
 		$shell->setOptions($options);
 		$expected = PhpcsMessages::fromArrays([], 'STDIN');
-		$messages = runSvnWorkflow([$svnFile], $options->toArray(), $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 
@@ -501,7 +501,7 @@ final class SvnWorkflowTest extends TestCase {
 		]);
 		$shell->setOptions($options);
 		$expected = PhpcsMessages::fromArrays([], 'STDIN');
-		$messages = runSvnWorkflow([$svnFile], $options->toArray(), $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 
@@ -517,7 +517,7 @@ final class SvnWorkflowTest extends TestCase {
 			'files' => [$svnFile],
 		]);
 		$shell->setOptions($options);
-		runSvnWorkflow([$svnFile], $options->toArray(), $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
+		runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
 		$this->assertFalse($shell->wasCommandCalled("svn diff 'foobar.php'"));
 		$this->assertFalse($shell->wasCommandCalled("svn cat 'foobar.php'"));
 		$this->assertFalse($shell->wasCommandCalled("svn info 'foobar.php'"));
@@ -536,7 +536,7 @@ final class SvnWorkflowTest extends TestCase {
 			'files' => [$svnFile],
 		]);
 		$shell->setOptions($options);
-		runSvnWorkflow([$svnFile], $options->toArray(), $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
+		runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
 	}
 
 	public function testFullSvnWorkflowForNewFile() {
@@ -551,7 +551,7 @@ final class SvnWorkflowTest extends TestCase {
 		]);
 		$shell->setOptions($options);
 		$expected = $this->phpcs->getResults('foobar.php', [20, 21]);
-		$messages = runSvnWorkflow([$svnFile], $options->toArray(), $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 
@@ -571,7 +571,7 @@ Run "phpcs --help" for usage information
 		]);
 		$shell->setOptions($options);
 		$expected = PhpcsMessages::fromArrays([], 'STDIN');
-		$messages = runSvnWorkflow([$svnFile], $options->toArray(), $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 
@@ -592,7 +592,7 @@ Run "phpcs --help" for usage information
 		]);
 		$shell->setOptions($options);
 		$cache = new CacheManager(new TestCache());
-		runSvnWorkflow([$svnFile], $options->toArray(), $shell, $cache, '\PhpcsChangedTests\debug' );
+		runSvnWorkflow([$svnFile], $options, $shell, $cache, '\PhpcsChangedTests\debug' );
 		
 		$cacheEntries = $cache->getEntries();
 		$this->assertNotEmpty($cacheEntries);

--- a/tests/helpers/TestShell.php
+++ b/tests/helpers/TestShell.php
@@ -8,8 +8,9 @@ use PhpcsChanged\Modes;
 use PhpcsChanged\ShellOperator;
 use PhpcsChanged\ShellException;
 use PhpcsChanged\NoChangesException;
+use PhpcsChanged\UnixShell;
 
-class TestShell implements ShellOperator {
+class TestShell extends UnixShell {
 
 	private $readableFileNames = [];
 
@@ -21,14 +22,11 @@ class TestShell implements ShellOperator {
 
 	private $options;
 
-	public function __construct(array $readableFileNames) {
+	public function __construct(CliOptions $options, array $readableFileNames) {
 		foreach ($readableFileNames as $fileName) {
 			$this->registerReadableFileName($fileName);
 		}
-	}
-
-	public function setOptions(CliOptions $options): void {
-		$this->options = $options;
+		parent::__construct($options);
 	}
 
 	public function registerReadableFileName(string $fileName, bool $override = false): bool {
@@ -94,164 +92,5 @@ class TestShell implements ShellOperator {
 
 	public function wasCommandCalled(string $registeredCommand): bool {
 		return isset($this->commandsCalled[$registeredCommand]);
-	}
-
-	public function getPhpcsStandards(): string {
-		$phpcs = $this->options->getExecutablePath('phpcs');
-		$installedCodingStandardsPhpcsOutputCommand = "{$phpcs} -i";
-		return $this->executeCommand($installedCodingStandardsPhpcsOutputCommand);
-	}
-
-	public function getFileNameFromPath(string $path): string {
-		$parts = explode('/', $path);
-		return end($parts);
-	}
-
-	private function getFullGitPathToFile(string $fileName): string {
-		$git = getenv('GIT') ?: 'git';
-		$command = "{$git} ls-files --full-name " . escapeshellarg($fileName);
-		$fullPath = $this->executeCommand($command);
-		return trim($fullPath);
-	}
-
-	private function getModifiedFileContentsCommand(string $fileName): string {
-		$git = getenv('GIT') ?: 'git';
-		$cat = getenv('CAT') ?: 'cat';
-		$fullPath = $this->getFullGitPathToFile($fileName);
-		if ($this->options->mode === Modes::GIT_BASE) {
-			// for git-base mode, we get the contents of the file from the HEAD version of the file in the current branch
-			return "{$git} show HEAD:" . escapeshellarg($fullPath);
-		}
-		if ($this->options->mode === Modes::GIT_UNSTAGED) {
-			// for git-unstaged mode, we get the contents of the file from the current working copy
-			return "{$cat} " . escapeshellarg($fileName);
-		}
-		// default mode is git-staged, so we get the contents from the staged version of the file
-		return "{$git} show :0:" . escapeshellarg($fullPath);
-	}
-
-	private function getUnmodifiedFileContentsCommand(string $fileName): string {
-		$git = getenv('GIT') ?: 'git';
-		if ($this->options->mode === Modes::GIT_BASE) {
-			$rev = escapeshellarg($this->options->gitBase);
-		} else if ($this->options->mode === Modes::GIT_UNSTAGED) {
-			$rev = ':0'; // :0 in this case means "staged version or HEAD if there is no staged version"
-		} else {
-			// git-staged is the default
-			$rev = 'HEAD';
-		}
-		$fullPath = $this->getFullGitPathToFile($fileName);
-		return "{$git} show {$rev}:" . escapeshellarg($fullPath);
-	}
-
-	public function getGitHashOfModifiedFile(string $fileName): string {
-		$git = getenv('GIT') ?: 'git';
-		$fileContentsCommand = $this->getModifiedFileContentsCommand($fileName);
-		$command = "{$fileContentsCommand} | {$git} hash-object --stdin";
-		$hash = $this->executeCommand($command);
-		if (! $hash) {
-			throw new ShellException("Cannot get modified file hash for file '{$fileName}'");
-		}
-		return $hash;
-	}
-
-	public function getGitHashOfUnmodifiedFile(string $fileName): string {
-		$git = getenv('GIT') ?: 'git';
-		$fileContentsCommand = $this->getUnmodifiedFileContentsCommand($fileName);
-		$command = "{$fileContentsCommand} | {$git} hash-object --stdin";
-		$hash = $this->executeCommand($command);
-		if (! $hash) {
-			throw new ShellException("Cannot get unmodified file hash for file '{$fileName}'");
-		}
-		return $hash;
-	}
-
-	private function getPhpcsStandardOption(): string {
-		$phpcsStandard = $this->options->phpcsStandard;
-		$phpcsStandardOption = $phpcsStandard ? ' --standard=' . escapeshellarg($phpcsStandard) : '';
-		$warningSeverity = $this->options->warningSeverity;
-		$phpcsStandardOption .= isset($warningSeverity) ? ' --warning-severity=' . escapeshellarg($warningSeverity) : '';
-		$errorSeverity = $this->options->errorSeverity;
-		$phpcsStandardOption .= isset($errorSeverity) ? ' --error-severity=' . escapeshellarg($errorSeverity) : '';
-		return $phpcsStandardOption;
-	}
-
-	public function getPhpcsOutputOfModifiedGitFile(string $fileName): string {
-		$phpcs = getenv('PHPCS') ?: 'phpcs';
-		$fileContentsCommand = $this->getModifiedFileContentsCommand($fileName);
-		$modifiedFilePhpcsOutputCommand = "{$fileContentsCommand} | {$phpcs} --report=json -q" . $this->getPhpcsStandardOption() . ' --stdin-path=' .  escapeshellarg($fileName) .' -';
-		$modifiedFilePhpcsOutput = $this->executeCommand($modifiedFilePhpcsOutputCommand);
-		if (! $modifiedFilePhpcsOutput) {
-			throw new ShellException("Cannot get modified file phpcs output for file '{$fileName}'");
-		}
-		if (false !== strpos($modifiedFilePhpcsOutput, 'You must supply at least one file or directory to process')) {
-			return '';
-		}
-		return $modifiedFilePhpcsOutput;
-	}
-
-	public function getPhpcsOutputOfUnmodifiedGitFile(string $fileName): string {
-		$phpcs = getenv('PHPCS') ?: 'phpcs';
-		$unmodifiedFileContentsCommand = $this->getUnmodifiedFileContentsCommand($fileName);
-		$unmodifiedFilePhpcsOutputCommand = "{$unmodifiedFileContentsCommand} | {$phpcs} --report=json -q" . $this->getPhpcsStandardOption() . ' --stdin-path=' .  escapeshellarg($fileName) . ' -';
-		$unmodifiedFilePhpcsOutput = $this->executeCommand($unmodifiedFilePhpcsOutputCommand);
-		if (! $unmodifiedFilePhpcsOutput) {
-			throw new ShellException("Cannot get unmodified file phpcs output for file '{$fileName}'");
-		}
-		return $unmodifiedFilePhpcsOutput;
-	}
-
-	private function doesFileExistInGitBase(string $fileName): bool {
-		$git = getenv('GIT') ?: 'git';
-		$gitStatusCommand = "{$git} cat-file -e " . escapeshellarg($this->options->gitBase) . ':' . escapeshellarg($this->getFullGitPathToFile($fileName)) . ' 2>/dev/null';
-		/** @var int */
-		$return_val = 1;
-		$this->executeCommand($gitStatusCommand, $return_val);
-		return 0 !== $return_val;
-	}
-
-	private function isFileStagedForAdding(string $fileName): bool {
-		$git = getenv('GIT') ?: 'git';
-		$gitStatusCommand = "{$git} status --porcelain " . escapeshellarg($fileName);
-		$gitStatusOutput = $this->executeCommand($gitStatusCommand);
-		if (! $gitStatusOutput || false === strpos($gitStatusOutput, $fileName)) {
-			return false;
-		}
-		if (isset($gitStatusOutput[0]) && $gitStatusOutput[0] === '?') {
-			throw new ShellException("File does not appear to be tracked by git: '{$fileName}'");
-		}
-		return isset($gitStatusOutput[0]) && $gitStatusOutput[0] === 'A';
-	}
-
-	public function doesUnmodifiedFileExistInGit(string $fileName): bool {
-		if ($this->options->mode === Modes::GIT_BASE) {
-			return $this->doesFileExistInGitBase($fileName);
-		}
-		return $this->isFileStagedForAdding($fileName);
-	}
-
-	public function getGitUnifiedDiff(string $fileName): string {
-		$git = getenv('GIT') ?: 'git';
-		$objectOption = $this->options->mode === Modes::GIT_BASE ? ' ' . escapeshellarg($this->options->gitBase) . '...' : '';
-		$stagedOption = empty($objectOption) && $this->options->mode !== Modes::GIT_UNSTAGED ? ' --staged' : '';
-		$unifiedDiffCommand = "{$git} diff{$stagedOption}{$objectOption} --no-prefix " . escapeshellarg($fileName);
-		$unifiedDiff = $this->executeCommand($unifiedDiffCommand);
-		if (! $unifiedDiff) {
-			throw new NoChangesException("Cannot get git diff for file '{$fileName}'; skipping");
-		}
-		return $unifiedDiff;
-	}
-
-	public function getGitMergeBase(): string {
-		if ($this->options->mode !== Modes::GIT_BASE) {
-			return '';
-		}
-		$git = getenv('GIT') ?: 'git';
-		$mergeBaseCommand = "{$git} merge-base " . escapeshellarg($this->options->gitBase) . ' HEAD';
-		$mergeBase = $this->executeCommand($mergeBaseCommand);
-		if (! $mergeBase) {
-			return $this->options->gitBase;
-		}
-		return trim($mergeBase);
 	}
 }

--- a/tests/helpers/TestShell.php
+++ b/tests/helpers/TestShell.php
@@ -96,6 +96,12 @@ class TestShell implements ShellOperator {
 		return isset($this->commandsCalled[$registeredCommand]);
 	}
 
+	public function getPhpcsStandards(): string {
+		$phpcs = $this->options->getExecutablePath('phpcs');
+		$installedCodingStandardsPhpcsOutputCommand = "{$phpcs} -i";
+		return $this->executeCommand($installedCodingStandardsPhpcsOutputCommand);
+	}
+
 	public function getFileNameFromPath(string $path): string {
 		$parts = explode('/', $path);
 		return end($parts);


### PR DESCRIPTION
This PR adds four new options to the CLI script:

```
          --phpcs-path <PATH>   The path to the phpcs executable. Overrides env variables.
            --svn-path <PATH>   The path to the svn executable. Overrides env variables.
            --git-path <PATH>   The path to the git executable. Overrides env variables.
            --cat-path <PATH>   The path to the cat executable. Overrides env variables.
```

Partially resolves https://github.com/sirbrillig/phpcs-changed/issues/70