### PR TITLE
Remove shell execute and validate executable commands

### DIFF
--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -182,14 +182,14 @@ Overrides:
 EOF;
 }
 
-function getReporter(string $reportType, CliOptions $options): Reporter {
+function getReporter(string $reportType, CliOptions $options, ShellOperator $shell): Reporter {
 	switch ($reportType) {
 		case 'full':
 			return new FullReporter();
 		case 'json':
 			return new JsonReporter();
 		case 'xml':
-			return new XmlReporter($options);
+			return new XmlReporter($options, $shell);
 	}
 	printErrorAndExit("Unknown Reporter '{$reportType}'");
 	throw new \Exception("Unknown Reporter '{$reportType}'"); // Just in case we don't exit for some reason.
@@ -433,8 +433,8 @@ function runGitWorkflowForFile(string $gitFile, CliOptions $options, ShellOperat
 	return getNewPhpcsMessages($unifiedDiff, PhpcsMessages::fromPhpcsJson($unmodifiedFilePhpcsOutput, $fileName), $modifiedFilePhpcsMessages);
 }
 
-function reportMessagesAndExit(PhpcsMessages $messages, CliOptions $options): void {
-	$reporter = getReporter($options->reporter, $options);
+function reportMessagesAndExit(PhpcsMessages $messages, CliOptions $options, ShellOperator $shell): void {
+	$reporter = getReporter($options->reporter, $options, $shell);
 	echo $reporter->getFormattedMessages($messages, $options->toArray());
 	if ($options->alwaysExitZero) {
 		exit(0);

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -11,7 +11,6 @@ use PhpcsChanged\FullReporter;
 use PhpcsChanged\PhpcsMessages;
 use PhpcsChanged\ShellException;
 use PhpcsChanged\ShellOperator;
-use PhpcsChanged\UnixShell;
 use PhpcsChanged\XmlReporter;
 use PhpcsChanged\CacheManager;
 use function PhpcsChanged\{getNewPhpcsMessages, getNewPhpcsMessagesFromFiles, getVersion};
@@ -66,9 +65,7 @@ EOF;
 	exit(0);
 }
 
-function printInstalledCodingStandards(): void {
-	$shell = new UnixShell();
-
+function printInstalledCodingStandards(ShellOperator $shell): void {
 	$installedCodingStandardsPhpcsOutput = $shell->getPhpcsStandards();
 	if (! $installedCodingStandardsPhpcsOutput) {
 		$errorMessage = "Cannot get installed coding standards";

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -212,7 +212,7 @@ function runManualWorkflow(string $diffFile, string $phpcsUnmodifiedFile, string
 function runSvnWorkflow(array $svnFiles, CliOptions $options, ShellOperator $shell, CacheManager $cache, callable $debug): PhpcsMessages {
 	try {
 		$debug('validating executables');
-		$shell->validateExecutables();
+		$shell->validateShellIsReady();
 		$debug('executables are valid');
 	} catch( \Exception $err ) {
 		$shell->printError($err->getMessage());
@@ -307,7 +307,7 @@ function runSvnWorkflowForFile(string $svnFile, CliOptions $options, ShellOperat
 function runGitWorkflow(CliOptions $options, ShellOperator $shell, CacheManager $cache, callable $debug): PhpcsMessages {
 	try {
 		$debug('validating executables');
-		$shell->validateExecutables();
+		$shell->validateShellIsReady();
 		$debug('executables are valid');
 		if ($options->gitBase) {
 			$options->gitBase = $shell->getGitMergeBase();

--- a/PhpcsChanged/ShellOperator.php
+++ b/PhpcsChanged/ShellOperator.php
@@ -13,7 +13,7 @@ interface ShellOperator {
 
 	public function getPhpcsVersion(): string;
 
-	public function validateExecutables(): void;
+	public function validateShellIsReady(): void;
 
 	public function isReadable(string $fileName): bool;
 

--- a/PhpcsChanged/ShellOperator.php
+++ b/PhpcsChanged/ShellOperator.php
@@ -16,9 +16,6 @@ interface ShellOperator {
 	// TODO: remove validateExecutableExists since executables are an implementation detail of the shell.
 	public function validateExecutableExists(string $name, string $command): void;
 
-	// TODO: remove executeCommand from the interface and rely on the more specific methods.
-	public function executeCommand(string $command, int &$return_val = null): string;
-
 	public function isReadable(string $fileName): bool;
 
 	public function getFileHash(string $fileName): string;

--- a/PhpcsChanged/ShellOperator.php
+++ b/PhpcsChanged/ShellOperator.php
@@ -11,6 +11,9 @@ use PhpcsChanged\CliOptions;
 interface ShellOperator {
 	public function clearCaches(): void;
 
+	public function getPhpcsVersion(): string;
+
+	// TODO: remove validateExecutableExists since executables are an implementation detail of the shell.
 	public function validateExecutableExists(string $name, string $command): void;
 
 	// TODO: remove executeCommand from the interface and rely on the more specific methods.

--- a/PhpcsChanged/ShellOperator.php
+++ b/PhpcsChanged/ShellOperator.php
@@ -13,8 +13,7 @@ interface ShellOperator {
 
 	public function getPhpcsVersion(): string;
 
-	// TODO: remove validateExecutableExists since executables are an implementation detail of the shell.
-	public function validateExecutableExists(string $name, string $command): void;
+	public function validateExecutables(): void;
 
 	public function isReadable(string $fileName): bool;
 

--- a/PhpcsChanged/UnixShell.php
+++ b/PhpcsChanged/UnixShell.php
@@ -8,7 +8,6 @@ use PhpcsChanged\CliOptions;
 use PhpcsChanged\Modes;
 use function PhpcsChanged\printError;
 use function PhpcsChanged\getDebug;
-use function PhpcsChanged\getPhpcsExecutable;
 
 /**
  * Module to perform file and shell operations
@@ -42,11 +41,57 @@ class UnixShell implements ShellOperator {
 		$this->svnInfo = [];
 	}
 
-	public function validateExecutableExists(string $name, string $command): void {
+	public function validateExecutables(): void {
+		if ($this->options->mode === Modes::MANUAL) {
+			$phpcs = $this->getPhpcsExecutable();
+			$this->validateExecutableExists('phpcs', $phpcs);
+		}
+
+		if ($this->options->mode === Modes::SVN) {
+			$cat = $this->options->getExecutablePath('cat');
+			$svn = $this->options->getExecutablePath('svn');
+			$this->validateExecutableExists('svn', $svn);
+			$this->validateExecutableExists('cat', $cat);
+			$phpcs = $this->getPhpcsExecutable();
+			$this->validateExecutableExists('phpcs', $phpcs);
+		}
+
+		if ($this->options->isGitMode()) {
+			$git = $this->options->getExecutablePath('git');
+			$this->validateExecutableExists('git', $git);
+			$phpcs = $this->getPhpcsExecutable();
+			$this->validateExecutableExists('phpcs', $phpcs);
+		}
+	}
+
+	protected function validateExecutableExists(string $name, string $command): void {
 		exec(sprintf("type %s > /dev/null 2>&1", escapeshellarg($command)), $ignore, $returnVal);
 		if ($returnVal != 0) {
 			throw new \Exception("Cannot find executable for {$name}, currently set to '{$command}'.");
 		}
+	}
+
+	private function getPhpcsExecutable(): string {
+		if (! empty($this->options->phpcsPath) || ! empty(getenv('PHPCS'))) {
+			return $this->options->getExecutablePath('phpcs');
+		}
+		if (! $this->options->noVendorPhpcs && $this->doesPhpcsExistInVendor()) {
+			return $this->getVendorPhpcsPath();
+		}
+		return 'phpcs';
+	}
+
+	private function doesPhpcsExistInVendor(): bool {
+		try {
+			$this->validateExecutableExists('phpcs', $this->getVendorPhpcsPath());
+		} catch (\Exception $err) {
+			return false;
+		}
+		return true;
+	}
+
+	private function getVendorPhpcsPath(): string {
+		return 'vendor/bin/phpcs';
 	}
 
 	protected function executeCommand(string $command, int &$return_val = null): string {
@@ -56,7 +101,7 @@ class UnixShell implements ShellOperator {
 	}
 
 	public function getPhpcsStandards(): string {
-		$phpcs = getPhpcsExecutable($this->options, $this);
+		$phpcs = $this->getPhpcsExecutable();
 		$installedCodingStandardsPhpcsOutputCommand = "{$phpcs} -i";
 		return $this->executeCommand($installedCodingStandardsPhpcsOutputCommand);
 	}
@@ -271,7 +316,7 @@ class UnixShell implements ShellOperator {
 	}
 	
 	private function getPhpcsCommand(string $fileName): string {
-		$phpcs = getPhpcsExecutable($this->options, $this);
+		$phpcs = $this->getPhpcsExecutable();
 		return "{$phpcs} --report=json -q" . $this->getPhpcsStandardOption() . ' --stdin-path=' .  escapeshellarg($fileName) . ' -';
 	}
 
@@ -362,7 +407,7 @@ class UnixShell implements ShellOperator {
 	}
 
 	public function getPhpcsVersion(): string {
-		$phpcs = getPhpcsExecutable($this->options, $this);
+		$phpcs = $this->getPhpcsExecutable();
 
 		$versionPhpcsOutputCommand = "{$phpcs} --version";
 		$versionPhpcsOutput = $this->executeCommand($versionPhpcsOutputCommand);

--- a/PhpcsChanged/UnixShell.php
+++ b/PhpcsChanged/UnixShell.php
@@ -360,4 +360,21 @@ class UnixShell implements ShellOperator {
 		$parts = explode('/', $path);
 		return end($parts);
 	}
+
+	public function getPhpcsVersion(): string {
+		$phpcs = getPhpcsExecutable($this->options, $this);
+
+		$versionPhpcsOutputCommand = "{$phpcs} --version";
+		$versionPhpcsOutput = $this->executeCommand($versionPhpcsOutputCommand);
+		if (! $versionPhpcsOutput) {
+			throw new ShellException("Cannot get phpcs version");
+		}
+
+		$matched = preg_match('/version\\s([0-9.]+)/uim', $versionPhpcsOutput, $matches);
+		if (empty($matched) || empty($matches[1])) {
+			throw new ShellException("Cannot parse phpcs version output");
+		}
+
+		return $matches[1];
+	}
 }

--- a/PhpcsChanged/UnixShell.php
+++ b/PhpcsChanged/UnixShell.php
@@ -41,7 +41,7 @@ class UnixShell implements ShellOperator {
 		$this->svnInfo = [];
 	}
 
-	public function validateExecutables(): void {
+	public function validateShellIsReady(): void {
 		if ($this->options->mode === Modes::MANUAL) {
 			$phpcs = $this->getPhpcsExecutable();
 			$this->validateExecutableExists('phpcs', $phpcs);

--- a/PhpcsChanged/UnixShell.php
+++ b/PhpcsChanged/UnixShell.php
@@ -49,7 +49,7 @@ class UnixShell implements ShellOperator {
 		}
 	}
 
-	public function executeCommand(string $command, int &$return_val = null): string {
+	protected function executeCommand(string $command, int &$return_val = null): string {
 		$output = [];
 		exec($command, $output, $return_val);
 		return implode(PHP_EOL, $output) . PHP_EOL;

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -100,7 +100,9 @@ if (isset($options['version'])) {
 }
 
 if (isset($options['i'])) {
-	printInstalledCodingStandards();
+	$cliOptions = CliOptions::fromArray($options);
+	$shell = new UnixShell($cliOptions);
+	printInstalledCodingStandards($shell);
 }
 
 // --git-branch exists for compatibility, --git-base supports branches

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -143,9 +143,11 @@ function run(array $rawOptions, callable $debug): void {
 	$debug('Running on filenames: ' . implode(', ', $options->files));
 
 	if ($options->mode === Modes::MANUAL) {
+		$shell = new UnixShell($options);
 		reportMessagesAndExit(
 			runManualWorkflow($options->diffFile, $options->phpcsUnmodified, $options->phpcsModified),
-			$options
+			$options,
+			$shell
 		);
 		return;
 	}
@@ -154,7 +156,8 @@ function run(array $rawOptions, callable $debug): void {
 		$shell = new UnixShell($options);
 		reportMessagesAndExit(
 			runSvnWorkflow($options->files, $options, $shell, new CacheManager(new FileCache(), $debug), $debug),
-			$options
+			$options,
+			$shell
 		);
 		return;
 	}
@@ -163,7 +166,8 @@ function run(array $rawOptions, callable $debug): void {
 		$shell = new UnixShell($options);
 		reportMessagesAndExit(
 			runGitWorkflow($options, $shell, new CacheManager(new FileCache(), $debug), $debug),
-			$options
+			$options,
+			$shell
 		);
 		return;
 	}

--- a/tests/XmlReporterTest.php
+++ b/tests/XmlReporterTest.php
@@ -7,6 +7,7 @@ require_once __DIR__ . '/helpers/helpers.php';
 use PHPUnit\Framework\TestCase;
 use PhpcsChanged\PhpcsMessages;
 use PhpcsChanged\CliOptions;
+use PhpcsChangedTests\TestShell;
 use PhpcsChangedTests\TestXmlReporter;
 
 final class XmlReporterTest extends TestCase {
@@ -32,7 +33,10 @@ final class XmlReporterTest extends TestCase {
 
 EOF;
 		$options = new CliOptions();
-		$reporter = new TestXmlReporter($options);
+		$shell = new TestShell($options, []);
+		$shell->registerExecutable('phpcs');
+		$shell->registerCommand('phpcs --version', 'PHP_CodeSniffer version 1.2.3 (stable) by Squiz (http://www.squiz.net)');
+		$reporter = new TestXmlReporter($options, $shell);
 		$result = $reporter->getFormattedMessages($messages, []);
 		$this->assertEquals($expected, $result);
 	}
@@ -59,7 +63,10 @@ EOF;
 
 EOF;
 		$options = new CliOptions();
-		$reporter = new TestXmlReporter($options);
+		$shell = new TestShell($options, []);
+		$shell->registerExecutable('phpcs');
+		$shell->registerCommand('phpcs --version', 'PHP_CodeSniffer version 1.2.3 (stable) by Squiz (http://www.squiz.net)');
+		$reporter = new TestXmlReporter($options, $shell);
 		$result = $reporter->getFormattedMessages($messages, ['s' => 1]);
 		$this->assertEquals($expected, $result);
 	}
@@ -85,7 +92,10 @@ EOF;
 
 EOF;
 		$options = new CliOptions();
-		$reporter = new TestXmlReporter($options);
+		$shell = new TestShell($options, []);
+		$shell->registerExecutable('phpcs');
+		$shell->registerCommand('phpcs --version', 'PHP_CodeSniffer version 1.2.3 (stable) by Squiz (http://www.squiz.net)');
+		$reporter = new TestXmlReporter($options, $shell);
 		$result = $reporter->getFormattedMessages($messages, ['s' => 1]);
 		$this->assertEquals($expected, $result);
 	}
@@ -122,7 +132,10 @@ EOF;
 
 EOF;
 		$options = new CliOptions();
-		$reporter = new TestXmlReporter($options);
+		$shell = new TestShell($options, []);
+		$shell->registerExecutable('phpcs');
+		$shell->registerCommand('phpcs --version', 'PHP_CodeSniffer version 1.2.3 (stable) by Squiz (http://www.squiz.net)');
+		$reporter = new TestXmlReporter($options, $shell);
 		$result = $reporter->getFormattedMessages($messages, []);
 		$this->assertEquals($expected, $result);
 	}
@@ -194,7 +207,10 @@ EOF;
 
 EOF;
 		$options = new CliOptions();
-		$reporter = new TestXmlReporter($options);
+		$shell = new TestShell($options, []);
+		$shell->registerExecutable('phpcs');
+		$shell->registerCommand('phpcs --version', 'PHP_CodeSniffer version 1.2.3 (stable) by Squiz (http://www.squiz.net)');
+		$reporter = new TestXmlReporter($options, $shell);
 		$result = $reporter->getFormattedMessages($messages, ['s' => 1]);
 		$this->assertEquals($expected, $result);
 	}
@@ -210,7 +226,10 @@ EOF;
 
 EOF;
 		$options = new CliOptions();
-		$reporter = new TestXmlReporter($options);
+		$shell = new TestShell($options, []);
+		$shell->registerExecutable('phpcs');
+		$shell->registerCommand('phpcs --version', 'PHP_CodeSniffer version 1.2.3 (stable) by Squiz (http://www.squiz.net)');
+		$reporter = new TestXmlReporter($options, $shell);
 		$result = $reporter->getFormattedMessages($messages, []);
 		$this->assertEquals($expected, $result);
 	}
@@ -237,7 +256,10 @@ EOF;
 
 EOF;
 		$options = new CliOptions();
-		$reporter = new TestXmlReporter($options);
+		$shell = new TestShell($options, []);
+		$shell->registerExecutable('phpcs');
+		$shell->registerCommand('phpcs --version', 'PHP_CodeSniffer version 1.2.3 (stable) by Squiz (http://www.squiz.net)');
+		$reporter = new TestXmlReporter($options, $shell);
 		$result = $reporter->getFormattedMessages($messages, []);
 		$this->assertEquals($expected, $result);
 	}
@@ -255,14 +277,20 @@ EOF;
 			],
 		], 'fileA.php');
 		$options = new CliOptions();
-		$reporter = new TestXmlReporter($options);
+		$shell = new TestShell($options, []);
+		$shell->registerExecutable('phpcs');
+		$shell->registerCommand('phpcs --version', 'PHP_CodeSniffer version 1.2.3 (stable) by Squiz (http://www.squiz.net)');
+		$reporter = new TestXmlReporter($options, $shell);
 		$this->assertEquals(1, $reporter->getExitCode($messages));
 	}
 
 	public function testGetExitCodeWithNoMessages() {
 		$messages = PhpcsMessages::fromArrays([], 'fileA.php');
 		$options = new CliOptions();
-		$reporter = new TestXmlReporter($options);
+		$shell = new TestShell($options, []);
+		$shell->registerExecutable('phpcs');
+		$shell->registerCommand('phpcs --version', 'PHP_CodeSniffer version 1.2.3 (stable) by Squiz (http://www.squiz.net)');
+		$reporter = new TestXmlReporter($options, $shell);
 		$this->assertEquals(0, $reporter->getExitCode($messages));
 	}
 }

--- a/tests/helpers/TestShell.php
+++ b/tests/helpers/TestShell.php
@@ -85,7 +85,7 @@ class TestShell extends UnixShell {
 		return $this->fileHashes[$fileName] ?? $fileName;
 	}
 
-	public function executeCommand(string $command, int &$return_val = null): string {
+	protected function executeCommand(string $command, int &$return_val = null): string {
 		foreach ($this->commands as $registeredCommand => $return) {
 			if ($registeredCommand === substr($command, 0, strlen($registeredCommand)) ) {
 				$return_val = $return['return_val'];


### PR DESCRIPTION
This removes the `executeCommand` and `validateExecutableExists` functions from `ShellOperator`, instead making them implementation details of the shell. This will allow for more diverse shells since these functions both assumed a UNIX-like environment.

In their place, this PR adds two new functions to `ShellOperator`: `getPhpcsVersion` which is needed by the `XmlReporter`, and `validateShellIsReady` which can be used as a general function to perform any necessary validation.

This is part of https://github.com/sirbrillig/phpcs-changed/issues/73