### PR TITLE
Add WindowsShell for native Windows support without WSL

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Normalize all text files to LF on checkout
+* text=auto eol=lf

--- a/.github/workflows/test-unix.yml
+++ b/.github/workflows/test-unix.yml
@@ -1,0 +1,59 @@
+name: Integration Test on Unix
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  integration-test-unix:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        php: ['8.1', '8.2']
+
+    name: "Unix integration: PHP ${{ matrix.php }}"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@v2
+
+      - name: Configure git for integration tests
+        run: |
+          git config user.email "test@example.com"
+          git config user.name "Test User"
+
+      # Stage a small change and run phpcs-changed in git-staged mode.
+      # This exercises on real Linux:
+      #   - 'type git' and 'type vendor/bin/phpcs' (executable validation)
+      #   - 'git show HEAD:...' and 'git show :0:...' (file content via git)
+      #   - 'git diff --staged --no-prefix ...' (diff generation)
+      - name: Integration test - git-staged mode
+        run: |
+          echo "// integration test" >> PhpcsChanged/UnixShell.php
+          git add PhpcsChanged/UnixShell.php
+          php bin/phpcs-changed --git-staged --always-exit-zero PhpcsChanged/UnixShell.php
+          git restore --staged PhpcsChanged/UnixShell.php
+          git restore PhpcsChanged/UnixShell.php
+
+      # Make an unstaged change and run phpcs-changed in git-unstaged mode.
+      # This exercises the Unix 'cat' command for reading local file contents.
+      - name: Integration test - git-unstaged mode
+        run: |
+          echo "// integration test" >> PhpcsChanged/UnixShell.php
+          php bin/phpcs-changed --git-unstaged --always-exit-zero PhpcsChanged/UnixShell.php
+          git restore PhpcsChanged/UnixShell.php

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -1,0 +1,70 @@
+name: Test on Windows
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-windows:
+    runs-on: windows-latest
+
+    strategy:
+      matrix:
+        php: ['8.1', '8.2']
+
+    name: "Windows: PHP ${{ matrix.php }}"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@v2
+
+      # Run the full PHPUnit suite on Windows.
+      # The Windows-specific tests use WindowsTestShell (mocked), so they run
+      # on any platform. This confirms the PHP code is Windows-compatible.
+      - name: Run PHPUnit tests
+        run: composer test
+
+      - name: Configure git for integration tests
+        run: |
+          git config user.email "test@example.com"
+          git config user.name "Test User"
+
+      # Stage a small change and run phpcs-changed in git-staged mode.
+      # This exercises on real Windows:
+      #   - 'where /q git' and 'where /q vendor/bin/phpcs.bat' (executable validation)
+      #   - 'git show HEAD:...' and 'git show :0:...' (file content via git)
+      #   - 'git diff --staged --no-prefix ...' (diff generation)
+      - name: Integration test - git-staged mode
+        shell: pwsh
+        run: |
+          Add-Content -Path "PhpcsChanged/WindowsShell.php" -Value "// integration test"
+          git add PhpcsChanged/WindowsShell.php
+          php bin/phpcs-changed --git-staged --always-exit-zero PhpcsChanged/WindowsShell.php
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          git restore --staged PhpcsChanged/WindowsShell.php
+          git restore PhpcsChanged/WindowsShell.php
+
+      # Make an unstaged change and run phpcs-changed in git-unstaged mode.
+      # This specifically exercises the Windows 'type' built-in, which is the
+      # key substitution for Unix 'cat' when reading local file contents.
+      - name: Integration test - git-unstaged mode (tests 'type' built-in)
+        shell: pwsh
+        run: |
+          Add-Content -Path "PhpcsChanged/WindowsShell.php" -Value "// integration test"
+          php bin/phpcs-changed --git-unstaged --always-exit-zero PhpcsChanged/WindowsShell.php
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          git restore PhpcsChanged/WindowsShell.php

--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -531,16 +531,10 @@ function shouldIgnorePath(string $path, ?string $patternOption = null): bool {
 			'*'   => '.*',
 		];
 
-		// We assume a / directory separator, as do the exclude rules
-		// most developers write, so we need a special case for any system
-		// that is different.
-		if (DIRECTORY_SEPARATOR === '\\') {
-			$replacements['/'] = '\\\\';
-		}
-
 		$pattern = strtr(strval($pattern), $replacements);
 
