### PR TITLE
Auto-detect phpcs in vendor directory

### DIFF
--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -197,7 +197,7 @@ function getPhpcsExecutable(CliOptions $options, ShellOperator $shell): string {
 	if (! empty($options->phpcsPath) || ! empty(getenv('PHPCS'))) {
 		return $options->getExecutablePath('phpcs');
 	}
-	if (doesPhpcsExistInVendor($shell)) {
+	if (! $options->noVendorPhpcs && doesPhpcsExistInVendor($shell)) {
 		return getVendorPhpcsPath();
 	}
 	return 'phpcs';

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -193,6 +193,29 @@ function getReporter(string $reportType, CliOptions $options): Reporter {
 	throw new \Exception("Unknown Reporter '{$reportType}'"); // Just in case we don't exit for some reason.
 }
 
+function getPhpcsExecutable(CliOptions $options, ShellOperator $shell): string {
+	if (! empty($options->phpcsPath) || ! empty(getenv('PHPCS'))) {
+		return $options->getExecutablePath('phpcs');
+	}
+	if (doesPhpcsExistInVendor($shell)) {
+		return getVendorPhpcsPath();
+	}
+	return 'phpcs';
+}
+
+function doesPhpcsExistInVendor(ShellOperator $shell): bool {
+	try {
+		$shell->validateExecutableExists('phpcs', getVendorPhpcsPath());
+	} catch (\Exception $err) {
+		return false;
+	}
+	return true;
+}
+
+function getVendorPhpcsPath(): string {
+	return 'vendor/bin/phpcs';
+}
+
 function runManualWorkflow(string $diffFile, string $phpcsUnmodifiedFile, string $phpcsModifiedFile): PhpcsMessages {
 	try {
 		$messages = getNewPhpcsMessagesFromFiles(
@@ -209,7 +232,7 @@ function runManualWorkflow(string $diffFile, string $phpcsUnmodifiedFile, string
 
 function runSvnWorkflow(array $svnFiles, CliOptions $options, ShellOperator $shell, CacheManager $cache, callable $debug): PhpcsMessages {
 	$svn = $options->getExecutablePath('svn');
-	$phpcs = $options->getExecutablePath('phpcs');
+	$phpcs = getPhpcsExecutable($options, $shell);
 	$cat = $options->getExecutablePath('cat');
 
 	try {
@@ -237,7 +260,7 @@ function runSvnWorkflow(array $svnFiles, CliOptions $options, ShellOperator $she
 
 function runSvnWorkflowForFile(string $svnFile, CliOptions $options, ShellOperator $shell, CacheManager $cache, callable $debug): PhpcsMessages {
 	$svn = $options->getExecutablePath('svn');
-	$phpcs = $options->getExecutablePath('phpcs');
+	$phpcs = getPhpcsExecutable($options, $shell);
 	$cat = $options->getExecutablePath('cat');
 
 	$phpcsStandard = $options->phpcsStandard;
@@ -317,7 +340,7 @@ function runSvnWorkflowForFile(string $svnFile, CliOptions $options, ShellOperat
 
 function runGitWorkflow(CliOptions $options, ShellOperator $shell, CacheManager $cache, callable $debug): PhpcsMessages {
 	$git = $options->getExecutablePath('git');
-	$phpcs = $options->getExecutablePath('phpcs');
+	$phpcs = getPhpcsExecutable($options, $shell);
 
 	try {
 		$debug('validating executables');

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -162,6 +162,7 @@ EOF;
 		'--always-exit-zero' => 'Always exit the script with a 0 return code. Otherwise, a 1 return code indicates phpcs messages.',
 		'--no-cache-git-root' => 'Prevent caching the git root used by the git workflow.',
 		'--no-verify-git-file' => 'Prevent checking if a file is tracked by git in the git workflow.',
+		'--no-vendor-phpcs' => 'Prevents looking for phpcs executable in vendor directory.',
 		'--phpcs-path <PATH>' => 'The path to the phpcs executable. Overrides env variables.',
 		'--svn-path <PATH>' => 'The path to the svn executable. Overrides env variables.',
 		'--git-path <PATH>' => 'The path to the git executable. Overrides env variables.',
@@ -176,6 +177,11 @@ Overrides:
 	'GIT', 'CAT', and 'PHPCS', respectively, to specify the full path for each
 	one. You can alternatively use the `--svn-path`, `--git-path`, `--cat-path`,
 	or `--phpcs-path` CLI options.
+
+	For phpcs, if the path is not overridden, and a `phpcs` executable exists
+	under the `vendor/bin` directory where this command is run, that executable
+	will be used instead of relying on the PATH. You can disable this feature
+	with the `--no-vendor-phpcs` option.
 
 EOF;
 }

--- a/PhpcsChanged/CliOptions.php
+++ b/PhpcsChanged/CliOptions.php
@@ -150,6 +150,15 @@ class CliOptions {
 	 */
 	public $errorSeverity = null;
 
+	/**
+	 * This option will disable the automatic detection of the `phpcs` executable
+	 * in a `vendor` directory. If true, and the phpcs executable path is not
+	 * overridden, the default path to phpcs will always be `'phpcs'`.
+	 *
+	 * @var bool
+	 */
+	public $noVendorPhpcs = false;
+
 	public static function fromArray(array $options): self {
 		$cliOptions = new self();
 		// Note that this array is likely created by `getopt()` which sets any
@@ -157,6 +166,9 @@ class CliOptions {
 		// determine if these options are set.
 		if (isset($options['files'])) {
 			$cliOptions->files = $options['files'];
+		}
+		if (isset($options['no-vendor-phpcs'])) {
+			$cliOptions->noVendorPhpcs = $options['no-vendor-phpcs'];
 		}
 		if (isset($options['phpcs-path'])) {
 			$cliOptions->phpcsPath = $options['phpcs-path'];
@@ -244,6 +256,9 @@ class CliOptions {
 		$options['files'] = $this->files;
 		if ($this->phpcsStandard) {
 			$options['standard'] = $this->phpcsStandard;
+		}
+		if ($this->noVendorPhpcs) {
+			$options['no-vendor-phpcs'] = true;
 		}
 		if ($this->phpcsPath) {
 			$options['phpcs-path'] = $this->phpcsPath;

--- a/PhpcsChanged/UnixShell.php
+++ b/PhpcsChanged/UnixShell.php
@@ -8,6 +8,7 @@ use PhpcsChanged\CliOptions;
 use PhpcsChanged\Modes;
 use function PhpcsChanged\Cli\printError;
 use function PhpcsChanged\Cli\getDebug;
+use function PhpcsChanged\Cli\getPhpcsExecutable;
 
 /**
  * Module to perform file and shell operations
@@ -41,7 +42,7 @@ class UnixShell implements ShellOperator {
 	}
 
 	public function getPhpcsStandards(): string {
-		$phpcs = $this->getPhpcsExecutable();
+		$phpcs = getPhpcsExecutable($this->options, $this);
 		$installedCodingStandardsPhpcsOutputCommand = "{$phpcs} -i";
 		return $this->executeCommand($installedCodingStandardsPhpcsOutputCommand);
 	}
@@ -187,32 +188,9 @@ class UnixShell implements ShellOperator {
 		return $phpcsStandardOption;
 	}
 
-	private function getPhpcsExecutable(): string {
-		if (! empty($this->options->phpcsPath) || ! empty(getenv('PHPCS'))) {
-			return $this->options->getExecutablePath('phpcs');
-		}
-		if ($this->doesPhpcsExistInVendor()) {
-			return $this->getVendorPhpcsPath();
-		}
-		return 'phpcs';
-	}
-
-	private function doesPhpcsExistInVendor(): bool {
-		try {
-			$this->validateExecutableExists('phpcs', $this->getVendorPhpcsPath());
-		} catch (\Exception $err) {
-			return false;
-		}
-		return true;
-	}
-
-	private function getVendorPhpcsPath(): string {
-		return 'vendor/bin/phpcs';
-	}
-
 	public function getPhpcsOutputOfModifiedGitFile(string $fileName): string {
 		$debug = getDebug($this->options->debug);
-		$phpcs = $this->getPhpcsExecutable();
+		$phpcs = getPhpcsExecutable($this->options, $this);
 		$fileContentsCommand = $this->getModifiedFileContentsCommand($fileName);
 		$modifiedFilePhpcsOutputCommand = "{$fileContentsCommand} | {$phpcs} --report=json -q" . $this->getPhpcsStandardOption() . ' --stdin-path=' .  escapeshellarg($fileName) .' -';
 		$debug('running modified file phpcs command:', $modifiedFilePhpcsOutputCommand);
@@ -230,7 +208,7 @@ class UnixShell implements ShellOperator {
 
 	public function getPhpcsOutputOfUnmodifiedGitFile(string $fileName): string {
 		$debug = getDebug($this->options->debug);
-		$phpcs = $this->getPhpcsExecutable();
+		$phpcs = getPhpcsExecutable($this->options, $this);
 		$unmodifiedFileContentsCommand = $this->getUnmodifiedFileContentsCommand($fileName);
 		$unmodifiedFilePhpcsOutputCommand = "{$unmodifiedFileContentsCommand} | {$phpcs} --report=json -q" . $this->getPhpcsStandardOption() . ' --stdin-path=' .  escapeshellarg($fileName) . ' -';
 		$debug('running unmodified file phpcs command:', $unmodifiedFilePhpcsOutputCommand);

--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ The `--arc-lint` option can be used when the phpcs-changed is run via arcanist, 
 
 The `--svn-path`, `--git-path`, `--cat-path`, and `--phpcs-path` options can be used to specify the paths to the executables of the same names. If these options are not set, the program will try to use the `SVN`, `GIT`, `CAT`, and `PHPCS` env variables. If those are also not set, the program will default to `svn`, `git`, `cat`, and `phpcs`, respectively, assuming that each command will be in the system's `PATH`.
 
+For phpcs, if the path is not overridden, and a `phpcs` executable exists under the `vendor/bin` directory where this command is run, that executable will be used instead of relying on the PATH. You can disable this feature with the `--no-vendor-phpcs` option.
+
 The `--debug` option will show every step taken by the script.
 
 ## PHP Library

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -52,6 +52,7 @@ $options = getopt(
 		'report:',
 		'debug',
 		'ignore:',
+		'no-vendor-phpcs',
 		'cache',
 		'no-cache',
 		'clear-cache',

--- a/tests/GitWorkflowTest.php
+++ b/tests/GitWorkflowTest.php
@@ -118,6 +118,32 @@ final class GitWorkflowTest extends TestCase {
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 
+	public function testFullGitWorkflowForOneFileStagedWithNoVendorDefaultPhpcs() {
+		$gitFile = 'foobar.php';
+		$phpcsPath = 'vendor/bin/phpcs';
+		$options = CliOptions::fromArray([
+			'no-cache-git-root' => 1,
+			'git-staged' => 1,
+			'files' => [$gitFile],
+			'no-vendor-phpcs' => true,
+		]);
+		$shell = new TestShell($options, [$gitFile]);
+		$shell->registerExecutable('git');
+		$shell->registerExecutable($phpcsPath);
+		$shell->registerExecutable('phpcs');
+		$fixture = $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;');
+		$shell->registerCommand("git diff --staged --no-prefix 'foobar.php'", $fixture);
+		$shell->registerCommand("git status --porcelain 'foobar.php'", $this->fixture->getModifiedFileInfo('foobar.php'));
+		$shell->registerCommand("git ls-files --full-name 'foobar.php'", "files/foobar.php");
+		$shell->registerCommand("git show HEAD:'files/foobar.php' | phpcs", $this->phpcs->getResults('STDIN', [20])->toPhpcsJson());
+		$shell->registerCommand("git show :0:'files/foobar.php' | phpcs", $this->phpcs->getResults('STDIN', [20, 21], 'Found unused symbol Foobar.')->toPhpcsJson());
+		$shell->registerCommand("git rev-parse --show-toplevel", 'run-from-git-root');
+		$cache = new CacheManager( new TestCache() );
+		$expected = $this->phpcs->getResults('bin/foobar.php', [20], 'Found unused symbol Foobar.');
+		$messages = runGitWorkflow($options, $shell, $cache, '\PhpcsChangedTests\Debug');
+		$this->assertEquals($expected->getMessages(), $messages->getMessages());
+	}
+
 	public function testFullGitWorkflowForOneFileUnstaged() {
 		$gitFile = 'foobar.php';
 		$options = CliOptions::fromArray(['no-cache-git-root' => 1, 'git-unstaged' => '1', 'files' => [$gitFile]]);

--- a/tests/GitWorkflowTest.php
+++ b/tests/GitWorkflowTest.php
@@ -29,6 +29,8 @@ final class GitWorkflowTest extends TestCase {
 		$gitFile = 'foobar.php';
 		$options = CliOptions::fromArray(['no-cache-git-root' => 1, 'git-staged' => 1, 'files' => [$gitFile]]);
 		$shell = new TestShell($options, [$gitFile]);
+		$shell->registerExecutable('git');
+		$shell->registerExecutable('phpcs');
 		$fixture = $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;');
 		$shell->registerCommand("git diff --staged --no-prefix 'foobar.php'", $fixture);
 		$shell->registerCommand("git status --porcelain 'foobar.php'", $this->fixture->getModifiedFileInfo('foobar.php'));
@@ -52,6 +54,8 @@ final class GitWorkflowTest extends TestCase {
 			'git-path' => $gitPath,
 		]);
 		$shell = new TestShell($options, [$gitFile]);
+		$shell->registerExecutable($gitPath);
+		$shell->registerExecutable('phpcs');
 		$fixture = $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;');
 		$shell->registerCommand("{$gitPath} diff --staged --no-prefix 'foobar.php'", $fixture);
 		$shell->registerCommand("{$gitPath} status --porcelain 'foobar.php'", $this->fixture->getModifiedFileInfo('foobar.php'));
@@ -75,6 +79,8 @@ final class GitWorkflowTest extends TestCase {
 			'phpcs-path' => $phpcsPath,
 		]);
 		$shell = new TestShell($options, [$gitFile]);
+		$shell->registerExecutable('git');
+		$shell->registerExecutable($phpcsPath);
 		$fixture = $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;');
 		$shell->registerCommand("git diff --staged --no-prefix 'foobar.php'", $fixture);
 		$shell->registerCommand("git status --porcelain 'foobar.php'", $this->fixture->getModifiedFileInfo('foobar.php'));
@@ -92,6 +98,8 @@ final class GitWorkflowTest extends TestCase {
 		$gitFile = 'foobar.php';
 		$options = CliOptions::fromArray(['no-cache-git-root' => 1, 'git-unstaged' => '1', 'files' => [$gitFile]]);
 		$shell = new TestShell($options, [$gitFile]);
+		$shell->registerExecutable('git');
+		$shell->registerExecutable('phpcs');
 		$fixture = $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;');
 		$shell->registerCommand("git diff --no-prefix 'foobar.php'", $fixture);
 		$shell->registerCommand("git status --porcelain 'foobar.php'", $this->fixture->getModifiedFileInfo('foobar.php'));
@@ -113,6 +121,8 @@ final class GitWorkflowTest extends TestCase {
 			'files' => [$gitFile],
 		]);
 		$shell = new TestShell($options, [$gitFile]);
+		$shell->registerExecutable('git');
+		$shell->registerExecutable('phpcs');
 		$shell->registerCommand("git status --porcelain 'foobar.php'", $this->fixture->getModifiedFileInfo('foobar.php'));
 		$shell->registerCommand("git ls-files --full-name 'foobar.php'", "files/foobar.php");
 		$shell->registerCommand("cat 'foobar.php' | phpcs", $this->phpcs->getEmptyResults()->toPhpcsJson());
@@ -136,6 +146,8 @@ final class GitWorkflowTest extends TestCase {
 			'files' => [$gitFile],
 		]);
 		$shell = new TestShell($options, [$gitFile]);
+		$shell->registerExecutable('git');
+		$shell->registerExecutable('phpcs');
 		$fixture = $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;');
 		$shell->registerCommand("git diff --no-prefix 'foobar.php'", $fixture);
 		$shell->registerCommand("git status --porcelain 'foobar.php'", $this->fixture->getModifiedFileInfo('foobar.php'));
@@ -169,6 +181,8 @@ final class GitWorkflowTest extends TestCase {
 			'files' => [$gitFile],
 		]);
 		$shell = new TestShell($options, [$gitFile]);
+		$shell->registerExecutable('git');
+		$shell->registerExecutable('phpcs');
 		$fixture = $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;');
 		$shell->registerCommand("git diff --no-prefix 'foobar.php'", $fixture);
 		$shell->registerCommand("git status --porcelain 'foobar.php'", $this->fixture->getModifiedFileInfo('foobar.php'));
@@ -207,6 +221,8 @@ final class GitWorkflowTest extends TestCase {
 			'files' => [$gitFile],
 		]);
 		$shell = new TestShell($options, [$gitFile]);
+		$shell->registerExecutable('git');
+		$shell->registerExecutable('phpcs');
 		$fixture = $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;');
 		$shell->registerCommand("git diff --no-prefix 'foobar.php'", $fixture);
 		$shell->registerCommand("git status --porcelain 'foobar.php'", $this->fixture->getModifiedFileInfo('foobar.php'));
@@ -245,6 +261,8 @@ final class GitWorkflowTest extends TestCase {
 			'files' => [$gitFile],
 		]);
 		$shell = new TestShell($options, [$gitFile]);
+		$shell->registerExecutable('git');
+		$shell->registerExecutable('phpcs');
 		$fixture = $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;');
 		$shell->registerCommand("git diff --no-prefix 'foobar.php'", $fixture);
 		$shell->registerCommand("git status --porcelain 'foobar.php'", $this->fixture->getModifiedFileInfo('foobar.php'));
@@ -282,6 +300,8 @@ final class GitWorkflowTest extends TestCase {
 			'files' => [$gitFile],
 		]);
 		$shell = new TestShell($options, [$gitFile]);
+		$shell->registerExecutable('git');
+		$shell->registerExecutable('phpcs');
 		$fixture = $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;');
 		$shell->registerCommand("git ls-files --full-name 'foobar.php'", "files/foobar.php");
 		$shell->registerCommand("git diff --no-prefix 'foobar.php'", $fixture);
@@ -314,6 +334,8 @@ final class GitWorkflowTest extends TestCase {
 			'files' => [$gitFile],
 		]);
 		$shell = new TestShell($options, [$gitFile]);
+		$shell->registerExecutable('git');
+		$shell->registerExecutable('phpcs');
 		$fixture = $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;');
 		$shell->registerCommand("git diff --no-prefix 'foobar.php'", $fixture);
 		$shell->registerCommand("git status --porcelain 'foobar.php'", $this->fixture->getModifiedFileInfo('foobar.php'));
@@ -341,6 +363,8 @@ final class GitWorkflowTest extends TestCase {
 		$gitFiles = ['foobar.php', 'baz.php'];
 		$options = CliOptions::fromArray(['no-cache-git-root' => 1, 'git-staged' => 1, 'files' => $gitFiles]);
 		$shell = new TestShell($options, $gitFiles);
+		$shell->registerExecutable('git');
+		$shell->registerExecutable('phpcs');
 		$fixture = $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;');
 		$shell->registerCommand("git diff --staged --no-prefix 'foobar.php'", $fixture);
 		$fixture = $this->fixture->getAddedLineDiff('baz.php', 'use Baz;');
@@ -367,6 +391,8 @@ final class GitWorkflowTest extends TestCase {
 		$gitFile = 'foobar.php';
 		$options = CliOptions::fromArray(['no-cache-git-root' => 1, 'git-staged' => 1, 'files' => [$gitFile]]);
 		$shell = new TestShell($options, [$gitFile]);
+		$shell->registerExecutable('git');
+		$shell->registerExecutable('phpcs');
 		$fixture = $this->fixture->getEmptyFileDiff();
 		$shell->registerCommand("git diff --staged --no-prefix 'foobar.php'", $fixture);
 		$shell->registerCommand("git status --porcelain 'foobar.php'", $this->fixture->getModifiedFileInfo('foobar.php'));
@@ -384,6 +410,8 @@ final class GitWorkflowTest extends TestCase {
 		$gitFile = 'foobar.php';
 		$options = CliOptions::fromArray(['no-cache-git-root' => 1, 'git-staged' => 1, 'files' => [$gitFile]]);
 		$shell = new TestShell($options, [$gitFile]);
+		$shell->registerExecutable('git');
+		$shell->registerExecutable('phpcs');
 		$shell->registerCommand("git status --porcelain 'foobar.php'", $this->fixture->getModifiedFileInfo('foobar.php'));
 		$shell->registerCommand("git ls-files --full-name 'foobar.php'", "files/foobar.php");
 		$shell->registerCommand("git show HEAD:'files/foobar.php'", $this->phpcs->getResults('STDIN', [])->toPhpcsJson());
@@ -400,6 +428,8 @@ final class GitWorkflowTest extends TestCase {
 		$gitFile = 'foobar.php';
 		$options = CliOptions::fromArray(['no-cache-git-root' => 1, 'git-staged' => 1, 'files' => [$gitFile]]);
 		$shell = new TestShell($options, [$gitFile]);
+		$shell->registerExecutable('git');
+		$shell->registerExecutable('phpcs');
 		$fixture = $this->fixture->getEmptyFileDiff();
 		$shell->registerCommand("git diff --staged --no-prefix 'foobar.php'", $fixture);
 		$shell->registerCommand("git status --porcelain 'foobar.php'", "?? foobar.php" );
@@ -415,6 +445,8 @@ final class GitWorkflowTest extends TestCase {
 		$gitFile = 'foobar.php';
 		$options = CliOptions::fromArray(['no-cache-git-root' => 1, 'git-staged' => 1, 'files' => [$gitFile]]);
 		$shell = new TestShell($options, [$gitFile]);
+		$shell->registerExecutable('git');
+		$shell->registerExecutable('phpcs');
 		$fixture = $this->fixture->getNewFileDiff('foobar.php');
 		$shell->registerCommand("git diff --staged --no-prefix 'foobar.php'", $fixture);
 		$shell->registerCommand("git status --porcelain 'foobar.php'", $this->fixture->getNewFileInfo('foobar.php'));
@@ -431,6 +463,8 @@ final class GitWorkflowTest extends TestCase {
 		$gitFile = 'foobar.php';
 		$options = CliOptions::fromArray(['no-cache-git-root' => 1, 'git-staged' => 1, 'files' => [$gitFile]]);
 		$shell = new TestShell($options, [$gitFile]);
+		$shell->registerExecutable('git');
+		$shell->registerExecutable('phpcs');
 		$fixture = $this->fixture->getNewFileDiff('foobar.php');
 		$shell->registerCommand("git diff --staged --no-prefix 'foobar.php'", $fixture);
 		$shell->registerCommand("git status --porcelain 'foobar.php'", $this->fixture->getNewFileInfo('foobar.php'));
@@ -452,6 +486,8 @@ Run "phpcs --help" for usage information
 		$gitFile = 'bin/foobar.php';
 		$options = CliOptions::fromArray(['no-cache-git-root' => 1, 'git-base' => 'master', 'files' => [$gitFile]]);
 		$shell = new TestShell($options, [$gitFile]);
+		$shell->registerExecutable('git');
+		$shell->registerExecutable('phpcs');
 		$fixture = $this->fixture->getAltAddedLineDiff('foobar.php', 'use Foobar;');
 		$shell->registerCommand("git ls-files --full-name 'bin/foobar.php'", "files/bin/foobar.php");
 		$shell->registerCommand("git merge-base 'master' HEAD", "0123456789abcdef0123456789abcdef01234567\n");
@@ -473,6 +509,8 @@ Run "phpcs --help" for usage information
 		$gitFile = 'test.php';
 		$options = CliOptions::fromArray(['no-cache-git-root' => 1, 'git-base' => 'master', 'files' => [$gitFile]]);
 		$shell = new TestShell($options, [$gitFile]);
+		$shell->registerExecutable('git');
+		$shell->registerExecutable('phpcs');
 		$shell->registerCommand("git status --porcelain 'test.php'", $this->fixture->getModifiedFileInfo('test.php'));
 		
 		$fixture = $this->fixture->getAltNewFileDiff('test.php');

--- a/tests/SvnWorkflowTest.php
+++ b/tests/SvnWorkflowTest.php
@@ -167,6 +167,28 @@ final class SvnWorkflowTest extends TestCase {
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 
+	public function testFullSvnWorkflowForOneFileWithNoVendorDefaultPhpcs() {
+		$svnFile = 'foobar.php';
+		$phpcsPath = 'vendor/bin/phpcs';
+		$options = CliOptions::fromArray([
+			'svn' => true,
+			'files' => [$svnFile],
+			'no-vendor-phpcs' => true,
+		]);
+		$shell = new TestShell($options, [$svnFile]);
+		$shell->registerExecutable('svn');
+		$shell->registerExecutable($phpcsPath);
+		$shell->registerExecutable('phpcs');
+		$shell->registerExecutable('cat');
+		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
+		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php'));
+		$shell->registerCommand("svn cat 'foobar.php' | phpcs", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
+		$shell->registerCommand("cat 'foobar.php' | phpcs", $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
+		$expected = $this->phpcs->getResults('bin/foobar.php', [20]);
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
+		$this->assertEquals($expected->getMessages(), $messages->getMessages());
+	}
+
 	public function testFullSvnWorkflowForOneFileWithNoMessages() {
 		$svnFile = 'foobar.php';
 		$options = CliOptions::fromArray([

--- a/tests/SvnWorkflowTest.php
+++ b/tests/SvnWorkflowTest.php
@@ -147,6 +147,26 @@ final class SvnWorkflowTest extends TestCase {
 		$this->assertEquals($expected->getMessages(), $messages->getMessages());
 	}
 
+	public function testFullSvnWorkflowForOneFileWithVendorDefaultPhpcs() {
+		$svnFile = 'foobar.php';
+		$phpcsPath = 'vendor/bin/phpcs';
+		$options = CliOptions::fromArray([
+			'svn' => true,
+			'files' => [$svnFile],
+		]);
+		$shell = new TestShell($options, [$svnFile]);
+		$shell->registerExecutable('svn');
+		$shell->registerExecutable($phpcsPath);
+		$shell->registerExecutable('cat');
+		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
+		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php'));
+		$shell->registerCommand("svn cat 'foobar.php' | {$phpcsPath}", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
+		$shell->registerCommand("cat 'foobar.php' | {$phpcsPath}", $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
+		$expected = $this->phpcs->getResults('bin/foobar.php', [20]);
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
+		$this->assertEquals($expected->getMessages(), $messages->getMessages());
+	}
+
 	public function testFullSvnWorkflowForOneFileWithNoMessages() {
 		$svnFile = 'foobar.php';
 		$options = CliOptions::fromArray([

--- a/tests/SvnWorkflowTest.php
+++ b/tests/SvnWorkflowTest.php
@@ -72,6 +72,9 @@ final class SvnWorkflowTest extends TestCase {
 			'files' => [$svnFile],
 		]);
 		$shell = new TestShell($options, [$svnFile]);
+		$shell->registerExecutable('svn');
+		$shell->registerExecutable('phpcs');
+		$shell->registerExecutable('cat');
 		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
 		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php'));
 		$shell->registerCommand("svn cat 'foobar.php' | phpcs", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
@@ -90,6 +93,9 @@ final class SvnWorkflowTest extends TestCase {
 			'svn-path' => $svnPath,
 		]);
 		$shell = new TestShell($options, [$svnFile]);
+		$shell->registerExecutable($svnPath);
+		$shell->registerExecutable('phpcs');
+		$shell->registerExecutable('cat');
 		$shell->registerCommand("{$svnPath} diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
 		$shell->registerCommand("{$svnPath} info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php'));
 		$shell->registerCommand("{$svnPath} cat 'foobar.php' | phpcs", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
@@ -108,6 +114,9 @@ final class SvnWorkflowTest extends TestCase {
 			'cat-path' => $catPath,
 		]);
 		$shell = new TestShell($options, [$svnFile]);
+		$shell->registerExecutable('svn');
+		$shell->registerExecutable('phpcs');
+		$shell->registerExecutable($catPath);
 		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
 		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php'));
 		$shell->registerCommand("svn cat 'foobar.php' | phpcs", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
@@ -126,6 +135,9 @@ final class SvnWorkflowTest extends TestCase {
 			'phpcs-path' => $phpcsPath,
 		]);
 		$shell = new TestShell($options, [$svnFile]);
+		$shell->registerExecutable('svn');
+		$shell->registerExecutable($phpcsPath);
+		$shell->registerExecutable('cat');
 		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
 		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php'));
 		$shell->registerCommand("svn cat 'foobar.php' | {$phpcsPath}", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
@@ -142,6 +154,9 @@ final class SvnWorkflowTest extends TestCase {
 			'files' => [$svnFile],
 		]);
 		$shell = new TestShell($options, [$svnFile]);
+		$shell->registerExecutable('svn');
+		$shell->registerExecutable('phpcs');
+		$shell->registerExecutable('cat');
 		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
 		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php'));
 		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getEmptyResults()->toPhpcsJson());
@@ -159,6 +174,9 @@ final class SvnWorkflowTest extends TestCase {
 			'files' => [$svnFile],
 		]);
 		$shell = new TestShell($options, [$svnFile]);
+		$shell->registerExecutable('svn');
+		$shell->registerExecutable('phpcs');
+		$shell->registerExecutable('cat');
 		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
 		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php'));
 		$shell->registerCommand("svn cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
@@ -176,6 +194,9 @@ final class SvnWorkflowTest extends TestCase {
 			'files' => [$svnFile],
 		]);
 		$shell = new TestShell($options, [$svnFile]);
+		$shell->registerExecutable('svn');
+		$shell->registerExecutable('phpcs');
+		$shell->registerExecutable('cat');
 		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
 		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php', '188280'));
 		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
@@ -196,6 +217,9 @@ final class SvnWorkflowTest extends TestCase {
 			'files' => [$svnFile],
 		]);
 		$shell = new TestShell($options, [$svnFile]);
+		$shell->registerExecutable('svn');
+		$shell->registerExecutable('phpcs');
+		$shell->registerExecutable('cat');
 		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
 		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php', '188280'));
 		$shell->registerCommand("svn cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
@@ -223,6 +247,9 @@ final class SvnWorkflowTest extends TestCase {
 			'files' => [$svnFile],
 		]);
 		$shell = new TestShell($options, [$svnFile]);
+		$shell->registerExecutable('svn');
+		$shell->registerExecutable('phpcs');
+		$shell->registerExecutable('cat');
 		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
 		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php', '188280'));
 		$shell->registerCommand("svn cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
@@ -261,6 +288,9 @@ final class SvnWorkflowTest extends TestCase {
 			'files' => [$svnFile],
 		]);
 		$shell = new TestShell($options, [$svnFile]);
+		$shell->registerExecutable('svn');
+		$shell->registerExecutable('phpcs');
+		$shell->registerExecutable('cat');
 		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
 		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php', '188280'));
 		$shell->registerCommand("svn cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
@@ -307,6 +337,9 @@ final class SvnWorkflowTest extends TestCase {
 			'files' => [$svnFile],
 		]);
 		$shell = new TestShell($options, [$svnFile]);
+		$shell->registerExecutable('svn');
+		$shell->registerExecutable('phpcs');
+		$shell->registerExecutable('cat');
 		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
 		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php', '188280'));
 		$shell->registerCommand("svn cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
@@ -354,6 +387,9 @@ final class SvnWorkflowTest extends TestCase {
 			'files' => [$svnFile],
 		]);
 		$shell = new TestShell($options, [$svnFile]);
+		$shell->registerExecutable('svn');
+		$shell->registerExecutable('phpcs');
+		$shell->registerExecutable('cat');
 		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
 		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php'));
 		$shell->registerCommand("svn cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
@@ -375,6 +411,9 @@ final class SvnWorkflowTest extends TestCase {
 			'files' => [$svnFile],
 		]);
 		$shell = new TestShell($options, [$svnFile]);
+		$shell->registerExecutable('svn');
+		$shell->registerExecutable('phpcs');
+		$shell->registerExecutable('cat');
 		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
 		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php', '188280'));
 		$shell->registerCommand("svn cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
@@ -398,6 +437,9 @@ final class SvnWorkflowTest extends TestCase {
 			'files' => [$svnFile],
 		]);
 		$shell = new TestShell($options, [$svnFile]);
+		$shell->registerExecutable('svn');
+		$shell->registerExecutable('phpcs');
+		$shell->registerExecutable('cat');
 		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
 		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php', '188280'));
 		$oldFileOutput = $this->phpcs->getResults('STDIN', [20, 99]);
@@ -421,6 +463,9 @@ final class SvnWorkflowTest extends TestCase {
 			'files' => [$svnFile],
 		]);
 		$shell = new TestShell($options, [$svnFile]);
+		$shell->registerExecutable('svn');
+		$shell->registerExecutable('phpcs');
+		$shell->registerExecutable('cat');
 		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
 		$shell->registerCommand("svn cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
 		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
@@ -449,6 +494,9 @@ final class SvnWorkflowTest extends TestCase {
 			'files' => [$svnFile],
 		]);
 		$shell = new TestShell($options, [$svnFile]);
+		$shell->registerExecutable('svn');
+		$shell->registerExecutable('phpcs');
+		$shell->registerExecutable('cat');
 		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getEmptyFileDiff());
 		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php', '188280'));
 		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
@@ -470,6 +518,9 @@ final class SvnWorkflowTest extends TestCase {
 			'files' => [$svnFile],
 		]);
 		$shell = new TestShell($options, [$svnFile]);
+		$shell->registerExecutable('svn');
+		$shell->registerExecutable('phpcs');
+		$shell->registerExecutable('cat');
 		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getEmptyFileDiff());
 		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php', '188280'));
 		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
@@ -489,6 +540,9 @@ final class SvnWorkflowTest extends TestCase {
 			'files' => $svnFiles,
 		]);
 		$shell = new TestShell($options, $svnFiles);
+		$shell->registerExecutable('svn');
+		$shell->registerExecutable('phpcs');
+		$shell->registerExecutable('cat');
 		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
 		$shell->registerCommand("svn diff 'baz.php'", $this->fixture->getAddedLineDiff('baz.php', 'use Baz;'));
 		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php'));
@@ -514,6 +568,9 @@ final class SvnWorkflowTest extends TestCase {
 			'files' => [$svnFile],
 		]);
 		$shell = new TestShell($options, [$svnFile]);
+		$shell->registerExecutable('svn');
+		$shell->registerExecutable('phpcs');
+		$shell->registerExecutable('cat');
 		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getEmptyFileDiff());
 		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php'));
 		$shell->registerCommand("svn cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
@@ -530,6 +587,9 @@ final class SvnWorkflowTest extends TestCase {
 			'files' => [$svnFile],
 		]);
 		$shell = new TestShell($options, [$svnFile]);
+		$shell->registerExecutable('svn');
+		$shell->registerExecutable('phpcs');
+		$shell->registerExecutable('cat');
 		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getEmptyFileDiff());
 		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php'));
 		$shell->registerCommand("svn cat 'foobar.php'", '{"totals":{"errors":0,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":0,"warnings":0,"messages":[]}}}');
@@ -546,6 +606,9 @@ final class SvnWorkflowTest extends TestCase {
 			'files' => [$svnFile],
 		]);
 		$shell = new TestShell($options, [$svnFile]);
+		$shell->registerExecutable('svn');
+		$shell->registerExecutable('phpcs');
+		$shell->registerExecutable('cat');
 		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getEmptyFileDiff());
 		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php'));
 		$shell->registerCommand("svn cat 'foobar.php'", '{"totals":{"errors":0,"warnings":0,"fixable":0},"files":{"STDIN":{"errors":0,"warnings":0,"messages":[]}}}');
@@ -564,6 +627,9 @@ final class SvnWorkflowTest extends TestCase {
 			'files' => [$svnFile],
 		]);
 		$shell = new TestShell($options, [$svnFile]);
+		$shell->registerExecutable('svn');
+		$shell->registerExecutable('phpcs');
+		$shell->registerExecutable('cat');
 		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getNonSvnFileDiff('foobar.php'), 1);
 		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfoNonSvnFile('foobar.php'), 1);
 		$shell->registerCommand("svn cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
@@ -578,6 +644,9 @@ final class SvnWorkflowTest extends TestCase {
 			'files' => [$svnFile],
 		]);
 		$shell = new TestShell($options, [$svnFile]);
+		$shell->registerExecutable('svn');
+		$shell->registerExecutable('phpcs');
+		$shell->registerExecutable('cat');
 		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getNewFileDiff('foobar.php'));
 		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfoNewFile('foobar.php'));
 		$shell->registerCommand("cat 'foobar.php'", $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
@@ -593,6 +662,9 @@ final class SvnWorkflowTest extends TestCase {
 			'files' => [$svnFile],
 		]);
 		$shell = new TestShell($options, [$svnFile]);
+		$shell->registerExecutable('svn');
+		$shell->registerExecutable('phpcs');
+		$shell->registerExecutable('cat');
 		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getNewFileDiff('foobar.php'));
 		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfoNewFile('foobar.php'));
 		$fixture = 'ERROR: You must supply at least one file or directory to process.
@@ -616,6 +688,9 @@ Run "phpcs --help" for usage information
 			'files' => [$svnFile],
 		]);
 		$shell = new TestShell($options, [$svnFile]);
+		$shell->registerExecutable('svn');
+		$shell->registerExecutable('phpcs');
+		$shell->registerExecutable('cat');
 		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
 		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php'));
 		$shell->registerCommand("svn cat 'foobar.php' | phpcs --report=json -q --standard='standard' --warning-severity='0' --error-severity='0'", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());

--- a/tests/helpers/TestShell.php
+++ b/tests/helpers/TestShell.php
@@ -20,6 +20,8 @@ class TestShell extends UnixShell {
 
 	private $fileHashes = [];
 
+	private $executables = [];
+
 	private $options;
 
 	public function __construct(CliOptions $options, array $readableFileNames) {
@@ -27,6 +29,10 @@ class TestShell extends UnixShell {
 			$this->registerReadableFileName($fileName);
 		}
 		parent::__construct($options);
+	}
+
+	public function registerExecutable(string $path): void {
+		$this->executables[$path] = true;
 	}
 
 	public function registerReadableFileName(string $fileName, bool $override = false): bool {
@@ -68,7 +74,12 @@ class TestShell extends UnixShell {
 
 	public function printError(string $message): void {} // phpcs:ignore VariableAnalysis
 
-	public function validateExecutableExists(string $name, string $command): void {} // phpcs:ignore VariableAnalysis
+	public function validateExecutableExists(string $name, string $command): void {
+		if (isset($this->executables[$command])) {
+			return;
+		}
+		throw new \Exception("The executable for {$name} with the path '{$command}' has not been mocked.");
+	}
 
 	public function getFileHash(string $fileName): string {
 		return $this->fileHashes[$fileName] ?? $fileName;


### PR DESCRIPTION
If the `--phpcs-path` option and `PHPCS` env variable are not set, normally `phpcs-changed` defaults to using `'phpcs'` to run phpcs commands, relying on the user's `$PATH` to find the executable.

This PR modifies that behavior slightly so that if there is a `vendor/bin/phpcs` file in the directory from which `phpcs-changed` is run, that executable will be used as the default instead.

Fixes https://github.com/sirbrillig/phpcs-changed/issues/70

- [x] Add new default.
- [x] Add tests for new default.
- [x] Add docs for new default.
- [x] Add option to disable new default.