### PR TITLE
Do not use an optional parameter in LintMessage's constructor

### DIFF
--- a/PhpcsChanged/LintMessage.php
+++ b/PhpcsChanged/LintMessage.php
@@ -9,7 +9,7 @@ class LintMessage {
 	private $type;
 	private $otherProperties;
 
-	public function __construct(int $line, string $file, string $type, array $otherProperties) {
+	public function __construct(int $line, ?string $file, string $type, array $otherProperties) {
 		$this->line = $line;
 		$this->file = $file;
 		$this->type = $type;

--- a/PhpcsChanged/LintMessage.php
+++ b/PhpcsChanged/LintMessage.php
@@ -9,7 +9,7 @@ class LintMessage {
 	private $type;
 	private $otherProperties;
 
-	public function __construct(int $line, string $file = null, string $type, array $otherProperties) {
+	public function __construct(int $line, string $file, string $type, array $otherProperties) {
 		$this->line = $line;
 		$this->file = $file;
 		$this->type = $type;


### PR DESCRIPTION
Using optional parameters before required parameters is deprecated since PHP 8.0 -- https://www.php.net/manual/en/migration80.deprecated.php

Removing the default value has no effect.