### PR TITLE
Git Workflow: do not use just the filename, but full path in reporting

### DIFF
--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -335,7 +335,6 @@ function runGitWorkflowForFile(string $gitFile, CliOptions $options, ShellOperat
 	$phpcsStandard = $options->phpcsStandard;
 	$warningSeverity = $options->warningSeverity;
 	$errorSeverity = $options->errorSeverity;
-	$fileName = $shell->getFileNameFromPath($gitFile);
 
 	try {
 		if (! $shell->isReadable($gitFile)) {
@@ -356,7 +355,7 @@ function runGitWorkflowForFile(string $gitFile, CliOptions $options, ShellOperat
 			}
 		}
 
-		$modifiedFilePhpcsMessages = PhpcsMessages::fromPhpcsJson($modifiedFilePhpcsOutput, $fileName);
+		$modifiedFilePhpcsMessages = PhpcsMessages::fromPhpcsJson($modifiedFilePhpcsOutput, $gitFile);
 		$hasNewPhpcsMessages = count($modifiedFilePhpcsMessages->getMessages()) > 0;
 
 		$unifiedDiff = '';
@@ -398,7 +397,7 @@ function runGitWorkflowForFile(string $gitFile, CliOptions $options, ShellOperat
 	}
 
 	$debug('processing data...');
-	return getNewPhpcsMessages($unifiedDiff, PhpcsMessages::fromPhpcsJson($unmodifiedFilePhpcsOutput, $fileName), $modifiedFilePhpcsMessages);
+	return getNewPhpcsMessages($unifiedDiff, PhpcsMessages::fromPhpcsJson($unmodifiedFilePhpcsOutput, $gitFile), $modifiedFilePhpcsMessages);
 }
 
 function reportMessagesAndExit(PhpcsMessages $messages, CliOptions $options, ShellOperator $shell): void {


### PR DESCRIPTION
Changes the `runGitWorkflowForFile` the way it uses the passed in path for a file, instead of just the filename, during reporting in order to fix the incorrectly reported issues in new files with same filename, but different paths.

A test covering the edge case is also included.

fixes #104