### PR TITLE
Update require for phpcodesniffer-composer-installer to allow 1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
 		"php": "^7.1 || ^8.0"
 	},
 	"require-dev": {
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.1 || ^1.0.0",
 		"phpunit/phpunit": "^6.4 || ^9.5",
 		"squizlabs/php_codesniffer": "^3.2.1",
 		"sirbrillig/phpcs-variable-analysis": "^2.1.3",

--- a/composer.json
+++ b/composer.json
@@ -1,49 +1,44 @@
 {
-    "name": "sirbrillig/phpcs-changed",
-    "description": "Run phpcs on files, but only report warnings/errors from lines which were changed.",
-    "type": "library",
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "Payton Swick",
-            "email": "payton@foolord.com"
-        }
-    ],
-    "minimum-stability": "dev",
-    "prefer-stable": true,
-    "scripts": {
-        "precommit": "composer test && composer lint && composer static-analysis",
-        "test": "./vendor/bin/phpunit --color=always --verbose",
-        "lint": "./vendor/bin/phpcs -s PhpcsChanged bin tests index.php",
-        "psalm": "./vendor/bin/psalm --no-cache bin/phpcs-changed",
-        "static-analysis": "composer psalm"
-    },
-    "bin": [
-        "bin/phpcs-changed"
-    ],
-    "config": {
-        "sort-order": true,
-        "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true
-        }
-    },
-    "autoload": {
-        "psr-4": {
-            "PhpcsChanged\\": "PhpcsChanged/"
-        },
-        "files": [
-            "PhpcsChanged/Cli.php",
-            "PhpcsChanged/functions.php"
-        ]
-    },
-    "require": {
-        "php": "^7.1 || ^8.0"
-    },
-    "require-dev": {
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
-        "phpunit/phpunit": "^6.4 || ^9.5",
-        "squizlabs/php_codesniffer": "^3.2.1",
-        "sirbrillig/phpcs-variable-analysis": "^2.1.3",
-        "vimeo/psalm": "^0.2 || ^0.3 || ^1.1 || ^4.24 || ^5.0@beta"
-    }
+	"name": "sirbrillig/phpcs-changed",
+	"description": "Run phpcs on files, but only report warnings/errors from lines which were changed.",
+	"type": "library",
+	"license": "MIT",
+	"authors": [
+		{
+			"name": "Payton Swick",
+			"email": "payton@foolord.com"
+		}
+	],
+	"minimum-stability": "dev",
+	"prefer-stable": true,
+	"scripts": {
+		"precommit": "composer test && composer lint && composer static-analysis",
+		"test": "./vendor/bin/phpunit --color=always --verbose",
+		"lint": "./vendor/bin/phpcs -s PhpcsChanged bin tests index.php",
+		"psalm": "./vendor/bin/psalm --no-cache bin/phpcs-changed",
+		"static-analysis": "composer psalm"
+	},
+	"bin": ["bin/phpcs-changed"],
+	"config": {
+		"sort-order": true,
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
+	},
+	"autoload": {
+		"psr-4": {
+			"PhpcsChanged\\": "PhpcsChanged/"
+		},
+		"files": ["PhpcsChanged/Cli.php", "PhpcsChanged/functions.php"]
+	},
+	"require": {
+		"php": "^7.1 || ^8.0"
+	},
+	"require-dev": {
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
+		"phpunit/phpunit": "^6.4 || ^9.5",
+		"squizlabs/php_codesniffer": "^3.2.1",
+		"sirbrillig/phpcs-variable-analysis": "^2.1.3",
+		"vimeo/psalm": "^0.2 || ^0.3 || ^1.1 || ^4.24 || ^5.0@beta"
+	}
 }


### PR DESCRIPTION
This updates the dependency of `phpcodesniffer-composer-installer` to allow for version 1.0 which has been out for some time.