### PR TITLE
Add benchmark script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 vendor
 composer.lock
+.bench-trunk/
+benchmark-results.md

--- a/BENCHMARKING.md
+++ b/BENCHMARKING.md
@@ -1,0 +1,113 @@
+# Benchmarking phpcs-changed
+
+`benchmark.sh` measures the wall-clock time of running `phpcs-changed --git-staged`
+against a set of changed PHP files, and compares the current branch to `trunk`.
+
+It uses [hyperfine](https://github.com/sharkdp/hyperfine) for statistical
+measurement and a self-contained throwaway git repo for reproducible test inputs.
+
+## Prerequisites
+
+```bash
+brew install hyperfine   # macOS
+composer install         # ensure vendor/bin/phpcs is present
+```
+
+## Running the benchmark
+
+```bash
+./benchmark.sh
+```
+
+By default this benchmarks **10 staged PHP files**, **10 measurement runs**,
+and **2 warmup runs**. All three are tunable via environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `N_FILES` | `10` | Number of changed PHP files in the test scenario |
+| `RUNS` | `10` | Hyperfine measurement runs per command |
+| `WARMUP` | `2` | Hyperfine warmup runs (excluded from results) |
+
+Examples:
+
+```bash
+# Quicker smoke test
+N_FILES=5 RUNS=3 WARMUP=1 ./benchmark.sh
+
+# Higher-confidence results with more files
+N_FILES=20 RUNS=20 ./benchmark.sh
+```
+
+Results are written to `benchmark-results.md` (Markdown table, suitable for
+pasting into a PR description).
+
+## How it works
+
+### Test environment
+
+The script creates a temporary git repo containing `N_FILES` PHP files.
+Each file has two committed versions:
+
+- **HEAD (unmodified)** — contains `TRUE` and `FALSE` uppercase constants,
+  which are PSR2 violations. Having violations in the committed version
+  ensures the "scan unmodified file" code path is exercised on every file.
+- **Staged (modified)** — the HEAD content plus a new function using `NULL`,
+  adding a third PSR2 violation.
+
+Because both versions have violations, every benchmarked call must do a full
+scan of both the modified and unmodified file for every file in the list.
+This is the worst case for the per-file approach and the fairest comparison.
+
+### Trunk worktree
+
+The script uses `git worktree add` to check out `trunk` as a sibling directory
+(`.bench-trunk/`) so both branches can be invoked without switching branches.
+The worktree is created on the first run and reused on subsequent runs.
+
+### What is being compared
+
+| Branch | phpcs invocations per run |
+|--------|--------------------------|
+| trunk | up to `2 × N_FILES` — one per file per version (modified + unmodified) |
+| feature branch | 1 — all file versions batched into a single phpcs call |
+
+The dominant cost in each phpcs invocation is **process startup** (~250–400 ms
+on typical hardware). The batch approach eliminates `2 × N_FILES − 1` of those
+startups.
+
+## Interpreting results
+
+Hyperfine reports mean time, standard deviation, and a relative speedup ratio.
+Example output for `N_FILES=10`:
+
+```
+Benchmark 1: batch (a75e2c2): 1 phpcs call
+  Time (mean ± σ):      2.44 s ±  0.05 s
+Benchmark 2: trunk (5c9f6b2): 20 phpcs calls
+  Time (mean ± σ):      5.74 s ±  0.11 s
+
+Summary: batch ran 2.36 ± 0.06 times faster than trunk
+```
+
+The speedup scales roughly linearly with `N_FILES`. A project with 20 changed
+files should see approximately twice the speedup of a 10-file project.
+
+The batch variant carries its own overhead (temp directory creation, one file
+write per file version, one phpcs invocation on all files). This overhead
+appears as a baseline cost that does not scale with `N_FILES`, so the
+crossover point where batching wins is low — roughly 2 or more files.
+
+## Artifacts
+
+The following files are created outside the git index and are gitignored:
+
+| Path | Description |
+|------|-------------|
+| `.bench-trunk/` | `git worktree` checkout of `trunk` |
+| `benchmark-results.md` | Hyperfine markdown export from the last run |
+
+To remove the worktree when you no longer need it:
+
+```bash
+git worktree remove .bench-trunk
+```

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# benchmark.sh — compare batch-phpcs-invocations branch vs trunk
+#
+# Usage:
+#   ./benchmark.sh
+#
+# Environment variables (all optional):
+#   N_FILES=10   number of changed PHP files to scan
+#   RUNS=10      hyperfine measurement runs
+#   WARMUP=2     hyperfine warmup runs
+#
+# Artifacts left in the repo root (not tracked by git):
+#   .bench-trunk/          git worktree for trunk (reused on subsequent runs)
+#   benchmark-results.md   hyperfine markdown export
+
+set -euo pipefail
+
+# ── Paths ──────────────────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BATCH_BIN="$SCRIPT_DIR/bin/phpcs-changed"
+TRUNK_WORKTREE="$SCRIPT_DIR/.bench-trunk"
+TRUNK_BIN="$TRUNK_WORKTREE/bin/phpcs-changed"
+PHPCS="$SCRIPT_DIR/vendor/bin/phpcs"
+RESULTS_FILE="$SCRIPT_DIR/benchmark-results.md"
+
+# ── Tuneable ───────────────────────────────────────────────────────────────
+N_FILES=${N_FILES:-10}
+RUNS=${RUNS:-10}
+WARMUP=${WARMUP:-2}
+
+# ── Sanity checks ─────────────────────────────────────────────────────────
+command -v hyperfine >/dev/null 2>&1 \
+  || { echo "ERROR: hyperfine not found. Install with: brew install hyperfine"; exit 1; }
+[ -f "$PHPCS" ] \
+  || { echo "ERROR: phpcs not found at $PHPCS. Run: composer install"; exit 1; }
+
+# ── 1. Trunk worktree ─────────────────────────────────────────────────────
+if [ ! -d "$TRUNK_WORKTREE" ]; then
+  echo "→ Creating trunk worktree at $TRUNK_WORKTREE …"
+  git -C "$SCRIPT_DIR" worktree add "$TRUNK_WORKTREE" trunk
+else
+  echo "→ Trunk worktree already exists."
+fi
+
+# ── 2. Ephemeral benchmark git repo ───────────────────────────────────────
+BENCH_REPO="$(mktemp -d)"
+trap 'rm -rf "$BENCH_REPO"' EXIT
+
+git -C "$BENCH_REPO" init -q
+git -C "$BENCH_REPO" config user.email "bench@example.com"
+git -C "$BENCH_REPO" config user.name "Benchmark"
+
+# Create initial PHP files with PSR2 violations (uppercase TRUE / FALSE).
+# Both the committed and staged versions have violations so trunk will always
+# scan both file versions — giving it 2×N_FILES phpcs invocations.
+echo "→ Preparing $N_FILES PHP test files …"
+FILES=()
+for i in $(seq 1 "$N_FILES"); do
+  fname="file${i}.php"
+
+  # Committed (HEAD) version ─ existing violations: TRUE, FALSE
+  cat > "$BENCH_REPO/$fname" << PHPEOF
+<?php
+class Foo${i}
+{
+    public function check(): bool
+    {
+        \$a = TRUE;
+        return \$a;
+    }
+
+    public function invert(): bool
+    {
+        \$b = FALSE;
+        return !\$b;
+    }
+}
+PHPEOF
+
+  FILES+=("$fname")
+  git -C "$BENCH_REPO" add "$fname"
+done
+git -C "$BENCH_REPO" commit -q -m "initial commit"
+
+# Staged version ─ add a new violation to each file
+for i in $(seq 1 "$N_FILES"); do
+  fname="file${i}.php"
+  cat >> "$BENCH_REPO/$fname" << PHPEOF
+
+function helper${i}(): void
+{
+    \$v = NULL;
+    echo \$v;
+}
+PHPEOF
+  git -C "$BENCH_REPO" add "$fname"
+done
+
+# ── 3. Run hyperfine ──────────────────────────────────────────────────────
+FILES_STR="${FILES[*]}"
+BATCH_SHA="$(git -C "$SCRIPT_DIR" rev-parse --short HEAD)"
+TRUNK_SHA="$(git -C "$TRUNK_WORKTREE" rev-parse --short HEAD)"
+
+BATCH_CMD="php '$BATCH_BIN' --git-staged --phpcs-path='$PHPCS' --standard=PSR2 --always-exit-zero $FILES_STR"
+TRUNK_CMD="php '$TRUNK_BIN' --git-staged --phpcs-path='$PHPCS' --standard=PSR2 --always-exit-zero $FILES_STR"
+
+echo ""
+printf "Benchmark: %d staged PHP files, --standard=PSR2\n" "$N_FILES"
+printf "  batch  %s  — 1 phpcs invocation (all files in one shot)\n" "$BATCH_SHA"
+printf "  trunk  %s  — up to %d phpcs invocations (2 per file)\n" "$TRUNK_SHA" "$((N_FILES * 2))"
+echo ""
+
+cd "$BENCH_REPO"
+# shellcheck disable=SC2086
+hyperfine \
+  --warmup "$WARMUP" \
+  --runs   "$RUNS" \
+  -n "batch ($BATCH_SHA): 1 phpcs call" \
+  -n "trunk ($TRUNK_SHA): $((N_FILES * 2)) phpcs calls" \
+  "$BATCH_CMD" \
+  "$TRUNK_CMD" \
+  --export-markdown "$RESULTS_FILE"
+
+echo ""
+echo "Results written to $RESULTS_FILE"


### PR DESCRIPTION
## Summary

- Adds `benchmark.sh`, a self-contained script that uses [hyperfine](https://github.com/sharkdp/hyperfine) to measure the wall-clock time of `phpcs-changed --git-staged` and compare the current branch against `trunk`
- Adds `BENCHMARKING.md` documenting prerequisites, usage, tunable parameters, methodology, and how to interpret results
- Updates `.gitignore` to exclude the benchmark worktree (`.bench-trunk/`) and results file (`benchmark-results.md`)

This is intended as a durable utility for evaluating future performance work, not tied to any specific branch.

## Usage

```bash
brew install hyperfine   # if not already installed
./benchmark.sh
```

Output:
```
Benchmark: 10 staged PHP files, --standard=PSR2
  batch  a75e2c2  — 1 phpcs invocation (all files in one shot)
  trunk  5c9f6b2  — up to 20 phpcs invocations (2 per file)

Benchmark 1: batch (a75e2c2): 1 phpcs call
  Time (mean ± σ):      2.44 s ±  0.05 s
Benchmark 2: trunk (5c9f6b2): 20 phpcs calls
  Time (mean ± σ):      5.74 s ±  0.11 s

Summary: batch ran 2.36 ± 0.06 times faster than trunk
```

Tunable via env vars (`N_FILES`, `RUNS`, `WARMUP`). Results are written to `benchmark-results.md` on each run.

## How it works

The script creates a throwaway git repo with `N_FILES` PHP files, each committed with existing PSR2 violations (`TRUE`/`FALSE`) and staged with one additional violation (`NULL`). Both file versions having violations ensures the unmodified-scan code path is exercised on every file — the worst case for per-file invocations.

A `git worktree` of `trunk` is created at `.bench-trunk/` on first run and reused on subsequent runs, so both branches can be timed without switching branches.

## Test plan

- [x] `./benchmark.sh` runs to completion
- [x] `N_FILES=2 RUNS=1 WARMUP=0 ./benchmark.sh` smoke test passes
- [x] `benchmark-results.md` is written and contains a valid Markdown table
- [x] `.bench-trunk/` is not tracked by git