### PR TITLE
Do not try to validate runtime options when loading bin script

### DIFF
--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -410,11 +410,11 @@ function reportMessagesAndExit(PhpcsMessages $messages, CliOptions $options, She
 	exit($reporter->getExitCode($messages));
 }
 
-function fileHasValidExtension(\SplFileInfo $file, CliOptions $options = null): bool {
+function fileHasValidExtension(\SplFileInfo $file, string $phpcsExtensions = ''): bool {
 	// The following logic is copied from PHPCS itself. See https://github.com/squizlabs/PHP_CodeSniffer/blob/2ecd8dc15364cdd6e5089e82ffef2b205c98c412/src/Filters/Filter.php#L161
 	// phpcs:disable
 
-	if (empty($options->phpcsExtensions)) {
+	if (empty($phpcsExtensions)) {
 		$AllowedExtensions = [
 			'php',
 			'inc',
@@ -422,7 +422,7 @@ function fileHasValidExtension(\SplFileInfo $file, CliOptions $options = null): 
 			'css',
 		];
 	} else {
-		$AllowedExtensions = explode(',', $options->phpcsExtensions);
+		$AllowedExtensions = explode(',', $phpcsExtensions);
 	}
 
 	// Extensions can only be checked for files.

--- a/PhpcsChanged/CliOptions.php
+++ b/PhpcsChanged/CliOptions.php
@@ -10,7 +10,9 @@ class CliOptions {
 	 *
 	 * Use the `Modes` constants for this purpose rather than the strings.
 	 *
-	 * @var 'svn'|'manual'|'git-staged'|'git-unstaged'|'git-base'|null
+	 * If this is null, validation will fail.
+	 *
+	 * @var 'svn'|'manual'|'git-staged'|'git-unstaged'|'git-base'|'info'|null
 	 */
 	public $mode;
 
@@ -253,6 +255,9 @@ class CliOptions {
 		}
 		if (isset($options['error-severity'])) {
 			$cliOptions->errorSeverity = $options['error-severity'];
+		}
+		if (isset($options['i'])) {
+			$cliOptions->mode = Modes::INFO_ONLY;
 		}
 		$cliOptions->validate();
 		return $cliOptions;

--- a/PhpcsChanged/Modes.php
+++ b/PhpcsChanged/Modes.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace PhpcsChanged;
 
 class Modes {
+	const INFO_ONLY = 'info';
 	const SVN = 'svn';
 	const MANUAL = 'manual';
 	const GIT_STAGED = 'git-staged';

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -75,7 +75,7 @@ foreach( $fileNames as $file ) {
 			continue;
 		}
 		$iterator = new \RecursiveIteratorIterator(new \RecursiveCallbackFilterIterator(new \RecursiveDirectoryIterator($file, (\RecursiveDirectoryIterator::SKIP_DOTS | \FilesystemIterator::FOLLOW_SYMLINKS)), function($file, $key, $iterator) use($options) {
-			if ($file->isFile() && !fileHasValidExtension($file, CliOptions::fromArray($options))) {
+			if ($file->isFile() && !fileHasValidExtension($file, isset($options['extensions']) && is_string($options['extensions']) ? $options['extensions'] : '')) {
 				return false;
 			}
 			return $iterator->hasChildren() || $file->isFile() ? true : false;


### PR DESCRIPTION
When the bin script is loading, it performs certain operations which need to be run before the full `CliOptions` objects can be safely created and validated. Notably, it needs to scan for valid filenames and, if the `-i` option was provided, it needs to create a shell to ask phpcs for its installed standards.

However, currently both these operations can fail because they both require creating a `CliOptions` object when it might not be valid.

This PR makes it so that the `CliOptions` object is not validated when it would likely be invalid. Specifically, it changes the filename validation to use the raw `--extensions` data and it creates a new mode, `INFO_ONLY`, that can be used to safely run the `-i` option.

Fixes https://github.com/sirbrillig/phpcs-changed/issues/94