-		$testPath = $path;
+		// Normalize to forward slashes so patterns like "bin/" work on all platforms.
+		$testPath = str_replace('\\', '/', $path);
 
 		$pattern = '`'.$pattern.'`i';
 		if (preg_match($pattern, $testPath) === 1) {

--- a/PhpcsChanged/ShellPlatform.php
+++ b/PhpcsChanged/ShellPlatform.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace PhpcsChanged;
+
+/**
+ * Platform-specific shell operations used by ShellRunner to perform
+ * git/svn/phpcs workflows. Implementations provide OS-level behaviors
+ * that differ between Unix and Windows.
+ */
+interface ShellPlatform {
+	/**
+	 * Execute a shell command and return its combined output.
+	 */
+	public function executeCommand(string $command, ?int &$return_val = null): string;
+
+	/**
+	 * Validate that an executable exists and is runnable.
+	 *
+	 * @throws \Exception if the executable cannot be found.
+	 */
+	public function validateExecutableExists(string $name, string $command): void;
+
+	/**
+	 * Validate that the local-file-read executable exists.
+	 *
+	 * May be a no-op on platforms where a shell built-in is used (e.g. Windows 'type').
+	 */
+	public function validateCatExecutableExists(): void;
+
+	/**
+	 * Return the null device path used to suppress stderr (e.g. '/dev/null' or 'NUL').
+	 */
+	public function getDevNull(): string;
+
+	/**
+	 * Return a shell command string that prints $fileName's contents to stdout.
+	 */
+	public function getLocalFileContentsCommand(string $fileName): string;
+
+	/**
+	 * Return the path to the vendor-installed phpcs executable.
+	 */
+	public function getVendorPhpcsPath(): string;
+}

--- a/PhpcsChanged/ShellRunner.php
+++ b/PhpcsChanged/ShellRunner.php
@@ -1,0 +1,391 @@
+<?php
+declare(strict_types=1);
+
+namespace PhpcsChanged;
+
+use PhpcsChanged\ShellPlatform;
+use PhpcsChanged\CliOptions;
+use PhpcsChanged\Modes;
+use function PhpcsChanged\getDebug;
+
+/**
+ * Implements the shared git/svn/phpcs shell workflows.
+ *
+ * Platform-specific operations (executable validation, file reading, etc.)
+ * are delegated to the injected ShellPlatform instance, allowing both
+ * UnixShell and WindowsShell to use this logic without inheriting from
+ * a common base class.
+ */
+class ShellRunner {
+	/**
+	 * @var CliOptions
+	 */
+	private $options;
+
+	/**
+	 * @var ShellPlatform
+	 */
+	private $platform;
+
+	/**
+	 * The git-absolute paths to each git file keyed by filename.
+	 *
+	 * @var Array<string, string>
+	 */
+	private $fullPaths = [];
+
+	/**
+	 * The output of `svn info` for each svn file keyed by filename.
+	 *
+	 * @var Array<string, string>
+	 */
+	private $svnInfo = [];
+
+	public function __construct(CliOptions $options, ShellPlatform $platform) {
+		$this->options = $options;
+		$this->platform = $platform;
+	}
+
+	public function clearCaches(): void {
+		$this->fullPaths = [];
+		$this->svnInfo = [];
+	}
+
+	public function validateShellIsReady(): void {
+		if ($this->options->mode === Modes::MANUAL) {
+			$phpcs = $this->getPhpcsExecutable();
+			$this->platform->validateExecutableExists('phpcs', $phpcs);
+		}
+
+		if ($this->options->mode === Modes::SVN) {
+			$svn = $this->options->getExecutablePath('svn');
+			$this->platform->validateExecutableExists('svn', $svn);
+			$this->platform->validateCatExecutableExists();
+			$phpcs = $this->getPhpcsExecutable();
+			$this->platform->validateExecutableExists('phpcs', $phpcs);
+		}
+
+		if ($this->options->isGitMode()) {
+			$git = $this->options->getExecutablePath('git');
+			$this->platform->validateExecutableExists('git', $git);
+			$phpcs = $this->getPhpcsExecutable();
+			$this->platform->validateExecutableExists('phpcs', $phpcs);
+		}
+	}
+
+	private function getPhpcsExecutable(): string {
+		if (boolval($this->options->phpcsPath) || boolval(getenv('PHPCS'))) {
+			return $this->options->getExecutablePath('phpcs');
+		}
+		if (! $this->options->noVendorPhpcs && $this->doesPhpcsExistInVendor()) {
+			return $this->platform->getVendorPhpcsPath();
+		}
+		return 'phpcs';
+	}
+
+	private function doesPhpcsExistInVendor(): bool {
+		try {
+			$this->platform->validateExecutableExists('phpcs', $this->platform->getVendorPhpcsPath());
+		} catch (\Exception $err) {
+			return false;
+		}
+		return true;
+	}
+
+	public function getPhpcsStandards(): string {
+		$phpcs = $this->getPhpcsExecutable();
+		return $this->platform->executeCommand("{$phpcs} -i");
+	}
+
+	private function doesFileExistInGitBase(string $fileName): bool {
+		$debug = getDebug($this->options->debug);
+		$git = $this->options->getExecutablePath('git');
+		$gitStatusCommand = "{$git} cat-file -e " . escapeshellarg($this->options->gitBase) . ':' . escapeshellarg($this->getFullGitPathToFile($fileName)) . ' 2>' . $this->platform->getDevNull();
+		$debug('checking status of file with command:', $gitStatusCommand);
+		/** @var int */
+		$return_val = 1;
+		$gitStatusOutput = $this->platform->executeCommand($gitStatusCommand, $return_val);
+		$debug('status command output:', $gitStatusOutput);
+		$debug('status command return val:', $return_val);
+		return 0 !== $return_val;
+	}
+
+	private function getGitStatusForFile(string $fileName): string {
+		$debug = getDebug($this->options->debug);
+		$git = $this->options->getExecutablePath('git');
+		$gitStatusCommand = "{$git} status --porcelain " . escapeshellarg($fileName);
+		$debug('checking git status of file with command:', $gitStatusCommand);
+		$gitStatusOutput = $this->platform->executeCommand($gitStatusCommand);
+		$debug('git status output:', $gitStatusOutput);
+		return $gitStatusOutput;
+	}
+
+	private function isFileStagedForAdding(string $fileName): bool {
+		$gitStatusOutput = $this->getGitStatusForFile($fileName);
+		// The git status will be empty for tracked, unchanged files.
+		if (! $gitStatusOutput || false === strpos($gitStatusOutput, $fileName)) {
+			return false;
+		}
+		if (isset($gitStatusOutput[0]) && $gitStatusOutput[0] === '?') {
+			throw new ShellException("File does not appear to be tracked by git: '{$fileName}'");
+		}
+		return isset($gitStatusOutput[0]) && $gitStatusOutput[0] === 'A';
+	}
+
+	public function doesUnmodifiedFileExistInGit(string $fileName): bool {
+		if ($this->options->mode === Modes::GIT_BASE) {
+			return $this->doesFileExistInGitBase($fileName);
+		}
+		return $this->isFileStagedForAdding($fileName);
+	}
+
+	private function getFullGitPathToFile(string $fileName): string {
+		// Return cache if set.
+		if (array_key_exists($fileName, $this->fullPaths)) {
+			return $this->fullPaths[$fileName];
+		}
+
+		$debug = getDebug($this->options->debug);
+		$git = $this->options->getExecutablePath('git');
+
+		// Verify that the file exists in git before we try to get its full path.
+		// There's never a case where we'd be scanning a modified file that is not
+		// tracked by git (a new file must be staged because otherwise we wouldn't
+		// know it exists).
+		if (! $this->options->noVerifyGitFile) {
+			$gitStatusOutput = $this->getGitStatusForFile($fileName);
+			// The git status will be empty for tracked, unchanged files.
+			if (isset($gitStatusOutput[0]) && $gitStatusOutput[0] === '?') {
+				throw new ShellException("File does not appear to be tracked by git: '{$fileName}'");
+			}
+		}
+
+		$command = "{$git} ls-files --full-name " . escapeshellarg($fileName);
+		$debug('getting full path to file with command:', $command);
+		$fullPath = trim($this->platform->executeCommand($command));
+
+		// This will not change so we can cache it.
+		$this->fullPaths[$fileName] = $fullPath;
+		return $fullPath;
+	}
+
+	private function getModifiedFileContentsCommand(string $fileName): string {
+		$git = $this->options->getExecutablePath('git');
+		$fullPath = $this->getFullGitPathToFile($fileName);
+		if ($this->options->mode === Modes::GIT_BASE) {
+			// for git-base mode, we get the contents of the file from the HEAD version of the file in the current branch
+			return "{$git} show HEAD:" . escapeshellarg($fullPath);
+		}
+		if ($this->options->mode === Modes::GIT_UNSTAGED) {
+			// for git-unstaged mode, we get the contents of the file from the current working copy
+			return $this->platform->getLocalFileContentsCommand($fileName);
+		}
+		// default mode is git-staged, so we get the contents from the staged version of the file
+		return "{$git} show :0:" . escapeshellarg($fullPath);
+	}
+
+	private function getUnmodifiedFileContentsCommand(string $fileName): string {
+		$git = $this->options->getExecutablePath('git');
+		if ($this->options->mode === Modes::GIT_BASE) {
+			$rev = escapeshellarg($this->options->gitBase);
+		} else if ($this->options->mode === Modes::GIT_UNSTAGED) {
+			$rev = ':0'; // :0 in this case means "staged version or HEAD if there is no staged version"
+		} else {
+			// git-staged is the default
+			$rev = 'HEAD';
+		}
+		$fullPath = $this->getFullGitPathToFile($fileName);
+		return "{$git} show {$rev}:" . escapeshellarg($fullPath);
+	}
+
+	public function getGitHashOfModifiedFile(string $fileName): string {
+		$debug = getDebug($this->options->debug);
+		$git = $this->options->getExecutablePath('git');
+		$fileContentsCommand = $this->getModifiedFileContentsCommand($fileName);
+		$command = "{$fileContentsCommand} | {$git} hash-object --stdin";
+		$debug('running modified file git hash command:', $command);
+		$hash = $this->platform->executeCommand($command);
+		if (! $hash) {
+			throw new ShellException("Cannot get modified file hash for file '{$fileName}'");
+		}
+		$debug('modified file git hash command output:', $hash);
+		return $hash;
+	}
+
+	public function getGitHashOfUnmodifiedFile(string $fileName): string {
+		$debug = getDebug($this->options->debug);
+		$git = $this->options->getExecutablePath('git');
+		$fileContentsCommand = $this->getUnmodifiedFileContentsCommand($fileName);
+		$command = "{$fileContentsCommand} | {$git} hash-object --stdin";
+		$debug('running unmodified file git hash command:', $command);
+		$hash = $this->platform->executeCommand($command);
+		if (! $hash) {
+			throw new ShellException("Cannot get unmodified file hash for file '{$fileName}'");
+		}
+		$debug('unmodified file git hash command output:', $hash);
+		return $hash;
+	}
+
+	private function getPhpcsStandardOption(): string {
+		$phpcsStandard = $this->options->phpcsStandard ?? '';
+		$phpcsStandardOption = strlen($phpcsStandard) > 0 ? ' --standard=' . escapeshellarg($phpcsStandard) : '';
+		$warningSeverity = $this->options->warningSeverity ?? '';
+		$phpcsStandardOption .= strlen($warningSeverity) > 0 ? ' --warning-severity=' . escapeshellarg($warningSeverity) : '';
+		$errorSeverity = $this->options->errorSeverity ?? '';
+		$phpcsStandardOption .= strlen($errorSeverity) > 0 ? ' --error-severity=' . escapeshellarg($errorSeverity) : '';
+		return $phpcsStandardOption;
+	}
+
+	private function getPhpcsExtensionsOption(): string {
+		$phpcsExtensions = $this->options->phpcsExtensions ?? '';
+		return strlen($phpcsExtensions) > 0 ? ' --extensions=' . escapeshellarg($phpcsExtensions) : '';
+	}
+
+	public function getPhpcsOutputOfModifiedGitFile(string $fileName): string {
+		$debug = getDebug($this->options->debug);
+		$fileContentsCommand = $this->getModifiedFileContentsCommand($fileName);
+		$command = "{$fileContentsCommand} | " . $this->getPhpcsCommand($fileName);
+		$debug('running modified file phpcs command:', $command);
+		$modifiedFilePhpcsOutput = $this->platform->executeCommand($command);
+		return $this->processPhpcsOutput($fileName, 'modified', $modifiedFilePhpcsOutput);
+	}
+
+	public function getPhpcsOutputOfUnmodifiedGitFile(string $fileName): string {
+		$debug = getDebug($this->options->debug);
+		$unmodifiedFileContentsCommand = $this->getUnmodifiedFileContentsCommand($fileName);
+		$command = "{$unmodifiedFileContentsCommand} | " . $this->getPhpcsCommand($fileName);
+		$debug('running unmodified file phpcs command:', $command);
+		$unmodifiedFilePhpcsOutput = $this->platform->executeCommand($command);
+		return $this->processPhpcsOutput($fileName, 'unmodified', $unmodifiedFilePhpcsOutput);
+	}
+
+	public function getGitUnifiedDiff(string $fileName): string {
+		$debug = getDebug($this->options->debug);
+		$git = $this->options->getExecutablePath('git');
+		$objectOption = $this->options->mode === Modes::GIT_BASE ? ' ' . escapeshellarg($this->options->gitBase) . '...' : '';
+		$stagedOption = ! boolval($objectOption) && $this->options->mode !== Modes::GIT_UNSTAGED ? ' --staged' : '';
+		$unifiedDiffCommand = "{$git} diff{$stagedOption}{$objectOption} --no-prefix " . escapeshellarg($fileName);
+		$debug('running diff command:', $unifiedDiffCommand);
+		$unifiedDiff = $this->platform->executeCommand($unifiedDiffCommand);
+		if (! $unifiedDiff) {
+			throw new NoChangesException("Cannot get git diff for file '{$fileName}'; skipping");
+		}
+		$debug('diff command output:', $unifiedDiff);
+		return $unifiedDiff;
+	}
+
+	public function getGitMergeBase(): string {
+		if ($this->options->mode !== Modes::GIT_BASE) {
+			return '';
+		}
+		$debug = getDebug($this->options->debug);
+		$git = $this->options->getExecutablePath('git');
+		$mergeBaseCommand = "{$git} merge-base " . escapeshellarg($this->options->gitBase) . ' HEAD';
+		$debug('running merge-base command:', $mergeBaseCommand);
+		$mergeBase = $this->platform->executeCommand($mergeBaseCommand);
+		if (! $mergeBase) {
+			$debug('merge-base command produced no output');
+			return $this->options->gitBase;
+		}
+		$debug('merge-base command output:', $mergeBase);
+		return trim($mergeBase);
+	}
+
+	public function getPhpcsOutputOfModifiedSvnFile(string $fileName): string {
+		$debug = getDebug($this->options->debug);
+		$command = $this->platform->getLocalFileContentsCommand($fileName) . ' | ' . $this->getPhpcsCommand($fileName);
+		$debug('running modified file phpcs command:', $command);
+		$modifiedFilePhpcsOutput = $this->platform->executeCommand($command);
+		return $this->processPhpcsOutput($fileName, 'modified', $modifiedFilePhpcsOutput);
+	}
+
+	public function getPhpcsOutputOfUnmodifiedSvnFile(string $fileName): string {
+		$debug = getDebug($this->options->debug);
+		$svn = $this->options->getExecutablePath('svn');
+		$command = "{$svn} cat " . escapeshellarg($fileName) . " | " . $this->getPhpcsCommand($fileName);
+		$debug('running unmodified file phpcs command:', $command);
+		$unmodifiedFilePhpcsOutput = $this->platform->executeCommand($command);
+		return $this->processPhpcsOutput($fileName, 'unmodified', $unmodifiedFilePhpcsOutput);
+	}
+
+	private function getPhpcsCommand(string $fileName): string {
+		$phpcs = $this->getPhpcsExecutable();
+		return "{$phpcs} --report=json -q" . $this->getPhpcsStandardOption() . $this->getPhpcsExtensionsOption() . ' --stdin-path=' . escapeshellarg($fileName) . ' -';
+	}
+
+	private function processPhpcsOutput(string $fileName, string $modifiedOrUnmodified, string $phpcsOutput): string {
+		$debug = getDebug($this->options->debug);
+		if (! $phpcsOutput) {
+			throw new ShellException("Cannot get {$modifiedOrUnmodified} file phpcs output for file '{$fileName}'");
+		}
+		$debug("{$modifiedOrUnmodified} file phpcs command output:", $phpcsOutput);
+		if (false !== strpos($phpcsOutput, 'You must supply at least one file or directory to process')) {
+			$debug("phpcs output implies {$modifiedOrUnmodified} file is empty");
+			return '';
+		}
+		return $phpcsOutput;
+	}
+
+	public function doesUnmodifiedFileExistInSvn(string $fileName): bool {
+		$svnFileInfo = $this->getSvnFileInfo($fileName);
+		return (false !== strpos($svnFileInfo, 'Schedule: add'));
+	}
+
+	public function getSvnRevisionId(string $fileName): string {
+		$svnFileInfo = $this->getSvnFileInfo($fileName);
+		preg_match('/\bLast Changed Rev:\s([^\n]+)/', $svnFileInfo, $matches);
+		// New files will not have a revision
+		return $matches[1] ?? '';
+	}
+
+	private function getSvnFileInfo(string $fileName): string {
+		// Return cache if set.
+		if (array_key_exists($fileName, $this->svnInfo)) {
+			return $this->svnInfo[$fileName];
+		}
+		$debug = getDebug($this->options->debug);
+		$svn = $this->options->getExecutablePath('svn');
+		$svnStatusCommand = "{$svn} info " . escapeshellarg($fileName);
+		$debug('checking svn status of file with command:', $svnStatusCommand);
+		$svnStatusOutput = $this->platform->executeCommand($svnStatusCommand);
+		$debug('svn status output:', $svnStatusOutput);
+		if (! $svnStatusOutput || false === strpos($svnStatusOutput, 'Schedule:')) {
+			throw new ShellException("Cannot get svn info for file '{$fileName}'");
+		}
+		// This will not change within a run so we can cache it.
+		$this->svnInfo[$fileName] = $svnStatusOutput;
+		return $svnStatusOutput;
+	}
+
+	public function getSvnUnifiedDiff(string $fileName): string {
+		$debug = getDebug($this->options->debug);
+		$svn = $this->options->getExecutablePath('svn');
+		$unifiedDiffCommand = "{$svn} diff " . escapeshellarg($fileName);
+		$debug('running diff command:', $unifiedDiffCommand);
+		$unifiedDiff = $this->platform->executeCommand($unifiedDiffCommand);
+		if (! $unifiedDiff) {
+			throw new NoChangesException("Cannot get svn diff for file '{$fileName}'; skipping");
+		}
+		$debug('diff command output:', $unifiedDiff);
+		return $unifiedDiff;
+	}
+
+	public function getPhpcsVersion(): string {
+		$phpcs = $this->getPhpcsExecutable();
+		$versionPhpcsOutput = $this->platform->executeCommand("{$phpcs} --version");
+		if (! $versionPhpcsOutput) {
+			throw new ShellException("Cannot get phpcs version");
+		}
+
+		$matched = preg_match('/version\\s([0-9.]+)/uim', $versionPhpcsOutput, $matches);
+		if (
+			$matched === false
+			|| count($matches) < 2
+			|| strlen($matches[1]) < 1
+		) {
+			throw new ShellException("Cannot parse phpcs version output");
+		}
+
+		return $matches[1];
+	}
+}

--- a/PhpcsChanged/UnixShell.php
+++ b/PhpcsChanged/UnixShell.php
@@ -4,408 +4,81 @@ declare(strict_types=1);
 namespace PhpcsChanged;
 
 use PhpcsChanged\ShellOperator;
+use PhpcsChanged\ShellPlatform;
 use PhpcsChanged\CliOptions;
-use PhpcsChanged\Modes;
 use function PhpcsChanged\printError;
-use function PhpcsChanged\getDebug;
 
 /**
- * Module to perform file and shell operations
+ * Unix ShellOperator implementation.
+ *
+ * Implements ShellPlatform with Unix-specific commands (cat, /dev/null, etc.)
+ * and delegates all shared git/svn/phpcs workflow logic to ShellRunner.
  */
-class UnixShell implements ShellOperator {
+class UnixShell implements ShellOperator, ShellPlatform {
 	/**
 	 * @var CliOptions
 	 */
-	protected $options;
+	private $options;
 
 	/**
-	 * The git-absolute paths to each git file keyed by filename.
-	 *
-	 * @var Array<string, string>
+	 * @var ShellRunner
 	 */
-	private $fullPaths = [];
-
-	/**
-	 * The output of `svn info` for each svn file keyed by filename.
-	 *
-	 * @var Array<string, string>
-	 */
-	private $svnInfo = [];
+	private $runner;
 
 	public function __construct(CliOptions $options) {
 		$this->options = $options;
+		$this->runner = new ShellRunner($options, $this);
 	}
+
+	// =========================================================================
+	// ShellPlatform implementation
+	// =========================================================================
 
 	#[\Override]
-	public function clearCaches(): void {
-		$this->fullPaths = [];
-		$this->svnInfo = [];
-	}
-
-	#[\Override]
-	public function validateShellIsReady(): void {
-		if ($this->options->mode === Modes::MANUAL) {
-			$phpcs = $this->getPhpcsExecutable();
-			$this->validateExecutableExists('phpcs', $phpcs);
-		}
-
-		if ($this->options->mode === Modes::SVN) {
-			$svn = $this->options->getExecutablePath('svn');
-			$this->validateExecutableExists('svn', $svn);
-			$this->validateCatExecutableExists();
-			$phpcs = $this->getPhpcsExecutable();
-			$this->validateExecutableExists('phpcs', $phpcs);
-		}
-
-		if ($this->options->isGitMode()) {
-			$git = $this->options->getExecutablePath('git');
-			$this->validateExecutableExists('git', $git);
-			$phpcs = $this->getPhpcsExecutable();
-			$this->validateExecutableExists('phpcs', $phpcs);
-		}
-	}
-
-	protected function validateExecutableExists(string $name, string $command): void {
-		exec(sprintf("type %s > /dev/null 2>&1", escapeshellarg($command)), $ignore, $returnVal);
-		if ($returnVal != 0) {
-			throw new \Exception("Cannot find executable for {$name}, currently set to '{$command}'.");
-		}
-	}
-
-	private function getPhpcsExecutable(): string {
-		if (boolval($this->options->phpcsPath) || boolval(getenv('PHPCS'))) {
-			return $this->options->getExecutablePath('phpcs');
-		}
-		if (! $this->options->noVendorPhpcs && $this->doesPhpcsExistInVendor()) {
-			return $this->getVendorPhpcsPath();
-		}
-		return 'phpcs';
-	}
-
-	private function doesPhpcsExistInVendor(): bool {
-		try {
-			$this->validateExecutableExists('phpcs', $this->getVendorPhpcsPath());
-		} catch (\Exception $err) {
-			return false;
-		}
-		return true;
-	}
-
-	protected function getVendorPhpcsPath(): string {
-		return 'vendor/bin/phpcs';
-	}
-
-	protected function getDevNull(): string {
-		return '/dev/null';
-	}
-
-	protected function validateCatExecutableExists(): void {
-		$cat = $this->options->getExecutablePath('cat');
-		$this->validateExecutableExists('cat', $cat);
-	}
-
-	protected function getLocalFileContentsCommand(string $fileName): string {
-		$cat = $this->options->getExecutablePath('cat');
-		return "{$cat} " . escapeshellarg($fileName);
-	}
-
-	protected function executeCommand(string $command, ?int &$return_val = null): string {
+	public function executeCommand(string $command, ?int &$return_val = null): string {
 		$output = [];
 		exec($command, $output, $return_val);
 		return implode(PHP_EOL, $output) . PHP_EOL;
 	}
 
 	#[\Override]
-	public function getPhpcsStandards(): string {
-		$phpcs = $this->getPhpcsExecutable();
-		$installedCodingStandardsPhpcsOutputCommand = "{$phpcs} -i";
-		return $this->executeCommand($installedCodingStandardsPhpcsOutputCommand);
-	}
-
-	private function doesFileExistInGitBase(string $fileName): bool {
-		$debug = getDebug($this->options->debug);
-		$git = $this->options->getExecutablePath('git');
-		$gitStatusCommand = "{$git} cat-file -e " . escapeshellarg($this->options->gitBase) . ':' . escapeshellarg($this->getFullGitPathToFile($fileName)) . ' 2>' . $this->getDevNull();
-		$debug('checking status of file with command:', $gitStatusCommand);
-		/** @var int */
-		$return_val = 1;
-		$gitStatusOutput = $this->executeCommand($gitStatusCommand, $return_val);
-		$debug('status command output:', $gitStatusOutput);
-		$debug('status command return val:', $return_val);
-		return 0 !== $return_val;
-	}
-
-	private function getGitStatusForFile(string $fileName): string {
-		$debug = getDebug($this->options->debug);
-		$git = $this->options->getExecutablePath('git');
-		$gitStatusCommand = "{$git} status --porcelain " . escapeshellarg($fileName);
-		$debug('checking git status of file with command:', $gitStatusCommand);
-		$gitStatusOutput = $this->executeCommand($gitStatusCommand);
-		$debug('git status output:', $gitStatusOutput);
-		return $gitStatusOutput;
-	}
-
-	private function isFileStagedForAdding(string $fileName): bool {
-		$gitStatusOutput = $this->getGitStatusForFile($fileName);
-		// The git status will be empty for tracked, unchanged files.
-		if (! $gitStatusOutput || false === strpos($gitStatusOutput, $fileName)) {
-			return false;
+	public function validateExecutableExists(string $name, string $command): void {
+		exec(sprintf("type %s > /dev/null 2>&1", escapeshellarg($command)), $ignore, $returnVal);
+		if ($returnVal != 0) {
+			throw new \Exception("Cannot find executable for {$name}, currently set to '{$command}'.");
 		}
-		if (isset($gitStatusOutput[0]) && $gitStatusOutput[0] === '?') {
-			throw new ShellException("File does not appear to be tracked by git: '{$fileName}'");
-		}
-		return isset($gitStatusOutput[0]) && $gitStatusOutput[0] === 'A';
 	}
 
 	#[\Override]
-	public function doesUnmodifiedFileExistInGit(string $fileName): bool {
-		if ($this->options->mode === Modes::GIT_BASE) {
-			return $this->doesFileExistInGitBase($fileName);
-		}
-		return $this->isFileStagedForAdding($fileName);
-	}
-
-	private function getFullGitPathToFile(string $fileName): string {
-		// Return cache if set.
-		if (array_key_exists($fileName, $this->fullPaths)) {
-			return $this->fullPaths[$fileName];
-		}
-
-		$debug = getDebug($this->options->debug);
-		$git = $this->options->getExecutablePath('git');
-
-		// Verify that the file exists in git before we try to get its full path.
-		// There's never a case where we'd be scanning a modified file that is not
-		// tracked by git (a new file must be staged because otherwise we wouldn't
-		// know it exists).
-		if (! $this->options->noVerifyGitFile) {
-			$gitStatusOutput = $this->getGitStatusForFile($fileName);
-			// The git status will be empty for tracked, unchanged files.
-			if (isset($gitStatusOutput[0]) && $gitStatusOutput[0] === '?') {
-				throw new ShellException("File does not appear to be tracked by git: '{$fileName}'");
-			}
-		}
-
-		$command = "{$git} ls-files --full-name " . escapeshellarg($fileName);
-		$debug('getting full path to file with command:', $command);
-		$fullPath = trim($this->executeCommand($command));
-
-		// This will not change so we can cache it.
-		$this->fullPaths[$fileName] = $fullPath;
-		return $fullPath;
-	}
-
-	private function getModifiedFileContentsCommand(string $fileName): string {
-		$git = $this->options->getExecutablePath('git');
-		$fullPath = $this->getFullGitPathToFile($fileName);
-		if ($this->options->mode === Modes::GIT_BASE) {
-			// for git-base mode, we get the contents of the file from the HEAD version of the file in the current branch
-			return "{$git} show HEAD:" . escapeshellarg($fullPath);
-		}
-		if ($this->options->mode === Modes::GIT_UNSTAGED) {
-			// for git-unstaged mode, we get the contents of the file from the current working copy
-			return $this->getLocalFileContentsCommand($fileName);
-		}
-		// default mode is git-staged, so we get the contents from the staged version of the file
-		return "{$git} show :0:" . escapeshellarg($fullPath);
-	}
-
-	private function getUnmodifiedFileContentsCommand(string $fileName): string {
-		$git = $this->options->getExecutablePath('git');
-		if ($this->options->mode === Modes::GIT_BASE) {
-			$rev = escapeshellarg($this->options->gitBase);
-		} else if ($this->options->mode === Modes::GIT_UNSTAGED) {
-			$rev = ':0'; // :0 in this case means "staged version or HEAD if there is no staged version"
-		} else {
-			// git-staged is the default
-			$rev = 'HEAD';
-		}
-		$fullPath = $this->getFullGitPathToFile($fileName);
-		return "{$git} show {$rev}:" . escapeshellarg($fullPath);
+	public function validateCatExecutableExists(): void {
+		$cat = $this->options->getExecutablePath('cat');
+		$this->validateExecutableExists('cat', $cat);
 	}
 
 	#[\Override]
-	public function getGitHashOfModifiedFile(string $fileName): string {
-		$debug = getDebug($this->options->debug);
-		$git = $this->options->getExecutablePath('git');
-		$fileContentsCommand = $this->getModifiedFileContentsCommand($fileName);
-		$command = "{$fileContentsCommand} | {$git} hash-object --stdin";
-		$debug('running modified file git hash command:', $command);
-		$hash = $this->executeCommand($command);
-		if (! $hash) {
-			throw new ShellException("Cannot get modified file hash for file '{$fileName}'");
-		}
-		$debug('modified file git hash command output:', $hash);
-		return $hash;
+	public function getDevNull(): string {
+		return '/dev/null';
 	}
 
 	#[\Override]
-	public function getGitHashOfUnmodifiedFile(string $fileName): string {
-		$debug = getDebug($this->options->debug);
-		$git = $this->options->getExecutablePath('git');
-		$fileContentsCommand = $this->getUnmodifiedFileContentsCommand($fileName);
-		$command = "{$fileContentsCommand} | {$git} hash-object --stdin";
-		$debug('running unmodified file git hash command:', $command);
-		$hash = $this->executeCommand($command);
-		if (! $hash) {
-			throw new ShellException("Cannot get unmodified file hash for file '{$fileName}'");
-		}
-		$debug('unmodified file git hash command output:', $hash);
-		return $hash;
-	}
-
-	private function getPhpcsStandardOption(): string {
-		$phpcsStandard = $this->options->phpcsStandard ?? '';
-		$phpcsStandardOption = strlen($phpcsStandard) > 0 ? ' --standard=' . escapeshellarg($phpcsStandard) : '';
-		$warningSeverity = $this->options->warningSeverity ?? '';
-		$phpcsStandardOption .= strlen($warningSeverity) > 0 ? ' --warning-severity=' . escapeshellarg($warningSeverity) : '';
-		$errorSeverity = $this->options->errorSeverity ?? '';
-		$phpcsStandardOption .= strlen($errorSeverity) > 0 ? ' --error-severity=' . escapeshellarg($errorSeverity) : '';
-		return $phpcsStandardOption;
-	}
-
-	private function getPhpcsExtensionsOption(): string {
-		$phpcsExtensions = $this->options->phpcsExtensions ?? '';
-		$phpcsExtensionsOption = strlen($phpcsExtensions) > 0 ? ' --extensions=' . escapeshellarg($phpcsExtensions) : '';
-		return $phpcsExtensionsOption;
+	public function getLocalFileContentsCommand(string $fileName): string {
+		$cat = $this->options->getExecutablePath('cat');
+		return "{$cat} " . escapeshellarg($fileName);
 	}
 
 	#[\Override]
-	public function getPhpcsOutputOfModifiedGitFile(string $fileName): string {
-		$debug = getDebug($this->options->debug);
-		$fileContentsCommand = $this->getModifiedFileContentsCommand($fileName);
-		$modifiedFilePhpcsOutputCommand = "{$fileContentsCommand} | " . $this->getPhpcsCommand($fileName);
-		$debug('running modified file phpcs command:', $modifiedFilePhpcsOutputCommand);
-		$modifiedFilePhpcsOutput = $this->executeCommand($modifiedFilePhpcsOutputCommand);
-		return $this->processPhpcsOutput($fileName, 'modified', $modifiedFilePhpcsOutput);
+	public function getVendorPhpcsPath(): string {
+		return 'vendor/bin/phpcs';
 	}
+
+	// =========================================================================
+	// ShellOperator — implemented directly (platform-specific or trivial)
+	// =========================================================================
 
 	#[\Override]
-	public function getPhpcsOutputOfUnmodifiedGitFile(string $fileName): string {
-		$debug = getDebug($this->options->debug);
-		$unmodifiedFileContentsCommand = $this->getUnmodifiedFileContentsCommand($fileName);
-		$unmodifiedFilePhpcsOutputCommand = "{$unmodifiedFileContentsCommand} | " . $this->getPhpcsCommand($fileName);
-		$debug('running unmodified file phpcs command:', $unmodifiedFilePhpcsOutputCommand);
-		$unmodifiedFilePhpcsOutput = $this->executeCommand($unmodifiedFilePhpcsOutputCommand);
-		return $this->processPhpcsOutput($fileName, 'unmodified', $unmodifiedFilePhpcsOutput);
-	}
-
-	#[\Override]
-	public function getGitUnifiedDiff(string $fileName): string {
-		$debug = getDebug($this->options->debug);
-		$git = $this->options->getExecutablePath('git');
-		$objectOption = $this->options->mode === Modes::GIT_BASE ? ' ' . escapeshellarg($this->options->gitBase) . '...' : '';
-		$stagedOption = ! boolval($objectOption) && $this->options->mode !== Modes::GIT_UNSTAGED ? ' --staged' : '';
-		$unifiedDiffCommand = "{$git} diff{$stagedOption}{$objectOption} --no-prefix " . escapeshellarg($fileName);
-		$debug('running diff command:', $unifiedDiffCommand);
-		$unifiedDiff = $this->executeCommand($unifiedDiffCommand);
-		if (! $unifiedDiff) {
-			throw new NoChangesException("Cannot get git diff for file '{$fileName}'; skipping");
-		}
-		$debug('diff command output:', $unifiedDiff);
-		return $unifiedDiff;
-	}
-
-	#[\Override]
-	public function getGitMergeBase(): string {
-		if ($this->options->mode !== Modes::GIT_BASE) {
-			return '';
-		}
-		$debug = getDebug($this->options->debug);
-		$git = $this->options->getExecutablePath('git');
-		$mergeBaseCommand = "{$git} merge-base " . escapeshellarg($this->options->gitBase) . ' HEAD';
-		$debug('running merge-base command:', $mergeBaseCommand);
-		$mergeBase = $this->executeCommand($mergeBaseCommand);
-		if (! $mergeBase) {
-			$debug('merge-base command produced no output');
-			return $this->options->gitBase;
-		}
-		$debug('merge-base command output:', $mergeBase);
-		return trim($mergeBase);
-	}
-
-	#[\Override]
-	public function getPhpcsOutputOfModifiedSvnFile(string $fileName): string {
-		$debug = getDebug($this->options->debug);
-		$modifiedFilePhpcsOutputCommand = $this->getLocalFileContentsCommand($fileName) . ' | ' . $this->getPhpcsCommand($fileName);
-		$debug('running modified file phpcs command:', $modifiedFilePhpcsOutputCommand);
-		$modifiedFilePhpcsOutput = $this->executeCommand($modifiedFilePhpcsOutputCommand);
-		return $this->processPhpcsOutput($fileName, 'modified', $modifiedFilePhpcsOutput);
-	}
-
-	#[\Override]
-	public function getPhpcsOutputOfUnmodifiedSvnFile(string $fileName): string {
-		$debug = getDebug($this->options->debug);
-		$svn = $this->options->getExecutablePath('svn');
-		$unmodifiedFilePhpcsOutputCommand = "{$svn} cat " . escapeshellarg($fileName) . " | " . $this->getPhpcsCommand($fileName);
-		$debug('running unmodified file phpcs command:', $unmodifiedFilePhpcsOutputCommand);
-		$unmodifiedFilePhpcsOutput = $this->executeCommand($unmodifiedFilePhpcsOutputCommand);
-		return $this->processPhpcsOutput($fileName, 'unmodified', $unmodifiedFilePhpcsOutput);
-	}
-
-	private function getPhpcsCommand(string $fileName): string {
-		$phpcs = $this->getPhpcsExecutable();
-		return "{$phpcs} --report=json -q" . $this->getPhpcsStandardOption() . $this->getPhpcsExtensionsOption() . ' --stdin-path=' .  escapeshellarg($fileName) . ' -';
-	}
-
-	private function processPhpcsOutput(string $fileName, string $modifiedOrUnmodified, string $phpcsOutput): string {
-		$debug = getDebug($this->options->debug);
-		if (! $phpcsOutput) {
-			throw new ShellException("Cannot get {$modifiedOrUnmodified} file phpcs output for file '{$fileName}'");
-		}
-		$debug("{$modifiedOrUnmodified} file phpcs command output:", $phpcsOutput);
-		if (false !== strpos($phpcsOutput, 'You must supply at least one file or directory to process')) {
-			$debug("phpcs output implies {$modifiedOrUnmodified} file is empty");
-			return '';
-		}
-		return $phpcsOutput;
-	}
-
-	#[\Override]
-	public function doesUnmodifiedFileExistInSvn(string $fileName): bool {
-		$svnFileInfo = $this->getSvnFileInfo($fileName);
-		return (false !== strpos($svnFileInfo, 'Schedule: add'));
-	}
-
-	#[\Override]
-	public function getSvnRevisionId(string $fileName): string {
-		$svnFileInfo = $this->getSvnFileInfo($fileName);
-		preg_match('/\bLast Changed Rev:\s([^\n]+)/', $svnFileInfo, $matches);
-		// New files will not have a revision
-		return $matches[1] ?? '';
-	}
-
-	private function getSvnFileInfo(string $fileName): string {
-		// Return cache if set.
-		if (array_key_exists($fileName, $this->svnInfo)) {
-			return $this->svnInfo[$fileName];
-		}
-		$debug = getDebug($this->options->debug);
-		$svn = $this->options->getExecutablePath('svn');
-		$svnStatusCommand = "{$svn} info " . escapeshellarg($fileName);
-		$debug('checking svn status of file with command:', $svnStatusCommand);
-		$svnStatusOutput = $this->executeCommand($svnStatusCommand);
-		$debug('svn status output:', $svnStatusOutput);
-		if (! $svnStatusOutput || false === strpos($svnStatusOutput, 'Schedule:')) {
-			throw new ShellException("Cannot get svn info for file '{$fileName}'");
-		}
-		// This will not change within a run so we can cache it.
-		$this->svnInfo[$fileName] = $svnStatusOutput;
-		return $svnStatusOutput;
-	}
-
-	#[\Override]
-	public function getSvnUnifiedDiff(string $fileName): string {
-		$debug = getDebug($this->options->debug);
-		$svn = $this->options->getExecutablePath('svn');
-		$unifiedDiffCommand = "{$svn} diff " . escapeshellarg($fileName);
-		$debug('running diff command:', $unifiedDiffCommand);
-		$unifiedDiff = $this->executeCommand($unifiedDiffCommand);
-		if (! $unifiedDiff) {
-			throw new NoChangesException("Cannot get svn diff for file '{$fileName}'; skipping");
-		}
-		$debug('diff command output:', $unifiedDiff);
-		return $unifiedDiff;
+	public function getFileNameFromPath(string $path): string {
+		$parts = explode('/', $path);
+		return end($parts);
 	}
 
 	#[\Override]
@@ -432,31 +105,87 @@ class UnixShell implements ShellOperator {
 		printError($message);
 	}
 
+	// =========================================================================
+	// ShellOperator — delegated to ShellRunner
+	// =========================================================================
+
 	#[\Override]
-	public function getFileNameFromPath(string $path): string {
-		$parts = explode('/', $path);
-		return end($parts);
+	public function clearCaches(): void {
+		$this->runner->clearCaches();
+	}
+
+	#[\Override]
+	public function validateShellIsReady(): void {
+		$this->runner->validateShellIsReady();
+	}
+
+	#[\Override]
+	public function getPhpcsStandards(): string {
+		return $this->runner->getPhpcsStandards();
+	}
+
+	#[\Override]
+	public function doesUnmodifiedFileExistInGit(string $fileName): bool {
+		return $this->runner->doesUnmodifiedFileExistInGit($fileName);
+	}
+
+	#[\Override]
+	public function doesUnmodifiedFileExistInSvn(string $fileName): bool {
+		return $this->runner->doesUnmodifiedFileExistInSvn($fileName);
+	}
+
+	#[\Override]
+	public function getGitHashOfModifiedFile(string $fileName): string {
+		return $this->runner->getGitHashOfModifiedFile($fileName);
+	}
+
+	#[\Override]
+	public function getGitHashOfUnmodifiedFile(string $fileName): string {
+		return $this->runner->getGitHashOfUnmodifiedFile($fileName);
+	}
+
+	#[\Override]
+	public function getPhpcsOutputOfModifiedGitFile(string $fileName): string {
+		return $this->runner->getPhpcsOutputOfModifiedGitFile($fileName);
+	}
+
+	#[\Override]
+	public function getPhpcsOutputOfUnmodifiedGitFile(string $fileName): string {
+		return $this->runner->getPhpcsOutputOfUnmodifiedGitFile($fileName);
+	}
+
+	#[\Override]
+	public function getPhpcsOutputOfModifiedSvnFile(string $fileName): string {
+		return $this->runner->getPhpcsOutputOfModifiedSvnFile($fileName);
+	}
+
+	#[\Override]
+	public function getPhpcsOutputOfUnmodifiedSvnFile(string $fileName): string {
+		return $this->runner->getPhpcsOutputOfUnmodifiedSvnFile($fileName);
+	}
+
+	#[\Override]
+	public function getGitUnifiedDiff(string $fileName): string {
+		return $this->runner->getGitUnifiedDiff($fileName);
+	}
+
+	#[\Override]
+	public function getGitMergeBase(): string {
+		return $this->runner->getGitMergeBase();
+	}
+
+	#[\Override]
+	public function getSvnRevisionId(string $fileName): string {
+		return $this->runner->getSvnRevisionId($fileName);
+	}
+
+	#[\Override]
+	public function getSvnUnifiedDiff(string $fileName): string {
+		return $this->runner->getSvnUnifiedDiff($fileName);
 	}
 
 	#[\Override]
 	public function getPhpcsVersion(): string {
-		$phpcs = $this->getPhpcsExecutable();
-
-		$versionPhpcsOutputCommand = "{$phpcs} --version";
-		$versionPhpcsOutput = $this->executeCommand($versionPhpcsOutputCommand);
-		if (! $versionPhpcsOutput) {
-			throw new ShellException("Cannot get phpcs version");
-		}
-
-		$matched = preg_match('/version\\s([0-9.]+)/uim', $versionPhpcsOutput, $matches);
-		if (
-			$matched === false
-			|| count($matches) < 2
-			|| strlen($matches[1]) < 1
-		) {
-			throw new ShellException("Cannot parse phpcs version output");
-		}
-
-		return $matches[1];
+		return $this->runner->getPhpcsVersion();
 	}
 }

--- a/PhpcsChanged/UnixShell.php
+++ b/PhpcsChanged/UnixShell.php
@@ -16,7 +16,7 @@ class UnixShell implements ShellOperator {
 	/**
 	 * @var CliOptions
 	 */
-	private $options;
+	protected $options;
 
 	/**
 	 * The git-absolute paths to each git file keyed by filename.
@@ -50,10 +50,9 @@ class UnixShell implements ShellOperator {
 		}
 
 		if ($this->options->mode === Modes::SVN) {
-			$cat = $this->options->getExecutablePath('cat');
 			$svn = $this->options->getExecutablePath('svn');
 			$this->validateExecutableExists('svn', $svn);
-			$this->validateExecutableExists('cat', $cat);
+			$this->validateCatExecutableExists();
 			$phpcs = $this->getPhpcsExecutable();
 			$this->validateExecutableExists('phpcs', $phpcs);
 		}
@@ -92,8 +91,22 @@ class UnixShell implements ShellOperator {
 		return true;
 	}
 
-	private function getVendorPhpcsPath(): string {
+	protected function getVendorPhpcsPath(): string {
 		return 'vendor/bin/phpcs';
+	}
+
+	protected function getDevNull(): string {
+		return '/dev/null';
+	}
+
+	protected function validateCatExecutableExists(): void {
+		$cat = $this->options->getExecutablePath('cat');
+		$this->validateExecutableExists('cat', $cat);
+	}
+
+	protected function getLocalFileContentsCommand(string $fileName): string {
+		$cat = $this->options->getExecutablePath('cat');
+		return "{$cat} " . escapeshellarg($fileName);
 	}
 
 	protected function executeCommand(string $command, ?int &$return_val = null): string {
@@ -112,7 +125,7 @@ class UnixShell implements ShellOperator {
 	private function doesFileExistInGitBase(string $fileName): bool {
 		$debug = getDebug($this->options->debug);
 		$git = $this->options->getExecutablePath('git');
-		$gitStatusCommand = "{$git} cat-file -e " . escapeshellarg($this->options->gitBase) . ':' . escapeshellarg($this->getFullGitPathToFile($fileName)) . ' 2>/dev/null';
+		$gitStatusCommand = "{$git} cat-file -e " . escapeshellarg($this->options->gitBase) . ':' . escapeshellarg($this->getFullGitPathToFile($fileName)) . ' 2>' . $this->getDevNull();
 		$debug('checking status of file with command:', $gitStatusCommand);
 		/** @var int */
 		$return_val = 1;
@@ -184,7 +197,6 @@ class UnixShell implements ShellOperator {
 
 	private function getModifiedFileContentsCommand(string $fileName): string {
 		$git = $this->options->getExecutablePath('git');
-		$cat = $this->options->getExecutablePath('cat');
 		$fullPath = $this->getFullGitPathToFile($fileName);
 		if ($this->options->mode === Modes::GIT_BASE) {
 			// for git-base mode, we get the contents of the file from the HEAD version of the file in the current branch
@@ -192,7 +204,7 @@ class UnixShell implements ShellOperator {
 		}
 		if ($this->options->mode === Modes::GIT_UNSTAGED) {
 			// for git-unstaged mode, we get the contents of the file from the current working copy
-			return "{$cat} " . escapeshellarg($fileName);
+			return $this->getLocalFileContentsCommand($fileName);
 		}
 		// default mode is git-staged, so we get the contents from the staged version of the file
 		return "{$git} show :0:" . escapeshellarg($fullPath);
@@ -315,8 +327,7 @@ class UnixShell implements ShellOperator {
 	#[\Override]
 	public function getPhpcsOutputOfModifiedSvnFile(string $fileName): string {
 		$debug = getDebug($this->options->debug);
-		$cat = $this->options->getExecutablePath('cat');
-		$modifiedFilePhpcsOutputCommand = "{$cat} " . escapeshellarg($fileName) . ' | ' . $this->getPhpcsCommand($fileName);
+		$modifiedFilePhpcsOutputCommand = $this->getLocalFileContentsCommand($fileName) . ' | ' . $this->getPhpcsCommand($fileName);
 		$debug('running modified file phpcs command:', $modifiedFilePhpcsOutputCommand);
 		$modifiedFilePhpcsOutput = $this->executeCommand($modifiedFilePhpcsOutputCommand);
 		return $this->processPhpcsOutput($fileName, 'modified', $modifiedFilePhpcsOutput);

--- a/PhpcsChanged/WindowsShell.php
+++ b/PhpcsChanged/WindowsShell.php
@@ -3,58 +3,50 @@ declare(strict_types=1);
 
 namespace PhpcsChanged;
 
+use PhpcsChanged\ShellOperator;
+use PhpcsChanged\ShellPlatform;
+use PhpcsChanged\CliOptions;
+use function PhpcsChanged\printError;
+
 /**
- * Windows-specific ShellOperator implementation for cmd.exe (no WSL required).
+ * Windows ShellOperator implementation (cmd.exe, no WSL required).
  *
- * Overrides Unix-specific idioms in UnixShell:
- * - Uses 'type' built-in instead of 'cat' for reading local files
- * - Uses 'NUL' instead of '/dev/null' for stderr suppression
- * - Uses 'where /q' instead of 'type' for executable discovery
- * - Uses 'vendor/bin/phpcs.bat' for vendor-installed phpcs
- * - Handles both forward and backslash path separators
+ * Implements ShellPlatform with Windows-specific commands:
+ * - 'type' built-in instead of 'cat' for reading local files
+ * - 'NUL' instead of '/dev/null' for stderr suppression
+ * - 'where /q' instead of 'type' for executable discovery
+ * - 'vendor/bin/phpcs.bat' for vendor-installed phpcs
+ * Delegates all shared git/svn/phpcs workflow logic to ShellRunner.
  */
-class WindowsShell extends UnixShell {
+class WindowsShell implements ShellOperator, ShellPlatform {
+	/**
+	 * @var CliOptions
+	 */
+	private $options;
+
+	/**
+	 * @var ShellRunner
+	 */
+	private $runner;
+
+	public function __construct(CliOptions $options) {
+		$this->options = $options;
+		$this->runner = new ShellRunner($options, $this);
+	}
+
+	// =========================================================================
+	// ShellPlatform implementation
+	// =========================================================================
+
 	#[\Override]
-	protected function getDevNull(): string {
-		return 'NUL';
+	public function executeCommand(string $command, ?int &$return_val = null): string {
+		$output = [];
+		exec($command, $output, $return_val);
+		return implode(PHP_EOL, $output) . PHP_EOL;
 	}
 
 	#[\Override]
-	protected function getLocalFileContentsCommand(string $fileName): string {
-		$cat = $this->options->getExecutablePath('cat');
-		if ($cat !== 'cat') {
-			// User has configured a custom cat executable; use it
-			return "{$cat} " . escapeshellarg($fileName);
-		}
-		// Use the Windows 'type' built-in command
-		return 'type ' . escapeshellarg($fileName);
-	}
-
-	#[\Override]
-	protected function validateCatExecutableExists(): void {
-		$cat = $this->options->getExecutablePath('cat');
-		if ($cat !== 'cat') {
-			// User has configured a custom cat executable; validate it exists
-			$this->validateExecutableExists('cat', $cat);
-		}
-		// Otherwise: 'type' is a Windows shell built-in, no validation needed
-	}
-
-	#[\Override]
-	protected function getVendorPhpcsPath(): string {
-		return 'vendor/bin/phpcs.bat';
-	}
-
-	#[\Override]
-	public function getFileNameFromPath(string $path): string {
-		// Handle both forward and backslashes for Windows paths
-		$normalized = str_replace('\\', '/', $path);
-		$parts = explode('/', $normalized);
-		return end($parts);
-	}
-
-	#[\Override]
-	protected function validateExecutableExists(string $name, string $command): void {
+	public function validateExecutableExists(string $name, string $command): void {
 		// Full or relative path — check that the file exists on disk
 		if (strpos($command, '/') !== false || strpos($command, '\\') !== false) {
 			if (!file_exists($command)) {
@@ -68,5 +60,156 @@ class WindowsShell extends UnixShell {
 		if ($returnVal != 0) {
 			throw new \Exception("Cannot find executable for {$name}, currently set to '{$command}'.");
 		}
+	}
+
+	#[\Override]
+	public function validateCatExecutableExists(): void {
+		$cat = $this->options->getExecutablePath('cat');
+		if ($cat !== 'cat') {
+			// User has configured a custom cat executable; validate it exists
+			$this->validateExecutableExists('cat', $cat);
+		}
+		// Otherwise: 'type' is a Windows shell built-in, no validation needed
+	}
+
+	#[\Override]
+	public function getDevNull(): string {
+		return 'NUL';
+	}
+
+	#[\Override]
+	public function getLocalFileContentsCommand(string $fileName): string {
+		$cat = $this->options->getExecutablePath('cat');
+		if ($cat !== 'cat') {
+			// User has configured a custom cat executable; use it
+			return "{$cat} " . escapeshellarg($fileName);
+		}
+		// Use the Windows 'type' built-in command
+		return 'type ' . escapeshellarg($fileName);
+	}
+
+	#[\Override]
+	public function getVendorPhpcsPath(): string {
+		return 'vendor/bin/phpcs.bat';
+	}
+
+	// =========================================================================
+	// ShellOperator — implemented directly (platform-specific or trivial)
+	// =========================================================================
+
+	#[\Override]
+	public function getFileNameFromPath(string $path): string {
+		// Handle both forward and backslashes for Windows paths
+		$normalized = str_replace('\\', '/', $path);
+		$parts = explode('/', $normalized);
+		return end($parts);
+	}
+
+	#[\Override]
+	public function isReadable(string $fileName): bool {
+		return is_readable($fileName);
+	}
+
+	#[\Override]
+	public function getFileHash(string $fileName): string {
+		$result = md5_file($fileName);
+		if ($result === false) {
+			throw new \Exception("Cannot get hash for file '{$fileName}'.");
+		}
+		return $result;
+	}
+
+	#[\Override]
+	public function exitWithCode(int $code): void {
+		exit($code);
+	}
+
+	#[\Override]
+	public function printError(string $message): void {
+		printError($message);
+	}
+
+	// =========================================================================
+	// ShellOperator — delegated to ShellRunner
+	// =========================================================================
+
+	#[\Override]
+	public function clearCaches(): void {
+		$this->runner->clearCaches();
+	}
+
+	#[\Override]
+	public function validateShellIsReady(): void {
+		$this->runner->validateShellIsReady();
+	}
+
+	#[\Override]
+	public function getPhpcsStandards(): string {
+		return $this->runner->getPhpcsStandards();
+	}
+
+	#[\Override]
+	public function doesUnmodifiedFileExistInGit(string $fileName): bool {
+		return $this->runner->doesUnmodifiedFileExistInGit($fileName);
+	}
+
+	#[\Override]
+	public function doesUnmodifiedFileExistInSvn(string $fileName): bool {
+		return $this->runner->doesUnmodifiedFileExistInSvn($fileName);
+	}
+
+	#[\Override]
+	public function getGitHashOfModifiedFile(string $fileName): string {
+		return $this->runner->getGitHashOfModifiedFile($fileName);
+	}
+
+	#[\Override]
+	public function getGitHashOfUnmodifiedFile(string $fileName): string {
+		return $this->runner->getGitHashOfUnmodifiedFile($fileName);
+	}
+
+	#[\Override]
+	public function getPhpcsOutputOfModifiedGitFile(string $fileName): string {
+		return $this->runner->getPhpcsOutputOfModifiedGitFile($fileName);
+	}
+
+	#[\Override]
+	public function getPhpcsOutputOfUnmodifiedGitFile(string $fileName): string {
+		return $this->runner->getPhpcsOutputOfUnmodifiedGitFile($fileName);
+	}
+
+	#[\Override]
+	public function getPhpcsOutputOfModifiedSvnFile(string $fileName): string {
+		return $this->runner->getPhpcsOutputOfModifiedSvnFile($fileName);
+	}
+
+	#[\Override]
+	public function getPhpcsOutputOfUnmodifiedSvnFile(string $fileName): string {
+		return $this->runner->getPhpcsOutputOfUnmodifiedSvnFile($fileName);
+	}
+
+	#[\Override]
+	public function getGitUnifiedDiff(string $fileName): string {
+		return $this->runner->getGitUnifiedDiff($fileName);
+	}
+
+	#[\Override]
+	public function getGitMergeBase(): string {
+		return $this->runner->getGitMergeBase();
+	}
+
+	#[\Override]
+	public function getSvnRevisionId(string $fileName): string {
+		return $this->runner->getSvnRevisionId($fileName);
+	}
+
+	#[\Override]
+	public function getSvnUnifiedDiff(string $fileName): string {
+		return $this->runner->getSvnUnifiedDiff($fileName);
+	}
+
+	#[\Override]
+	public function getPhpcsVersion(): string {
+		return $this->runner->getPhpcsVersion();
 	}
 }

--- a/PhpcsChanged/WindowsShell.php
+++ b/PhpcsChanged/WindowsShell.php
@@ -90,7 +90,7 @@ class WindowsShell implements ShellOperator, ShellPlatform {
 
 	#[\Override]
 	public function getVendorPhpcsPath(): string {
-		return 'vendor/bin/phpcs.bat';
+		return 'vendor\\bin\\phpcs.bat';
 	}
 
 	// =========================================================================

--- a/PhpcsChanged/WindowsShell.php
+++ b/PhpcsChanged/WindowsShell.php
@@ -1,0 +1,72 @@
+<?php
+declare(strict_types=1);
+
+namespace PhpcsChanged;
+
+/**
+ * Windows-specific ShellOperator implementation for cmd.exe (no WSL required).
+ *
+ * Overrides Unix-specific idioms in UnixShell:
+ * - Uses 'type' built-in instead of 'cat' for reading local files
+ * - Uses 'NUL' instead of '/dev/null' for stderr suppression
+ * - Uses 'where /q' instead of 'type' for executable discovery
+ * - Uses 'vendor/bin/phpcs.bat' for vendor-installed phpcs
+ * - Handles both forward and backslash path separators
+ */
+class WindowsShell extends UnixShell {
+	#[\Override]
+	protected function getDevNull(): string {
+		return 'NUL';
+	}
+
+	#[\Override]
+	protected function getLocalFileContentsCommand(string $fileName): string {
+		$cat = $this->options->getExecutablePath('cat');
+		if ($cat !== 'cat') {
+			// User has configured a custom cat executable; use it
+			return "{$cat} " . escapeshellarg($fileName);
+		}
+		// Use the Windows 'type' built-in command
+		return 'type ' . escapeshellarg($fileName);
+	}
+
+	#[\Override]
+	protected function validateCatExecutableExists(): void {
+		$cat = $this->options->getExecutablePath('cat');
+		if ($cat !== 'cat') {
+			// User has configured a custom cat executable; validate it exists
+			$this->validateExecutableExists('cat', $cat);
+		}
+		// Otherwise: 'type' is a Windows shell built-in, no validation needed
+	}
+
+	#[\Override]
+	protected function getVendorPhpcsPath(): string {
+		return 'vendor/bin/phpcs.bat';
+	}
+
+	#[\Override]
+	public function getFileNameFromPath(string $path): string {
+		// Handle both forward and backslashes for Windows paths
+		$normalized = str_replace('\\', '/', $path);
+		$parts = explode('/', $normalized);
+		return end($parts);
+	}
+
+	#[\Override]
+	protected function validateExecutableExists(string $name, string $command): void {
+		// Full or relative path — check that the file exists on disk
+		if (strpos($command, '/') !== false || strpos($command, '\\') !== false) {
+			if (!file_exists($command)) {
+				throw new \Exception("Cannot find executable for {$name}, currently set to '{$command}'.");
+			}
+			return;
+		}
+		// Bare command name — search PATH using Windows 'where' command
+		$ignore = [];
+		exec(sprintf('where /q %s', escapeshellarg($command)), $ignore, $returnVal);
+		if ($returnVal != 0) {
+			throw new \Exception("Cannot find executable for {$name}, currently set to '{$command}'.");
+		}
+	}
+}

--- a/bin/phpcs-changed
+++ b/bin/phpcs-changed
@@ -21,6 +21,7 @@ use function PhpcsChanged\{
 	printInstalledCodingStandards
 };
 use PhpcsChanged\UnixShell;
+use PhpcsChanged\WindowsShell;
 use PhpcsChanged\CacheManager;
 use PhpcsChanged\FileCache;
 use PhpcsChanged\CliOptions;
@@ -106,7 +107,7 @@ if (isset($options['version'])) {
 
 if (isset($options['i'])) {
 	$cliOptions = CliOptions::fromArray($options);
-	$shell = new UnixShell($cliOptions);
+	$shell = PHP_OS_FAMILY === 'Windows' ? new WindowsShell($cliOptions) : new UnixShell($cliOptions);
 	printInstalledCodingStandards($shell);
 }
 
@@ -150,8 +151,9 @@ function run(array $rawOptions, callable $debug): void {
 	}
 	$debug('Running on filenames: ' . implode(', ', $options->files));
 
+	$shell = PHP_OS_FAMILY === 'Windows' ? new WindowsShell($options) : new UnixShell($options);
+
 	if ($options->mode === Modes::MANUAL) {
-		$shell = new UnixShell($options);
 		reportMessagesAndExit(
 			runManualWorkflow($options->diffFile, $options->phpcsUnmodified, $options->phpcsModified),
 			$options,
@@ -161,7 +163,6 @@ function run(array $rawOptions, callable $debug): void {
 	}
 
 	if ($options->mode === Modes::SVN) {
-		$shell = new UnixShell($options);
 		reportMessagesAndExit(
 			runSvnWorkflow($options->files, $options, $shell, new CacheManager(new FileCache(), $debug), $debug),
 			$options,
@@ -171,7 +172,6 @@ function run(array $rawOptions, callable $debug): void {
 	}
 
 	if ($options->isGitMode()) {
-		$shell = new UnixShell($options);
 		reportMessagesAndExit(
 			runGitWorkflow($options, $shell, new CacheManager(new FileCache(), $debug), $debug),
 			$options,

--- a/index.php
+++ b/index.php
@@ -23,6 +23,8 @@ require_once __DIR__ . '/PhpcsChanged/CheckstyleReporter.php';
 require_once __DIR__ . '/PhpcsChanged/NoChangesException.php';
 require_once __DIR__ . '/PhpcsChanged/ShellException.php';
 require_once __DIR__ . '/PhpcsChanged/ShellOperator.php';
+require_once __DIR__ . '/PhpcsChanged/ShellPlatform.php';
+require_once __DIR__ . '/PhpcsChanged/ShellRunner.php';
 require_once __DIR__ . '/PhpcsChanged/UnixShell.php';
 require_once __DIR__ . '/PhpcsChanged/WindowsShell.php';
 require_once __DIR__ . '/PhpcsChanged/CacheEntry.php';

--- a/index.php
+++ b/index.php
@@ -24,6 +24,7 @@ require_once __DIR__ . '/PhpcsChanged/NoChangesException.php';
 require_once __DIR__ . '/PhpcsChanged/ShellException.php';
 require_once __DIR__ . '/PhpcsChanged/ShellOperator.php';
 require_once __DIR__ . '/PhpcsChanged/UnixShell.php';
+require_once __DIR__ . '/PhpcsChanged/WindowsShell.php';
 require_once __DIR__ . '/PhpcsChanged/CacheEntry.php';
 require_once __DIR__ . '/PhpcsChanged/CacheObject.php';
 require_once __DIR__ . '/PhpcsChanged/CacheInterface.php';

--- a/tests/GitWorkflowWindowsTest.php
+++ b/tests/GitWorkflowWindowsTest.php
@@ -1,0 +1,126 @@
+<?php
+declare(strict_types=1);
+
+require_once dirname(__DIR__) . '/index.php';
+require_once __DIR__ . '/helpers/helpers.php';
+
+use PHPUnit\Framework\TestCase;
+use PhpcsChanged\CacheManager;
+use PhpcsChanged\CliOptions;
+use PhpcsChanged\WindowsShell;
+use PhpcsChangedTests\WindowsTestShell;
+use PhpcsChangedTests\GitFixture;
+use PhpcsChangedTests\PhpcsFixture;
+use PhpcsChangedTests\TestCache;
+use function PhpcsChanged\runGitWorkflow;
+
+final class GitWorkflowWindowsTest extends TestCase {
+	public $fixture;
+	public $phpcs;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->fixture = new GitFixture();
+		$this->phpcs = new PhpcsFixture();
+	}
+
+	public function testFullGitWorkflowForOneFileStagedOnWindows() {
+		$gitFile = 'foobar.php';
+		$options = CliOptions::fromArray(['no-cache-git-root' => false, 'git-staged' => false, 'files' => [$gitFile]]);
+		$shell = new WindowsTestShell($options, [$gitFile]);
+		$shell->registerExecutable('git');
+		$shell->registerExecutable('phpcs');
+		$fixture = $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;');
+		$shell->registerCommand("git diff --staged --no-prefix 'foobar.php'", $fixture);
+		$shell->registerCommand("git status --porcelain 'foobar.php'", $this->fixture->getModifiedFileInfo('foobar.php'));
+		$shell->registerCommand("git ls-files --full-name 'foobar.php'", "files/foobar.php");
+		$shell->registerCommand("git show HEAD:'files/foobar.php' | phpcs", $this->phpcs->getResults('STDIN', [20])->toPhpcsJson());
+		$shell->registerCommand("git show :0:'files/foobar.php' | phpcs", $this->phpcs->getResults('STDIN', [20, 21], 'Found unused symbol Foobar.')->toPhpcsJson());
+		$shell->registerCommand("git rev-parse --show-toplevel", 'run-from-git-root');
+		$cache = new CacheManager(new TestCache());
+		$expected = $this->phpcs->getResults('bin/foobar.php', [20], 'Found unused symbol Foobar.');
+		$messages = runGitWorkflow($options, $shell, $cache, '\PhpcsChangedTests\Debug');
+		$this->assertEquals($expected->getMessages(), $messages->getMessages());
+	}
+
+	public function testFullGitWorkflowForOneFileStagedWithVendorDefaultPhpcsOnWindows() {
+		$gitFile = 'foobar.php';
+		// On Windows, vendor phpcs uses .bat extension
+		$phpcsPath = 'vendor/bin/phpcs.bat';
+		$options = CliOptions::fromArray([
+			'no-cache-git-root' => false,
+			'git-staged' => false,
+			'files' => [$gitFile],
+		]);
+		$shell = new WindowsTestShell($options, [$gitFile]);
+		$shell->registerExecutable('git');
+		$shell->registerExecutable($phpcsPath);
+		$fixture = $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;');
+		$shell->registerCommand("git diff --staged --no-prefix 'foobar.php'", $fixture);
+		$shell->registerCommand("git status --porcelain 'foobar.php'", $this->fixture->getModifiedFileInfo('foobar.php'));
+		$shell->registerCommand("git ls-files --full-name 'foobar.php'", "files/foobar.php");
+		$shell->registerCommand("git show HEAD:'files/foobar.php' | {$phpcsPath}", $this->phpcs->getResults('STDIN', [20])->toPhpcsJson());
+		$shell->registerCommand("git show :0:'files/foobar.php' | {$phpcsPath}", $this->phpcs->getResults('STDIN', [20, 21], 'Found unused symbol Foobar.')->toPhpcsJson());
+		$shell->registerCommand("git rev-parse --show-toplevel", 'run-from-git-root');
+		$cache = new CacheManager(new TestCache());
+		$expected = $this->phpcs->getResults('bin/foobar.php', [20], 'Found unused symbol Foobar.');
+		$messages = runGitWorkflow($options, $shell, $cache, '\PhpcsChangedTests\Debug');
+		$this->assertEquals($expected->getMessages(), $messages->getMessages());
+	}
+
+	public function testFullGitWorkflowForOneFileUnstagedUsesTypeOnWindows() {
+		$gitFile = 'foobar.php';
+		$options = CliOptions::fromArray(['no-cache-git-root' => false, 'git-unstaged' => false, 'files' => [$gitFile]]);
+		$shell = new WindowsTestShell($options, [$gitFile]);
+		$shell->registerExecutable('git');
+		$shell->registerExecutable('phpcs');
+		$fixture = $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;');
+		$shell->registerCommand("git diff --no-prefix 'foobar.php'", $fixture);
+		$shell->registerCommand("git status --porcelain 'foobar.php'", $this->fixture->getModifiedFileInfo('foobar.php'));
+		$shell->registerCommand("git ls-files --full-name 'foobar.php'", "files/foobar.php");
+		$shell->registerCommand("git show :0:'files/foobar.php'", $this->phpcs->getResults('STDIN', [20], 'Found unused symbol Foobar.')->toPhpcsJson());
+		// Windows uses 'type' instead of 'cat' for reading local files
+		$shell->registerCommand("type 'foobar.php'", $this->phpcs->getResults('STDIN', [21, 20], 'Found unused symbol Foobar.')->toPhpcsJson());
+		$shell->registerCommand("git rev-parse --show-toplevel", 'run-from-git-root');
+		$cache = new CacheManager(new TestCache());
+		$expected = $this->phpcs->getResults('bin/foobar.php', [20], 'Found unused symbol Foobar.');
+		$messages = runGitWorkflow($options, $shell, $cache, '\PhpcsChangedTests\Debug');
+		$this->assertEquals($expected->getMessages(), $messages->getMessages());
+	}
+
+	public function testFullGitWorkflowForOneFileUnstagedWithCustomCatOnWindows() {
+		$gitFile = 'foobar.php';
+		$catPath = 'C:/tools/cat.exe';
+		$options = CliOptions::fromArray([
+			'no-cache-git-root' => false,
+			'git-unstaged' => false,
+			'files' => [$gitFile],
+			'cat-path' => $catPath,
+		]);
+		$shell = new WindowsTestShell($options, [$gitFile]);
+		$shell->registerExecutable('git');
+		$shell->registerExecutable('phpcs');
+		$shell->registerExecutable($catPath);
+		$fixture = $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;');
+		$shell->registerCommand("git diff --no-prefix 'foobar.php'", $fixture);
+		$shell->registerCommand("git status --porcelain 'foobar.php'", $this->fixture->getModifiedFileInfo('foobar.php'));
+		$shell->registerCommand("git ls-files --full-name 'foobar.php'", "files/foobar.php");
+		$shell->registerCommand("git show :0:'files/foobar.php'", $this->phpcs->getResults('STDIN', [20], 'Found unused symbol Foobar.')->toPhpcsJson());
+		// Custom cat path is used
+		$shell->registerCommand("{$catPath} 'foobar.php'", $this->phpcs->getResults('STDIN', [21, 20], 'Found unused symbol Foobar.')->toPhpcsJson());
+		$shell->registerCommand("git rev-parse --show-toplevel", 'run-from-git-root');
+		$cache = new CacheManager(new TestCache());
+		$expected = $this->phpcs->getResults('bin/foobar.php', [20], 'Found unused symbol Foobar.');
+		$messages = runGitWorkflow($options, $shell, $cache, '\PhpcsChangedTests\Debug');
+		$this->assertEquals($expected->getMessages(), $messages->getMessages());
+	}
+
+	public function testGetFileNameFromPathHandlesWindowsBackslashes() {
+		$options = CliOptions::fromArray(['git-staged' => false, 'files' => ['foobar.php']]);
+		$shell = new WindowsShell($options);
+		$this->assertEquals('foobar.php', $shell->getFileNameFromPath('C:\\Users\\user\\foobar.php'));
+		$this->assertEquals('foobar.php', $shell->getFileNameFromPath('some/path/foobar.php'));
+		$this->assertEquals('foobar.php', $shell->getFileNameFromPath('some\\path\\foobar.php'));
+		$this->assertEquals('foobar.php', $shell->getFileNameFromPath('foobar.php'));
+	}
+}

--- a/tests/GitWorkflowWindowsTest.php
+++ b/tests/GitWorkflowWindowsTest.php
@@ -45,8 +45,8 @@ final class GitWorkflowWindowsTest extends TestCase {
 
 	public function testFullGitWorkflowForOneFileStagedWithVendorDefaultPhpcsOnWindows() {
 		$gitFile = 'foobar.php';
-		// On Windows, vendor phpcs uses .bat extension
-		$phpcsPath = 'vendor/bin/phpcs.bat';
+		// On Windows, vendor phpcs uses .bat extension with backslash path separators
+		$phpcsPath = 'vendor\\bin\\phpcs.bat';
 		$options = CliOptions::fromArray([
 			'no-cache-git-root' => false,
 			'git-staged' => false,

--- a/tests/SvnWorkflowWindowsTest.php
+++ b/tests/SvnWorkflowWindowsTest.php
@@ -1,0 +1,87 @@
+<?php
+declare(strict_types=1);
+
+require_once dirname(__DIR__) . '/index.php';
+require_once __DIR__ . '/helpers/helpers.php';
+
+use PHPUnit\Framework\TestCase;
+use PhpcsChanged\CliOptions;
+use PhpcsChanged\CacheManager;
+use PhpcsChangedTests\WindowsTestShell;
+use PhpcsChangedTests\TestCache;
+use PhpcsChangedTests\SvnFixture;
+use PhpcsChangedTests\PhpcsFixture;
+use function PhpcsChanged\runSvnWorkflow;
+
+final class SvnWorkflowWindowsTest extends TestCase {
+	public $phpcs;
+	public $fixture;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->fixture = new SvnFixture();
+		$this->phpcs = new PhpcsFixture();
+	}
+
+	public function testFullSvnWorkflowForOneFileOnWindows() {
+		$svnFile = 'foobar.php';
+		$options = CliOptions::fromArray([
+			'svn' => false, // getopt is weird and sets options to false
+			'files' => [$svnFile],
+		]);
+		$shell = new WindowsTestShell($options, [$svnFile]);
+		$shell->registerExecutable('svn');
+		$shell->registerExecutable('phpcs');
+		// Note: no 'cat' registration needed on Windows — 'type' is a built-in
+		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
+		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php'));
+		$shell->registerCommand("svn cat 'foobar.php' | phpcs", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
+		// Windows uses 'type' instead of 'cat' for reading the modified local file
+		$shell->registerCommand("type 'foobar.php' | phpcs", $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
+		$expected = $this->phpcs->getResults('bin/foobar.php', [20]);
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
+		$this->assertEquals($expected->getMessages(), $messages->getMessages());
+	}
+
+	public function testFullSvnWorkflowForOneFileWithReplacedCatOnWindows() {
+		$svnFile = 'foobar.php';
+		$catPath = 'C:/tools/cat.exe';
+		$options = CliOptions::fromArray([
+			'svn' => false,
+			'files' => [$svnFile],
+			'cat-path' => $catPath,
+		]);
+		$shell = new WindowsTestShell($options, [$svnFile]);
+		$shell->registerExecutable('svn');
+		$shell->registerExecutable('phpcs');
+		$shell->registerExecutable($catPath);
+		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
+		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php'));
+		$shell->registerCommand("svn cat 'foobar.php' | phpcs", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
+		// Custom cat path is used instead of 'type'
+		$shell->registerCommand("{$catPath} 'foobar.php' | phpcs", $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
+		$expected = $this->phpcs->getResults('bin/foobar.php', [20]);
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
+		$this->assertEquals($expected->getMessages(), $messages->getMessages());
+	}
+
+	public function testFullSvnWorkflowForOneFileWithVendorPhpcsBatOnWindows() {
+		$svnFile = 'foobar.php';
+		// On Windows, vendor phpcs uses .bat extension
+		$phpcsPath = 'vendor/bin/phpcs.bat';
+		$options = CliOptions::fromArray([
+			'svn' => false,
+			'files' => [$svnFile],
+		]);
+		$shell = new WindowsTestShell($options, [$svnFile]);
+		$shell->registerExecutable('svn');
+		$shell->registerExecutable($phpcsPath);
+		$shell->registerCommand("svn diff 'foobar.php'", $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;'));
+		$shell->registerCommand("svn info 'foobar.php'", $this->fixture->getSvnInfo('foobar.php'));
+		$shell->registerCommand("svn cat 'foobar.php' | {$phpcsPath}", $this->phpcs->getResults('STDIN', [20, 99])->toPhpcsJson());
+		$shell->registerCommand("type 'foobar.php' | {$phpcsPath}", $this->phpcs->getResults('STDIN', [20, 21])->toPhpcsJson());
+		$expected = $this->phpcs->getResults('bin/foobar.php', [20]);
+		$messages = runSvnWorkflow([$svnFile], $options, $shell, new CacheManager(new TestCache()), '\PhpcsChangedTests\debug');
+		$this->assertEquals($expected->getMessages(), $messages->getMessages());
+	}
+}

--- a/tests/SvnWorkflowWindowsTest.php
+++ b/tests/SvnWorkflowWindowsTest.php
@@ -67,8 +67,8 @@ final class SvnWorkflowWindowsTest extends TestCase {
 
 	public function testFullSvnWorkflowForOneFileWithVendorPhpcsBatOnWindows() {
 		$svnFile = 'foobar.php';
-		// On Windows, vendor phpcs uses .bat extension
-		$phpcsPath = 'vendor/bin/phpcs.bat';
+		// On Windows, vendor phpcs uses .bat extension with backslash path separators
+		$phpcsPath = 'vendor\\bin\\phpcs.bat';
 		$options = CliOptions::fromArray([
 			'svn' => false,
 			'files' => [$svnFile],

--- a/tests/helpers/TestShell.php
+++ b/tests/helpers/TestShell.php
@@ -83,7 +83,7 @@ class TestShell extends UnixShell {
 		return $this->fileHashes[$fileName] ?? $fileName;
 	}
 
-	protected function executeCommand(string $command, ?int &$return_val = null): string {
+	public function executeCommand(string $command, ?int &$return_val = null): string {
 		foreach ($this->commands as $registeredCommand => $return) {
 			if ($registeredCommand === substr($command, 0, strlen($registeredCommand)) ) {
 				$return_val = $return['return_val'];

--- a/tests/helpers/TestShell.php
+++ b/tests/helpers/TestShell.php
@@ -84,8 +84,11 @@ class TestShell extends UnixShell {
 	}
 
 	public function executeCommand(string $command, ?int &$return_val = null): string {
+		// Normalize double quotes to single quotes so commands registered with Unix-style
+		// quoting (single quotes) also match on Windows where escapeshellarg() uses double quotes.
+		$normalizedCommand = str_replace('"', "'", $command);
 		foreach ($this->commands as $registeredCommand => $return) {
-			if ($registeredCommand === substr($command, 0, strlen($registeredCommand)) ) {
+			if ($registeredCommand === substr($normalizedCommand, 0, strlen($registeredCommand)) ) {
 				$return_val = $return['return_val'];
 				$this->commandsCalled[$registeredCommand] = $command;
 				return $return['output'];

--- a/tests/helpers/WindowsTestShell.php
+++ b/tests/helpers/WindowsTestShell.php
@@ -4,13 +4,9 @@ declare(strict_types=1);
 namespace PhpcsChangedTests;
 
 use PhpcsChanged\CliOptions;
-use PhpcsChanged\Modes;
-use PhpcsChanged\ShellOperator;
-use PhpcsChanged\ShellException;
-use PhpcsChanged\NoChangesException;
-use PhpcsChanged\UnixShell;
+use PhpcsChanged\WindowsShell;
 
-class TestShell extends UnixShell {
+class WindowsTestShell extends WindowsShell {
 
 	private $readableFileNames = [];
 
@@ -34,7 +30,7 @@ class TestShell extends UnixShell {
 	}
 
 	public function registerReadableFileName(string $fileName, bool $override = false): bool {
-		if (!isset($this->readableFileNames[$fileName]) || $override ) {
+		if (!isset($this->readableFileNames[$fileName]) || $override) {
 			$this->readableFileNames[$fileName] = true;
 			return true;
 		}
@@ -85,7 +81,7 @@ class TestShell extends UnixShell {
 
 	protected function executeCommand(string $command, ?int &$return_val = null): string {
 		foreach ($this->commands as $registeredCommand => $return) {
-			if ($registeredCommand === substr($command, 0, strlen($registeredCommand)) ) {
+			if ($registeredCommand === substr($command, 0, strlen($registeredCommand))) {
 				$return_val = $return['return_val'];
 				$this->commandsCalled[$registeredCommand] = $command;
 				return $return['output'];

--- a/tests/helpers/WindowsTestShell.php
+++ b/tests/helpers/WindowsTestShell.php
@@ -80,8 +80,11 @@ class WindowsTestShell extends WindowsShell {
 	}
 
 	public function executeCommand(string $command, ?int &$return_val = null): string {
+		// Normalize double quotes to single quotes so commands registered with Unix-style
+		// quoting (single quotes) also match on Windows where escapeshellarg() uses double quotes.
+		$normalizedCommand = str_replace('"', "'", $command);
 		foreach ($this->commands as $registeredCommand => $return) {
-			if ($registeredCommand === substr($command, 0, strlen($registeredCommand))) {
+			if ($registeredCommand === substr($normalizedCommand, 0, strlen($registeredCommand))) {
 				$return_val = $return['return_val'];
 				$this->commandsCalled[$registeredCommand] = $command;
 				return $return['output'];

--- a/tests/helpers/WindowsTestShell.php
+++ b/tests/helpers/WindowsTestShell.php
@@ -79,7 +79,7 @@ class WindowsTestShell extends WindowsShell {
 		return $this->fileHashes[$fileName] ?? $fileName;
 	}
 
-	protected function executeCommand(string $command, ?int &$return_val = null): string {
+	public function executeCommand(string $command, ?int &$return_val = null): string {
 		foreach ($this->commands as $registeredCommand => $return) {
 			if ($registeredCommand === substr($command, 0, strlen($registeredCommand))) {
 				$return_val = $return['return_val'];

--- a/tests/helpers/helpers.php
+++ b/tests/helpers/helpers.php
@@ -7,6 +7,7 @@ require_once __DIR__ . '/PhpcsFixture.php';
 require_once __DIR__ . '/SvnFixture.php';
 require_once __DIR__ . '/GitFixture.php';
 require_once __DIR__ . '/TestShell.php';
+require_once __DIR__ . '/WindowsTestShell.php';
 require_once __DIR__ . '/TestCache.php';
 require_once __DIR__ . '/Functions.php';
 require_once __DIR__ . '/TestXmlReporter.php';


### PR DESCRIPTION
Fixes https://github.com/sirbrillig/phpcs-changed/issues/73

## Summary

- Adds `WindowsShell` class for native Windows cmd.exe support (no WSL required)
- Extracts all shared git/svn/phpcs workflow logic into a new `ShellRunner` class
- Introduces a `ShellPlatform` interface for the 6 platform-specific operations `ShellRunner` calls back through
- Both `UnixShell` and `WindowsShell` implement `ShellOperator` and `ShellPlatform` directly — no inheritance relationship between them
- `bin/phpcs-changed` selects the appropriate shell at runtime via `PHP_OS_FAMILY === 'Windows'`
- Adds a GitHub Actions workflow to verify on a real `windows-latest` runner

**Windows-specific behavior in `WindowsShell`:**
| Unix | Windows |
|---|---|
| `cat <file>` | `type <file>` (built-in) |
| `2>/dev/null` | `2>NUL` |
| `type <cmd> >/dev/null 2>&1` | `where /q <cmd>` |
| `vendor/bin/phpcs` | `vendor\bin\phpcs.bat` |
| `explode('/', $path)` | normalizes both `/` and `\` |

## Test plan

- [ ] All 144 existing tests pass without regression (`composer test`)
- [ ] Linting passes (`composer lint`)
- [ ] Static analysis passes (`composer psalm`)
- [ ] New `GitWorkflowWindowsTest` covers: staged workflow, vendor phpcs.bat, git-unstaged uses `type`, custom cat path
- [ ] New `SvnWorkflowWindowsTest` covers: `type` instead of `cat`, custom cat path, vendor phpcs.bat
- [ ] GitHub Actions Windows CI passes on `windows-latest` (PHP 8.1 and 8.2)
- [ ] Manual verification on Windows: `php bin/phpcs-changed --git-staged some-file.php`