### PR TITLE
Add '--extensions' option to use in PHPCS and for allowed extensions

### DIFF
--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -142,6 +142,7 @@ EOF;
 
 	printTwoColumns([
 		'--standard <STANDARD>' => 'The phpcs standard to use.',
+		'--extensions <EXTENSIONS>' => 'A comma separated list of extensions to check',
 		'--report <REPORTER>' => 'The phpcs reporter to use. One of "full" (default), "json", or "xml".',
 		'-s' => 'Show sniff codes for each error when the reporter is "full".',
 		'--ignore <PATTERNS>' => 'A comma separated list of patterns to ignore files and directories.',

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -410,11 +410,11 @@ function reportMessagesAndExit(PhpcsMessages $messages, CliOptions $options, She
 	exit($reporter->getExitCode($messages));
 }
 
-function fileHasValidExtension(\SplFileInfo $file, string $extensionsOption): bool {
+function fileHasValidExtension(\SplFileInfo $file, CliOptions $options = null): bool {
 	// The following logic is copied from PHPCS itself. See https://github.com/squizlabs/PHP_CodeSniffer/blob/2ecd8dc15364cdd6e5089e82ffef2b205c98c412/src/Filters/Filter.php#L161
 	// phpcs:disable
 
-	if (empty($extensionsOption)) {
+	if (empty($options->phpcsExtensions)) {
 		$AllowedExtensions = [
 			'php',
 			'inc',
@@ -422,7 +422,7 @@ function fileHasValidExtension(\SplFileInfo $file, string $extensionsOption): bo
 			'css',
 		];
 	} else {
-		$AllowedExtensions = explode(',', $extensionsOption);
+		$AllowedExtensions = explode(',', $options->phpcsExtensions);
 	}
 
 	// Extensions can only be checked for files.

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -142,7 +142,7 @@ EOF;
 
 	printTwoColumns([
 		'--standard <STANDARD>' => 'The phpcs standard to use.',
-		'--extensions <EXTENSIONS>' => 'A comma separated list of extensions to check',
+		'--extensions <EXTENSIONS>' => 'A comma separated list of extensions to check.',
 		'--report <REPORTER>' => 'The phpcs reporter to use. One of "full" (default), "json", or "xml".',
 		'-s' => 'Show sniff codes for each error when the reporter is "full".',
 		'--ignore <PATTERNS>' => 'A comma separated list of patterns to ignore files and directories.',

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -410,15 +410,21 @@ function reportMessagesAndExit(PhpcsMessages $messages, CliOptions $options, She
 	exit($reporter->getExitCode($messages));
 }
 
-function fileHasValidExtension(\SplFileInfo $file): bool {
+function fileHasValidExtension(\SplFileInfo $file, string $extensionsOption): bool {
 	// The following logic is copied from PHPCS itself. See https://github.com/squizlabs/PHP_CodeSniffer/blob/2ecd8dc15364cdd6e5089e82ffef2b205c98c412/src/Filters/Filter.php#L161
 	// phpcs:disable
-	$AllowedExtensions = [
-		'php',
-		'inc',
-		'js',
-		'css',
-	];
+
+	if (empty($extensionsOption)) {
+		$AllowedExtensions = [
+			'php',
+			'inc',
+			'js',
+			'css',
+		];
+	} else {
+		$AllowedExtensions = explode(',', $extensionsOption);
+	}
+
 	// Extensions can only be checked for files.
 	if (!$file->isFile()) {
 		return false;

--- a/PhpcsChanged/CliOptions.php
+++ b/PhpcsChanged/CliOptions.php
@@ -120,6 +120,11 @@ class CliOptions {
 	public $phpcsStandard = null;
 
 	/**
+	 * @var string|null
+	 */
+	public $phpcsExtensions = null;
+
+	/**
 	 * @var bool
 	 */
 	public $alwaysExitZero = false;
@@ -231,6 +236,9 @@ class CliOptions {
 		if (isset($options['standard'])) {
 			$cliOptions->phpcsStandard = $options['standard'];
 		}
+		if (isset($options['extensions'])) {
+			$cliOptions->phpcsExtensions = $options['extensions'];
+		}
 		if (isset($options['always-exit-zero'])) {
 			$cliOptions->alwaysExitZero = true;
 		}
@@ -256,6 +264,9 @@ class CliOptions {
 		$options['files'] = $this->files;
 		if ($this->phpcsStandard) {
 			$options['standard'] = $this->phpcsStandard;
+		}
+		if ($this->phpcsExtensions) {
+			$options['extensions'] = $this->phpcsExtensions;
 		}
 		if ($this->noVendorPhpcs) {
 			$options['no-vendor-phpcs'] = true;

--- a/PhpcsChanged/UnixShell.php
+++ b/PhpcsChanged/UnixShell.php
@@ -247,6 +247,12 @@ class UnixShell implements ShellOperator {
 		return $phpcsStandardOption;
 	}
 
+	private function getPhpcsExtensionsOption(): string {
+		$phpcsExtensions = $this->options->phpcsExtensions;
+		$phpcsExtensionsOption = $phpcsExtensions ? ' --extensions=' . escapeshellarg($phpcsExtensions) : '';
+		return $phpcsExtensionsOption;
+	}
+
 	public function getPhpcsOutputOfModifiedGitFile(string $fileName): string {
 		$debug = getDebug($this->options->debug);
 		$fileContentsCommand = $this->getModifiedFileContentsCommand($fileName);
@@ -314,10 +320,10 @@ class UnixShell implements ShellOperator {
 		$unmodifiedFilePhpcsOutput = $this->executeCommand($unmodifiedFilePhpcsOutputCommand);
 		return $this->processPhpcsOutput($fileName, 'unmodified', $unmodifiedFilePhpcsOutput);
 	}
-	
+
 	private function getPhpcsCommand(string $fileName): string {
 		$phpcs = $this->getPhpcsExecutable();
-		return "{$phpcs} --report=json -q" . $this->getPhpcsStandardOption() . ' --stdin-path=' .  escapeshellarg($fileName) . ' -';
+		return "{$phpcs} --report=json -q" . $this->getPhpcsStandardOption() . $this->getPhpcsExtensionsOption() . ' --stdin-path=' .  escapeshellarg($fileName) . ' -';
 	}
 
 	private function processPhpcsOutput(string $fileName, string $modifiedOrUnmodified, string $phpcsOutput): string {

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ You can use `--report` to customize the output type. `full` (the default) is hum
 
 You can use `--standard` to specify a specific phpcs standard to run. This matches the phpcs option of the same name.
 
+You can use `--extensions` to specify a list of valid file extensions that phpcs should check. These should be separated by commas. This matches the phpcs option of the same name.
+
 You can also use the `-s` option to Always show sniff codes after each error in the full reporter. This matches the phpcs option of the same name.
 
 The `--error-severity` and `--warning-severity` options can be used for instructing the `phpcs` command on what error and warning severity to report. Those values are being passed through to `phpcs` itself. Consult `phpcs` documentation for severity settings.

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -75,7 +75,7 @@ foreach( $fileNames as $file ) {
 			continue;
 		}
 		$iterator = new \RecursiveIteratorIterator(new \RecursiveCallbackFilterIterator(new \RecursiveDirectoryIterator($file, (\RecursiveDirectoryIterator::SKIP_DOTS | \FilesystemIterator::FOLLOW_SYMLINKS)), function($file, $key, $iterator) use($options) {
-			if ($file->isFile() && !fileHasValidExtension($file, $options['extensions'])) {
+			if ($file->isFile() && !fileHasValidExtension($file, CliOptions::fromArray($options))) {
 				return false;
 			}
 			return $iterator->hasChildren() || $file->isFile() ? true : false;

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -74,8 +74,8 @@ foreach( $fileNames as $file ) {
 		if (shouldIgnorePath($file, isset($options['ignore']) && is_string($options['ignore']) ? $options['ignore'] : null)) {
 			continue;
 		}
-		$iterator = new \RecursiveIteratorIterator(new \RecursiveCallbackFilterIterator(new \RecursiveDirectoryIterator($file, (\RecursiveDirectoryIterator::SKIP_DOTS | \FilesystemIterator::FOLLOW_SYMLINKS)), function($file, $key, $iterator){
-			if ($file->isFile() && !fileHasValidExtension($file)) {
+		$iterator = new \RecursiveIteratorIterator(new \RecursiveCallbackFilterIterator(new \RecursiveDirectoryIterator($file, (\RecursiveDirectoryIterator::SKIP_DOTS | \FilesystemIterator::FOLLOW_SYMLINKS)), function($file, $key, $iterator) use($options) {
+			if ($file->isFile() && !fileHasValidExtension($file, $options['extensions'])) {
 				return false;
 			}
 			return $iterator->hasChildren() || $file->isFile() ? true : false;

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -49,6 +49,7 @@ $options = getopt(
 		'git-branch:',
 		'git-base:',
 		'standard:',
+		'extensions:',
 		'report:',
 		'debug',
 		'ignore:',


### PR DESCRIPTION
This PR adds the `--extensions` option to pass to PHPCS command and to use if for allowed extensions when a dir is used instead of a file.