### PR TITLE
Fix no-vendor-phpcs flag

### DIFF
--- a/PhpcsChanged/CliOptions.php
+++ b/PhpcsChanged/CliOptions.php
@@ -173,7 +173,7 @@ class CliOptions {
 			$cliOptions->files = $options['files'];
 		}
 		if (isset($options['no-vendor-phpcs'])) {
-			$cliOptions->noVendorPhpcs = $options['no-vendor-phpcs'];
+			$cliOptions->noVendorPhpcs = true;
 		}
 		if (isset($options['phpcs-path'])) {
 			$cliOptions->phpcsPath = $options['phpcs-path'];

--- a/tests/GitWorkflowTest.php
+++ b/tests/GitWorkflowTest.php
@@ -27,7 +27,7 @@ final class GitWorkflowTest extends TestCase {
 
 	public function testFullGitWorkflowForOneFileStaged() {
 		$gitFile = 'foobar.php';
-		$options = CliOptions::fromArray(['no-cache-git-root' => 1, 'git-staged' => 1, 'files' => [$gitFile]]);
+		$options = CliOptions::fromArray(['no-cache-git-root' => false, 'git-staged' => false, 'files' => [$gitFile]]);
 		$shell = new TestShell($options, [$gitFile]);
 		$shell->registerExecutable('git');
 		$shell->registerExecutable('phpcs');
@@ -48,8 +48,8 @@ final class GitWorkflowTest extends TestCase {
 		$gitFile = 'foobar.php';
 		$gitPath = 'bin/foo/git';
 		$options = CliOptions::fromArray([
-			'no-cache-git-root' => 1,
-			'git-staged' => 1,
+			'no-cache-git-root' => false,
+			'git-staged' => false,
 			'files' => [$gitFile],
 			'git-path' => $gitPath,
 		]);
@@ -73,8 +73,8 @@ final class GitWorkflowTest extends TestCase {
 		$gitFile = 'foobar.php';
 		$phpcsPath = 'bin/foo/phpcs';
 		$options = CliOptions::fromArray([
-			'no-cache-git-root' => 1,
-			'git-staged' => 1,
+			'no-cache-git-root' => false,
+			'git-staged' => false,
 			'files' => [$gitFile],
 			'phpcs-path' => $phpcsPath,
 		]);
@@ -98,8 +98,8 @@ final class GitWorkflowTest extends TestCase {
 		$gitFile = 'foobar.php';
 		$phpcsPath = 'vendor/bin/phpcs';
 		$options = CliOptions::fromArray([
-			'no-cache-git-root' => 1,
-			'git-staged' => 1,
+			'no-cache-git-root' => false,
+			'git-staged' => false,
 			'files' => [$gitFile],
 		]);
 		$shell = new TestShell($options, [$gitFile]);
@@ -122,10 +122,10 @@ final class GitWorkflowTest extends TestCase {
 		$gitFile = 'foobar.php';
 		$phpcsPath = 'vendor/bin/phpcs';
 		$options = CliOptions::fromArray([
-			'no-cache-git-root' => 1,
-			'git-staged' => 1,
+			'no-cache-git-root' => false, // getopt is weird and sets options to false
+			'git-staged' => false, // getopt is weird and sets options to false
 			'files' => [$gitFile],
-			'no-vendor-phpcs' => true,
+			'no-vendor-phpcs' => false, // getopt is weird and sets options to false
 		]);
 		$shell = new TestShell($options, [$gitFile]);
 		$shell->registerExecutable('git');
@@ -146,7 +146,7 @@ final class GitWorkflowTest extends TestCase {
 
 	public function testFullGitWorkflowForOneFileUnstaged() {
 		$gitFile = 'foobar.php';
-		$options = CliOptions::fromArray(['no-cache-git-root' => 1, 'git-unstaged' => '1', 'files' => [$gitFile]]);
+		$options = CliOptions::fromArray(['no-cache-git-root' => false, 'git-unstaged' => false, 'files' => [$gitFile]]);
 		$shell = new TestShell($options, [$gitFile]);
 		$shell->registerExecutable('git');
 		$shell->registerExecutable('phpcs');
@@ -166,8 +166,8 @@ final class GitWorkflowTest extends TestCase {
 	public function testFullGitWorkflowForOneChangedFileWithoutPhpcsMessagesLintsOnlyNewFile() {
 		$gitFile = 'foobar.php';
 		$options = CliOptions::fromArray([
-			'no-cache-git-root' => 1,
-			'git-unstaged' => '1',
+			'no-cache-git-root' => false,
+			'git-unstaged' => false,
 			'files' => [$gitFile],
 		]);
 		$shell = new TestShell($options, [$gitFile]);
@@ -190,8 +190,8 @@ final class GitWorkflowTest extends TestCase {
 	public function testFullGitWorkflowForOneFileUnstagedCachesDataThenUsesCache() {
 		$gitFile = 'foobar.php';
 		$options = CliOptions::fromArray([
-			'no-cache-git-root' => 1,
-			'git-unstaged' => '1',
+			'no-cache-git-root' => false,
+			'git-unstaged' => false,
 			'cache' => false, // getopt is weird and sets options to false
 			'files' => [$gitFile],
 		]);
@@ -222,8 +222,8 @@ final class GitWorkflowTest extends TestCase {
 	public function testFullGitWorkflowForOneFileUnstagedCachesDataThenUsesCacheWithSeveritySet() {
 		$gitFile = 'foobar.php';
 		$options = CliOptions::fromArray([
-			'no-cache-git-root' => 1,
-			'git-unstaged' => '1',
+			'no-cache-git-root' => false,
+			'git-unstaged' => false,
 			'cache' => false, // getopt is weird and sets options to false
 			'standard' => 'standard',
 			'warning-severity' => '1',
@@ -262,8 +262,8 @@ final class GitWorkflowTest extends TestCase {
 	public function testFullGitWorkflowForOneFileUnstagedCachesDataThenUsesCacheWithSeveritySetToZero() {
 		$gitFile = 'foobar.php';
 		$options = CliOptions::fromArray([
-			'no-cache-git-root' => 1,
-			'git-unstaged' => '1',
+			'no-cache-git-root' => false,
+			'git-unstaged' => false,
 			'cache' => false, // getopt is weird and sets options to false
 			'standard' => 'standard',
 			'warning-severity' => '0',
@@ -304,8 +304,8 @@ final class GitWorkflowTest extends TestCase {
 	public function testFullGitWorkflowForOneFileUnstagedCachesDataThenUsesCacheWithSeverityNotSet() {
 		$gitFile = 'foobar.php';
 		$options = CliOptions::fromArray([
-			'no-cache-git-root' => 1,
-			'git-unstaged' => '1',
+			'no-cache-git-root' => false,
+			'git-unstaged' => false,
 			'cache' => false, // getopt is weird and sets options to false
 			'standard' => 'standard',
 			'files' => [$gitFile],
@@ -344,8 +344,8 @@ final class GitWorkflowTest extends TestCase {
 	public function testFullGitWorkflowForOneFileUnstagedCachesDataThenClearsOldCacheWhenOldFileChanges() {
 		$gitFile = 'foobar.php';
 		$options = CliOptions::fromArray([
-			'no-cache-git-root' => 1,
-			'git-unstaged' => '1',
+			'no-cache-git-root' => false,
+			'git-unstaged' => false,
 			'cache' => false, // getopt is weird and sets options to false
 			'files' => [$gitFile],
 		]);
@@ -378,8 +378,8 @@ final class GitWorkflowTest extends TestCase {
 	public function testFullGitWorkflowForOneFileUnstagedCachesDataThenClearsNewCacheWhenFileChanges() {
 		$gitFile = 'foobar.php';
 		$options = CliOptions::fromArray([
-			'no-cache-git-root' => 1,
-			'git-unstaged' => '1',
+			'no-cache-git-root' => false,
+			'git-unstaged' => false,
 			'cache' => false, // getopt is weird and sets options to false
 			'files' => [$gitFile],
 		]);
@@ -411,7 +411,7 @@ final class GitWorkflowTest extends TestCase {
 
 	public function testFullGitWorkflowForMultipleFilesStaged() {
 		$gitFiles = ['foobar.php', 'baz.php'];
-		$options = CliOptions::fromArray(['no-cache-git-root' => 1, 'git-staged' => 1, 'files' => $gitFiles]);
+		$options = CliOptions::fromArray(['no-cache-git-root' => false, 'git-staged' => false, 'files' => $gitFiles]);
 		$shell = new TestShell($options, $gitFiles);
 		$shell->registerExecutable('git');
 		$shell->registerExecutable('phpcs');
@@ -439,7 +439,7 @@ final class GitWorkflowTest extends TestCase {
 
 	public function testFullGitWorkflowForUnchangedFileWithPhpcsMessages() {
 		$gitFile = 'foobar.php';
-		$options = CliOptions::fromArray(['no-cache-git-root' => 1, 'git-staged' => 1, 'files' => [$gitFile]]);
+		$options = CliOptions::fromArray(['no-cache-git-root' => false, 'git-staged' => false, 'files' => [$gitFile]]);
 		$shell = new TestShell($options, [$gitFile]);
 		$shell->registerExecutable('git');
 		$shell->registerExecutable('phpcs');
@@ -458,7 +458,7 @@ final class GitWorkflowTest extends TestCase {
 
 	public function testFullGitWorkflowForUnchangedFileWithoutPhpcsMessages() {
 		$gitFile = 'foobar.php';
-		$options = CliOptions::fromArray(['no-cache-git-root' => 1, 'git-staged' => 1, 'files' => [$gitFile]]);
+		$options = CliOptions::fromArray(['no-cache-git-root' => false, 'git-staged' => false, 'files' => [$gitFile]]);
 		$shell = new TestShell($options, [$gitFile]);
 		$shell->registerExecutable('git');
 		$shell->registerExecutable('phpcs');
@@ -476,7 +476,7 @@ final class GitWorkflowTest extends TestCase {
 	public function testFullGitWorkflowForNonGitFile() {
 		$this->expectException(ShellException::class);
 		$gitFile = 'foobar.php';
-		$options = CliOptions::fromArray(['no-cache-git-root' => 1, 'git-staged' => 1, 'files' => [$gitFile]]);
+		$options = CliOptions::fromArray(['no-cache-git-root' => false, 'git-staged' => false, 'files' => [$gitFile]]);
 		$shell = new TestShell($options, [$gitFile]);
 		$shell->registerExecutable('git');
 		$shell->registerExecutable('phpcs');
@@ -493,7 +493,7 @@ final class GitWorkflowTest extends TestCase {
 
 	public function testFullGitWorkflowForNewFile() {
 		$gitFile = 'foobar.php';
-		$options = CliOptions::fromArray(['no-cache-git-root' => 1, 'git-staged' => 1, 'files' => [$gitFile]]);
+		$options = CliOptions::fromArray(['no-cache-git-root' => false, 'git-staged' => false, 'files' => [$gitFile]]);
 		$shell = new TestShell($options, [$gitFile]);
 		$shell->registerExecutable('git');
 		$shell->registerExecutable('phpcs');
@@ -511,7 +511,7 @@ final class GitWorkflowTest extends TestCase {
 
 	public function testFullGitWorkflowForEmptyNewFile() {
 		$gitFile = 'foobar.php';
-		$options = CliOptions::fromArray(['no-cache-git-root' => 1, 'git-staged' => 1, 'files' => [$gitFile]]);
+		$options = CliOptions::fromArray(['no-cache-git-root' => false, 'git-staged' => false, 'files' => [$gitFile]]);
 		$shell = new TestShell($options, [$gitFile]);
 		$shell->registerExecutable('git');
 		$shell->registerExecutable('phpcs');
@@ -534,7 +534,7 @@ Run "phpcs --help" for usage information
 
 	public function testFullGitWorkflowForInterBranchDiff() {
 		$gitFile = 'bin/foobar.php';
-		$options = CliOptions::fromArray(['no-cache-git-root' => 1, 'git-base' => 'master', 'files' => [$gitFile]]);
+		$options = CliOptions::fromArray(['no-cache-git-root' => false, 'git-base' => 'master', 'files' => [$gitFile]]);
 		$shell = new TestShell($options, [$gitFile]);
 		$shell->registerExecutable('git');
 		$shell->registerExecutable('phpcs');
@@ -557,7 +557,7 @@ Run "phpcs --help" for usage information
 
 	public function testFullGitWorkflowForUnchangedFileForInterBranchDiff() {
 		$gitFile = 'bin/foobar.php';
-		$options = CliOptions::fromArray(['no-cache-git-root' => 1, 'git-base' => 'master', 'files' => [$gitFile]]);
+		$options = CliOptions::fromArray(['no-cache-git-root' => false, 'git-base' => 'master', 'files' => [$gitFile]]);
 		$shell = new TestShell($options, [$gitFile]);
 		$shell->registerExecutable('git');
 		$shell->registerExecutable('phpcs');
@@ -578,7 +578,7 @@ Run "phpcs --help" for usage information
 
 	public function testFullGitWorkflowWithUntrackedFileForInterBranchDiff() {
 		$gitFile = 'bin/foobar.php';
-		$options = CliOptions::fromArray(['no-cache-git-root' => 1, 'git-base' => 'master', 'files' => [$gitFile]]);
+		$options = CliOptions::fromArray(['no-cache-git-root' => false, 'git-base' => 'master', 'files' => [$gitFile]]);
 		$shell = new TestShell($options, [$gitFile]);
 		$shell->registerExecutable('git');
 		$shell->registerExecutable('phpcs');
@@ -601,7 +601,7 @@ Run "phpcs --help" for usage information
 
 	public function testNameDetectionInFullGitWorkflowForInterBranchDiff() {
 		$gitFile = 'test.php';
-		$options = CliOptions::fromArray(['no-cache-git-root' => 1, 'git-base' => 'master', 'files' => [$gitFile]]);
+		$options = CliOptions::fromArray(['no-cache-git-root' => false, 'git-base' => 'master', 'files' => [$gitFile]]);
 		$shell = new TestShell($options, [$gitFile]);
 		$shell->registerExecutable('git');
 		$shell->registerExecutable('phpcs');

--- a/tests/SvnWorkflowTest.php
+++ b/tests/SvnWorkflowTest.php
@@ -28,7 +28,7 @@ final class SvnWorkflowTest extends TestCase {
 	public function testFullSvnWorkflowForOneFile() {
 		$svnFile = 'foobar.php';
 		$options = CliOptions::fromArray([
-			'svn' => true,
+			'svn' => false, // getopt is weird and sets options to false
 			'files' => [$svnFile],
 		]);
 		$shell = new TestShell($options, [$svnFile]);
@@ -48,7 +48,7 @@ final class SvnWorkflowTest extends TestCase {
 		$svnFile = 'foobar.php';
 		$svnPath = 'bin/foo/svn';
 		$options = CliOptions::fromArray([
-			'svn' => true,
+			'svn' => false, // getopt is weird and sets options to false
 			'files' => [$svnFile],
 			'svn-path' => $svnPath,
 		]);
@@ -69,7 +69,7 @@ final class SvnWorkflowTest extends TestCase {
 		$svnFile = 'foobar.php';
 		$catPath = 'bin/foo/cat';
 		$options = CliOptions::fromArray([
-			'svn' => true,
+			'svn' => false, // getopt is weird and sets options to false
 			'files' => [$svnFile],
 			'cat-path' => $catPath,
 		]);
@@ -90,7 +90,7 @@ final class SvnWorkflowTest extends TestCase {
 		$svnFile = 'foobar.php';
 		$phpcsPath = 'bin/foo/phpcs';
 		$options = CliOptions::fromArray([
-			'svn' => true,
+			'svn' => false, // getopt is weird and sets options to false
 			'files' => [$svnFile],
 			'phpcs-path' => $phpcsPath,
 		]);
@@ -111,7 +111,7 @@ final class SvnWorkflowTest extends TestCase {
 		$svnFile = 'foobar.php';
 		$phpcsPath = 'vendor/bin/phpcs';
 		$options = CliOptions::fromArray([
-			'svn' => true,
+			'svn' => false, // getopt is weird and sets options to false
 			'files' => [$svnFile],
 		]);
 		$shell = new TestShell($options, [$svnFile]);
@@ -131,9 +131,9 @@ final class SvnWorkflowTest extends TestCase {
 		$svnFile = 'foobar.php';
 		$phpcsPath = 'vendor/bin/phpcs';
 		$options = CliOptions::fromArray([
-			'svn' => true,
+			'svn' => false, // getopt is weird and sets options to false
 			'files' => [$svnFile],
-			'no-vendor-phpcs' => true,
+			'no-vendor-phpcs' => false, // getopt is weird and sets options to false
 		]);
 		$shell = new TestShell($options, [$svnFile]);
 		$shell->registerExecutable('svn');
@@ -152,7 +152,7 @@ final class SvnWorkflowTest extends TestCase {
 	public function testFullSvnWorkflowForOneFileWithNoMessages() {
 		$svnFile = 'foobar.php';
 		$options = CliOptions::fromArray([
-			'svn' => true,
+			'svn' => false, // getopt is weird and sets options to false
 			'files' => [$svnFile],
 		]);
 		$shell = new TestShell($options, [$svnFile]);
@@ -171,7 +171,7 @@ final class SvnWorkflowTest extends TestCase {
 	public function testFullSvnWorkflowForOneFileWithCachingEnabledButNoCache() {
 		$svnFile = 'foobar.php';
 		$options = CliOptions::fromArray([
-			'svn' => true,
+			'svn' => false, // getopt is weird and sets options to false
 			'cache' => false, // getopt is weird and sets options to false
 			'files' => [$svnFile],
 		]);
@@ -191,7 +191,7 @@ final class SvnWorkflowTest extends TestCase {
 	public function testFullSvnWorkflowForOneFileWithOldFileCached() {
 		$svnFile = 'foobar.php';
 		$options = CliOptions::fromArray([
-			'svn' => true,
+			'svn' => false, // getopt is weird and sets options to false
 			'cache' => false, // getopt is weird and sets options to false
 			'files' => [$svnFile],
 		]);
@@ -214,7 +214,7 @@ final class SvnWorkflowTest extends TestCase {
 	public function testFullSvnWorkflowForOneFileUncachedThenCachesBothVersionsOfTheFile() {
 		$svnFile = 'foobar.php';
 		$options = CliOptions::fromArray([
-			'svn' => true,
+			'svn' => false, // getopt is weird and sets options to false
 			'cache' => false, // getopt is weird and sets options to false
 			'files' => [$svnFile],
 		]);
@@ -244,7 +244,7 @@ final class SvnWorkflowTest extends TestCase {
 	public function testFullSvnWorkflowForOneDoesNotUseNewFileCacheWhenHashChanges() {
 		$svnFile = 'foobar.php';
 		$options = CliOptions::fromArray([
-			'svn' => true,
+			'svn' => false, // getopt is weird and sets options to false
 			'cache' => false, // getopt is weird and sets options to false
 			'files' => [$svnFile],
 		]);
@@ -285,7 +285,7 @@ final class SvnWorkflowTest extends TestCase {
 	public function testFullSvnWorkflowForOneClearsCacheForFileWhenHashChanges() {
 		$svnFile = 'foobar.php';
 		$options = CliOptions::fromArray([
-			'svn' => true,
+			'svn' => false, // getopt is weird and sets options to false
 			'cache' => false, // getopt is weird and sets options to false
 			'files' => [$svnFile],
 		]);
@@ -334,7 +334,7 @@ final class SvnWorkflowTest extends TestCase {
 	public function testFullSvnWorkflowForOneDoesNotClearCacheWhenStandardChanges() {
 		$svnFile = 'foobar.php';
 		$options = CliOptions::fromArray([
-			'svn' => true,
+			'svn' => false, // getopt is weird and sets options to false
 			'cache' => false, // getopt is weird and sets options to false
 			'files' => [$svnFile],
 		]);
@@ -384,7 +384,7 @@ final class SvnWorkflowTest extends TestCase {
 	public function testFullSvnWorkflowForOneFileUncachedWhenCachingIsDisabled() {
 		$svnFile = 'foobar.php';
 		$options = CliOptions::fromArray([
-			'svn' => true,
+			'svn' => false, // getopt is weird and sets options to false
 			'no-cache' => false, // getopt is weird and sets options to false
 			'files' => [$svnFile],
 		]);
@@ -408,7 +408,7 @@ final class SvnWorkflowTest extends TestCase {
 	public function testFullSvnWorkflowForOneFileWithOldCacheVersion() {
 		$svnFile = 'foobar.php';
 		$options = CliOptions::fromArray([
-			'svn' => true,
+			'svn' => false, // getopt is weird and sets options to false
 			'cache' => false, // getopt is weird and sets options to false
 			'files' => [$svnFile],
 		]);
@@ -433,7 +433,7 @@ final class SvnWorkflowTest extends TestCase {
 	public function testFullSvnWorkflowForOneFileWithCacheThatHasDifferentStandard() {
 		$svnFile = 'foobar.php';
 		$options = CliOptions::fromArray([
-			'svn' => true,
+			'svn' => false, // getopt is weird and sets options to false
 			'cache' => false, // getopt is weird and sets options to false
 			'standard' => 'TestStandard1',
 			'files' => [$svnFile],
@@ -460,7 +460,7 @@ final class SvnWorkflowTest extends TestCase {
 	public function testFullSvnWorkflowForOneFileWithCacheOfOldFileVersionDoesNotUseCache() {
 		$svnFile = 'foobar.php';
 		$options = CliOptions::fromArray([
-			'svn' => true,
+			'svn' => false, // getopt is weird and sets options to false
 			'cache' => false, // getopt is weird and sets options to false
 			'files' => [$svnFile],
 		]);
@@ -491,7 +491,7 @@ final class SvnWorkflowTest extends TestCase {
 	public function testFullSvnWorkflowForUnchangedFileWithBothFilesCached() {
 		$svnFile = 'foobar.php';
 		$options = CliOptions::fromArray([
-			'svn' => true,
+			'svn' => false, // getopt is weird and sets options to false
 			'cache' => false, // getopt is weird and sets options to false
 			'files' => [$svnFile],
 		]);
@@ -515,7 +515,7 @@ final class SvnWorkflowTest extends TestCase {
 	public function testFullSvnWorkflowForUnchangedFileWithOldFileCached() {
 		$svnFile = 'foobar.php';
 		$options = CliOptions::fromArray([
-			'svn' => true,
+			'svn' => false, // getopt is weird and sets options to false
 			'cache' => false, // getopt is weird and sets options to false
 			'files' => [$svnFile],
 		]);
@@ -538,7 +538,7 @@ final class SvnWorkflowTest extends TestCase {
 	public function testFullSvnWorkflowForMultipleFiles() {
 		$svnFiles = ['foobar.php', 'baz.php'];
 		$options = CliOptions::fromArray([
-			'svn' => true,
+			'svn' => false, // getopt is weird and sets options to false
 			'files' => $svnFiles,
 		]);
 		$shell = new TestShell($options, $svnFiles);
@@ -566,7 +566,7 @@ final class SvnWorkflowTest extends TestCase {
 	public function testFullSvnWorkflowForUnchangedFileWithPhpCsMessages() {
 		$svnFile = 'foobar.php';
 		$options = CliOptions::fromArray([
-			'svn' => true,
+			'svn' => false, // getopt is weird and sets options to false
 			'files' => [$svnFile],
 		]);
 		$shell = new TestShell($options, [$svnFile]);
@@ -585,7 +585,7 @@ final class SvnWorkflowTest extends TestCase {
 	public function testFullSvnWorkflowForUnchangedFileWithoutPhpCsMessages() {
 		$svnFile = 'foobar.php';
 		$options = CliOptions::fromArray([
-			'svn' => true,
+			'svn' => false, // getopt is weird and sets options to false
 			'files' => [$svnFile],
 		]);
 		$shell = new TestShell($options, [$svnFile]);
@@ -604,7 +604,7 @@ final class SvnWorkflowTest extends TestCase {
 	public function testFullSvnWorkflowForChangedFileWithoutPhpCsMessagesLintsOnlyNewFile() {
 		$svnFile = 'foobar.php';
 		$options = CliOptions::fromArray([
-			'svn' => true,
+			'svn' => false, // getopt is weird and sets options to false
 			'files' => [$svnFile],
 		]);
 		$shell = new TestShell($options, [$svnFile]);
@@ -625,7 +625,7 @@ final class SvnWorkflowTest extends TestCase {
 		$this->expectException(ShellException::class);
 		$svnFile = 'foobar.php';
 		$options = CliOptions::fromArray([
-			'svn' => true,
+			'svn' => false, // getopt is weird and sets options to false
 			'files' => [$svnFile],
 		]);
 		$shell = new TestShell($options, [$svnFile]);
@@ -642,7 +642,7 @@ final class SvnWorkflowTest extends TestCase {
 	public function testFullSvnWorkflowForNewFile() {
 		$svnFile = 'foobar.php';
 		$options = CliOptions::fromArray([
-			'svn' => true,
+			'svn' => false, // getopt is weird and sets options to false
 			'files' => [$svnFile],
 		]);
 		$shell = new TestShell($options, [$svnFile]);
@@ -660,7 +660,7 @@ final class SvnWorkflowTest extends TestCase {
 	public function testFullSvnWorkflowForEmptyNewFile() {
 		$svnFile = 'foobar.php';
 		$options = CliOptions::fromArray([
-			'svn' => true,
+			'svn' => false, // getopt is weird and sets options to false
 			'files' => [$svnFile],
 		]);
 		$shell = new TestShell($options, [$svnFile]);
@@ -682,7 +682,7 @@ Run "phpcs --help" for usage information
 	public function testFullSvnWorkflowForOneFileWithSeveritySetToZero() {
 		$svnFile = 'foobar.php';
 		$options = CliOptions::fromArray([
-			'svn' => true,
+			'svn' => false, // getopt is weird and sets options to false
 			'warning-severity' => '0',
 			'error-severity' => '0',
 			'cache' => false, // getopt is weird and sets options to false


### PR DESCRIPTION
PHP's `getopt` function sets boolean options to `false`, which is counter-intuitive. When we parse options, we must take that into account. That was already done for other boolean options, but I made a mistake in https://github.com/sirbrillig/phpcs-changed/pull/81 and did not correctly set the `--no-vendor-phpcs` option.

This was hidden because the unit tests do not use `getopt` and instead create the options manually and I forgot to set the option to `false`.

In this PR I fix those tests and then fix the bug.

In researching this bug, I also found a bunch of other options in the tests that did not correctly set their flags to `false`, which I've also fixed (thankfully they did not uncover any additional bugs).