### PR TITLE
Fix PHP 8.4 deprecation warnings

### DIFF
--- a/PhpcsChanged/CacheManager.php
+++ b/PhpcsChanged/CacheManager.php
@@ -45,7 +45,7 @@ class CacheManager {
 	 */
 	private $debug;
 
-	public function __construct(CacheInterface $cache, callable $debug = null) {
+	public function __construct(CacheInterface $cache, ?callable $debug = null) {
 		$this->cache = $cache;
 		$noopDebug =
 			/** @param string[] $output */

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -451,7 +451,7 @@ function fileHasValidExtension(\SplFileInfo $file, string $phpcsExtensions = '')
 	// phpcs:enable
 }
 
-function shouldIgnorePath(string $path, string $patternOption = null): bool {
+function shouldIgnorePath(string $path, ?string $patternOption = null): bool {
 	if (null===$patternOption) {
 		return false;
 	}

--- a/PhpcsChanged/LintMessages.php
+++ b/PhpcsChanged/LintMessages.php
@@ -33,7 +33,7 @@ class LintMessages {
 	/**
 	 * @return static
 	 */
-	public static function fromLintMessages(array $messages, string $fileName = null) {
+	public static function fromLintMessages(array $messages, ?string $fileName = null) {
 		return new static(array_map(function(LintMessage $message) use ($fileName) {
 			if (is_string($fileName) && strlen($fileName) > 0) {
 				$message->setFile($fileName);

--- a/PhpcsChanged/PhpcsMessages.php
+++ b/PhpcsChanged/PhpcsMessages.php
@@ -11,11 +11,11 @@ class PhpcsMessages extends LintMessages {
 		return PhpcsMessagesHelpers::toPhpcsJson($this);
 	}
 
-	public static function fromPhpcsJson(string $messages, string $forcedFileName = null): self {
+	public static function fromPhpcsJson(string $messages, ?string $forcedFileName = null): self {
 		return PhpcsMessagesHelpers::fromPhpcsJson($messages, $forcedFileName);
 	}
 
-	public static function fromArrays(array $messages, string $fileName = null): self {
+	public static function fromArrays(array $messages, ?string $fileName = null): self {
 		return PhpcsMessagesHelpers::fromArrays($messages, $fileName);
 	}
 }

--- a/PhpcsChanged/PhpcsMessagesHelpers.php
+++ b/PhpcsChanged/PhpcsMessagesHelpers.php
@@ -8,7 +8,7 @@ use PhpcsChanged\LintMessage;
 use PhpcsChanged\JsonReporter;
 
 class PhpcsMessagesHelpers {
-	public static function fromPhpcsJson(string $messages, string $forcedFileName = null): PhpcsMessages {
+	public static function fromPhpcsJson(string $messages, ?string $forcedFileName = null): PhpcsMessages {
 		if (! boolval($messages)) {
 			return self::fromArrays([], $forcedFileName ?? 'STDIN');
 		}
@@ -43,7 +43,7 @@ class PhpcsMessagesHelpers {
 		return $reporter->getFormattedMessages($messages, []);
 	}
 
-	public static function fromArrays(array $messages, string $fileName = null): PhpcsMessages {
+	public static function fromArrays(array $messages, ?string $fileName = null): PhpcsMessages {
 		return new PhpcsMessages(array_map(function(array $messageArray) use ($fileName) {
 			return new LintMessage($messageArray['line'] ?? 0, $fileName, $messageArray['type'] ?? 'ERROR', $messageArray);
 		}, $messages));

--- a/PhpcsChanged/UnixShell.php
+++ b/PhpcsChanged/UnixShell.php
@@ -94,7 +94,7 @@ class UnixShell implements ShellOperator {
 		return 'vendor/bin/phpcs';
 	}
 
-	protected function executeCommand(string $command, int &$return_val = null): string {
+	protected function executeCommand(string $command, ?int &$return_val = null): string {
 		$output = [];
 		exec($command, $output, $return_val);
 		return implode(PHP_EOL, $output) . PHP_EOL;

--- a/tests/helpers/SvnFixture.php
+++ b/tests/helpers/SvnFixture.php
@@ -44,7 +44,7 @@ Added: svn:eol-style
 EOF;
 	}
 
-	public function getSvnInfo(string $filename, string $revision = '188280', string $lastChangedRevision = null): string {
+	public function getSvnInfo(string $filename, string $revision = '188280', ?string $lastChangedRevision = null): string {
 		$lastChangedRevision = $lastChangedRevision ?? $revision;
 		return <<<EOF
 Path: {$filename}

--- a/tests/helpers/TestShell.php
+++ b/tests/helpers/TestShell.php
@@ -85,7 +85,7 @@ class TestShell extends UnixShell {
 		return $this->fileHashes[$fileName] ?? $fileName;
 	}
 
-	protected function executeCommand(string $command, int &$return_val = null): string {
+	protected function executeCommand(string $command, ?int &$return_val = null): string {
 		foreach ($this->commands as $registeredCommand => $return) {
 			if ($registeredCommand === substr($command, 0, strlen($registeredCommand)) ) {
 				$return_val = $return['return_val'];


### PR DESCRIPTION
## What
Fixes deprecation warnings on PHP 8.4 - see https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated

For example:
```
Deprecated: PhpcsChanged\shouldIgnorePath(): Implicitly marking parameter $patternOption as nullable is deprecated, the explicit nullable type must be used instead in phpcs-changed/PhpcsChanged/Cli.php on line 454
Deprecated: PhpcsChanged\LintMessages::fromLintMessages(): Implicitly marking parameter $fileName as nullable is deprecated, the explicit nullable type must be used instead in phpcs-changed/PhpcsChanged/LintMessages.php on line 36
Deprecated: PhpcsChanged\PhpcsMessages::fromPhpcsJson(): Implicitly marking parameter $forcedFileName as nullable is deprecated, the explicit nullable type must be used instead in phpcs-changed/PhpcsChanged/PhpcsMessages.php on line 14
Deprecated: PhpcsChanged\PhpcsMessages::fromArrays(): Implicitly marking parameter $fileName as nullable is deprecated, the explicit nullable type must be used instead in phpcs-changed/PhpcsChanged/PhpcsMessages.php on line 18
Deprecated: PhpcsChanged\PhpcsMessagesHelpers::fromPhpcsJson(): Implicitly marking parameter $forcedFileName as nullable is deprecated, the explicit nullable type must be used instead in phpcs-changed/PhpcsChanged/PhpcsMessagesHelpers.php on line 11
Deprecated: PhpcsChanged\PhpcsMessagesHelpers::fromArrays(): Implicitly marking parameter $fileName as nullable is deprecated, the explicit nullable type must be used instead in phpcs-changed/PhpcsChanged/PhpcsMessagesHelpers.php on line 46
Deprecated: PhpcsChanged\UnixShell::executeCommand(): Implicitly marking parameter $return_val as nullable is deprecated, the explicit nullable type must be used instead in phpcs-changed/PhpcsChanged/UnixShell.php on line 97
Deprecated: PhpcsChanged\CacheManager::__construct(): Implicitly marking parameter $debug as nullable is deprecated, the explicit nullable type must be used instead in phpcs-changed/PhpcsChanged/CacheManager.php on line 48
Deprecated: PhpcsChangedTests\SvnFixture::getSvnInfo(): Implicitly marking parameter $lastChangedRevision as nullable is deprecated, the explicit nullable type must be used instead in phpcs-changed/tests/helpers/SvnFixture.php on line 47
Deprecated: PhpcsChangedTests\TestShell::executeCommand(): Implicitly marking parameter $return_val as nullable is deprecated, the explicit nullable type must be used instead in phpcs-changed/tests/helpers/TestShell.php on line 88
```

## Testing
<img width="572" alt="sirbrillig-phpcs-changed-php84" src="https://github.com/user-attachments/assets/520a3b2f-e365-4d5e-b5a1-50b54a9904e5" />