### PR TITLE
Fixed typo when checking if the field `diffFile` is empty.

### DIFF
--- a/PhpcsChanged/CliOptions.php
+++ b/PhpcsChanged/CliOptions.php
@@ -366,7 +366,7 @@ class CliOptions {
 			throw new InvalidOptionException('You must use either automatic or manual mode.');
 		}
 		if ($this->mode === Modes::MANUAL) {
-			if (empty($this->diff) || empty($this->phpcsUnmodified) || empty($this->phpcsModified)) {
+			if (empty($this->diffFile) || empty($this->phpcsUnmodified) || empty($this->phpcsModified)) {
 				throw new InvalidOptionException('Manual mode requires a diff, the unmodified file phpcs output, and the modified file phpcs output.');
 			}
 		}


### PR DESCRIPTION
After moving the options to `CliOptions` in commit d7eb1168f5d4054, the field `diff` was renamed to `diffFile`, which caused a bug in the handler for the `--diff` argument.