### PR TITLE
Batch phpcs into two invocations: one for new files, one for old

### DIFF
--- a/PhpcsChanged/Cli.php
+++ b/PhpcsChanged/Cli.php
@@ -229,12 +229,163 @@ function runSvnWorkflow(array $svnFiles, CliOptions $options, ShellOperator $she
 
 	loadCache($cache, $shell, $options->toArray());
 
-	$phpcsMessages = array_map(function(string $svnFile) use ($options, $shell, $cache, $debug): PhpcsMessages {
-		return runSvnWorkflowForFile($svnFile, $options, $shell, $cache, $debug);
-	}, $svnFiles);
+	$phpcsStandard = $options->phpcsStandard;
+	$warningSeverity = $options->warningSeverity;
+	$errorSeverity = $options->errorSeverity;
+
+	// Phase 1: Determine which files need new (modified) phpcs scans
+	$needsNewPhpcs = [];
+	$newOutputs = [];
+	$isNewFileMap = [];
+	$modifiedHashMap = [];
+
+	foreach ($svnFiles as $svnFile) {
+		try {
+			if (! $shell->isReadable($svnFile)) {
+				throw new ShellException("Cannot read file '{$svnFile}'");
+			}
+
+			$modifiedFileHash = '';
+			$newCached = null;
+			if (isCachingEnabled($options->toArray())) {
+				$modifiedFileHash = $shell->getFileHash($svnFile);
+				$newCached = $cache->getCacheForFile($svnFile, 'new', $modifiedFileHash, $phpcsStandard ?? '', $warningSeverity ?? '', $errorSeverity ?? '');
+				$debug(($newCached !== null ? 'Using' : 'Not using') . " cache for modified file '{$svnFile}' at hash '{$modifiedFileHash}', and standard '{$phpcsStandard}'");
+			}
+			$modifiedHashMap[$svnFile] = $modifiedFileHash;
+
+			if ($newCached !== null) {
+				$newOutputs[$svnFile] = $newCached;
+			} else {
+				$needsNewPhpcs[] = $svnFile;
+			}
+		} catch( ShellException $err ) {
+			$shell->printError($err->getMessage());
+			$shell->exitWithCode(1);
+			throw $err; // Just in case we do not actually exit, like in tests
+		}
+	}
+
+	// Phase 2: Batch phpcs on all uncached new (modified) file versions
+	$newBatchTime = 0.0;
+	if (! empty($needsNewPhpcs)) {
+		try {
+			$batchStartTime = microtime(true);
+			$batchResults = $shell->getPhpcsOutputForNewSvnFiles($needsNewPhpcs);
+			$newBatchTime = microtime(true) - $batchStartTime;
+		} catch( \Exception $err ) {
+			$shell->printError($err->getMessage());
+			$shell->exitWithCode(1);
+			throw $err; // Just in case we do not actually exit, like in tests
+		}
+		foreach ($needsNewPhpcs as $svnFile) {
+			$newOutputs[$svnFile] = $batchResults[$svnFile] ?? '';
+			if (isCachingEnabled($options->toArray())) {
+				$cache->setCacheForFile($svnFile, 'new', $modifiedHashMap[$svnFile], $phpcsStandard ?? '', $warningSeverity ?? '', $errorSeverity ?? '', $newOutputs[$svnFile]);
+			}
+		}
+	}
+
+	// Phase 3: Determine which files need old (unmodified) phpcs scans.
+	// Only scan old versions for files that have new phpcs messages and are not brand-new.
+	$needsOldPhpcs = [];
+	$oldOutputs = [];
+	$revisionIdMap = [];
+
+	foreach ($svnFiles as $svnFile) {
+		$fileName = $shell->getFileNameFromPath($svnFile);
+		$newOutput = $newOutputs[$svnFile] ?? '';
+		$newFileMessages = PhpcsMessages::fromPhpcsJson($newOutput, $fileName);
+		if (count($newFileMessages->getMessages()) === 0) {
+			continue; // No new messages; no need to scan old version
+		}
+
+		try {
+			$isNewFile = $shell->doesUnmodifiedFileExistInSvn($svnFile);
+			$isNewFileMap[$svnFile] = $isNewFile;
+			if ($isNewFile) {
+				$debug("File '{$svnFile}' is new; unmodified version will not be scanned.");
+				continue;
+			}
+
+			$revisionId = $shell->getSvnRevisionId($svnFile);
+			$revisionIdMap[$svnFile] = $revisionId;
+			$oldCached = null;
+			if (isCachingEnabled($options->toArray())) {
+				$oldCached = $cache->getCacheForFile($svnFile, 'old', $revisionId, $phpcsStandard ?? '', $warningSeverity ?? '', $errorSeverity ?? '');
+				$debug(($oldCached !== null ? 'Using' : 'Not using') . " cache for unmodified file '{$svnFile}' at revision '{$revisionId}', and standard '{$phpcsStandard}'");
+			}
+
+			if ($oldCached !== null) {
+				$oldOutputs[$svnFile] = $oldCached;
+			} else {
+				$needsOldPhpcs[] = $svnFile;
+			}
+		} catch( ShellException $err ) {
+			$shell->printError($err->getMessage());
+			$shell->exitWithCode(1);
+			throw $err; // Just in case we do not actually exit, like in tests
+		}
+	}
+
+	// Phase 4: Batch phpcs on all uncached old (unmodified) file versions
+	$oldBatchTime = 0.0;
+	if (! empty($needsOldPhpcs)) {
+		try {
+			$batchStartTime = microtime(true);
+			$batchResults = $shell->getPhpcsOutputForOldSvnFiles($needsOldPhpcs);
+			$oldBatchTime = microtime(true) - $batchStartTime;
+		} catch( \Exception $err ) {
+			$shell->printError($err->getMessage());
+			$shell->exitWithCode(1);
+			throw $err; // Just in case we do not actually exit, like in tests
+		}
+		foreach ($needsOldPhpcs as $svnFile) {
+			$oldOutputs[$svnFile] = $batchResults[$svnFile] ?? '';
+			if (isCachingEnabled($options->toArray())) {
+				$cache->setCacheForFile($svnFile, 'old', $revisionIdMap[$svnFile], $phpcsStandard ?? '', $warningSeverity ?? '', $errorSeverity ?? '', $oldOutputs[$svnFile]);
+			}
+		}
+	}
+
+	$totalBatchSize = count($needsNewPhpcs) + count($needsOldPhpcs);
+	$totalBatchTime = $newBatchTime + $oldBatchTime;
+	$timePerFile = $totalBatchSize > 0 ? $totalBatchTime / $totalBatchSize : 0.0;
+
+	// Phase 5: Filter - compute new messages per file
+	$phpcsMessages = [];
+	foreach ($svnFiles as $svnFile) {
+		$fileName = $shell->getFileNameFromPath($svnFile);
+		try {
+			$newOutput = $newOutputs[$svnFile] ?? '';
+			$newFileMessages = PhpcsMessages::fromPhpcsJson($newOutput, $fileName);
+			$newFileMessages->setTiming($fileName, $timePerFile);
+
+			if (count($newFileMessages->getMessages()) === 0) {
+				throw new NoChangesException("Modified file '{$svnFile}' has no PHPCS messages; skipping");
+			}
+
+			$unifiedDiff = $shell->getSvnUnifiedDiff($svnFile);
+			$isNewFile = $isNewFileMap[$svnFile] ?? false;
+			if ($isNewFile) {
+				$debug('Skipping the linting of the unmodified file as it is a new file.');
+				$phpcsMessages[] = getNewPhpcsMessages($unifiedDiff, PhpcsMessages::fromPhpcsJson('', $fileName), $newFileMessages);
+				continue;
+			}
+
+			$oldOutput = $oldOutputs[$svnFile] ?? '';
+			$phpcsMessages[] = getNewPhpcsMessages($unifiedDiff, PhpcsMessages::fromPhpcsJson($oldOutput, $fileName), $newFileMessages);
+		} catch( NoChangesException $err ) {
+			$debug($err->getMessage());
+			$phpcsMessages[] = getNewPhpcsMessages('', PhpcsMessages::fromPhpcsJson('', $fileName), PhpcsMessages::fromPhpcsJson(''));
+		} catch( \Exception $err ) {
+			$shell->printError($err->getMessage());
+			$shell->exitWithCode(1);
+			throw $err; // Just in case we do not actually exit, like in tests
+		}
+	}
 
 	saveCache($cache, $shell, $options->toArray());
-
 	$shell->clearCaches();
 	return PhpcsMessages::merge($phpcsMessages);
 }
@@ -336,12 +487,165 @@ function runGitWorkflow(CliOptions $options, ShellOperator $shell, CacheManager 
 
 	loadCache($cache, $shell, $options->toArray());
 
-	$phpcsMessages = array_map(function(string $gitFile) use ($options, $shell, $cache, $debug): PhpcsMessages {
-		return runGitWorkflowForFile($gitFile, $options, $shell, $cache, $debug);
-	}, $options->files);
+	$phpcsStandard = $options->phpcsStandard;
+	$warningSeverity = $options->warningSeverity;
+	$errorSeverity = $options->errorSeverity;
+
+	// Phase 1: Determine which files need new (modified) phpcs scans
+	$needsNewPhpcs = [];
+	$newOutputs = [];
+	$isNewFileMap = [];
+	$modifiedHashMap = [];
+
+	foreach ($options->files as $gitFile) {
+		try {
+			if (! $shell->isReadable($gitFile)) {
+				throw new ShellException("Cannot read file '{$gitFile}'");
+			}
+
+			$modifiedHash = '';
+			$newCached = null;
+			if (isCachingEnabled($options->toArray())) {
+				$modifiedHash = $shell->getGitHashOfModifiedFile($gitFile);
+				$newCached = $cache->getCacheForFile($gitFile, 'new', $modifiedHash, $phpcsStandard ?? '', $warningSeverity ?? '', $errorSeverity ?? '');
+				$debug(($newCached !== null ? 'Using' : 'Not using') . " cache for modified file '{$gitFile}' at hash '{$modifiedHash}', and standard '{$phpcsStandard}'");
+			}
+			$modifiedHashMap[$gitFile] = $modifiedHash;
+
+			if ($newCached !== null) {
+				$newOutputs[$gitFile] = $newCached;
+			} else {
+				$needsNewPhpcs[] = $gitFile;
+			}
+		} catch(ShellException $err) {
+			$shell->printError($err->getMessage());
+			$shell->exitWithCode(1);
+			throw $err; // Just in case we do not actually exit
+		}
+	}
+
+	// Phase 2: Batch phpcs on all uncached new (modified) file versions
+	$newBatchTime = 0.0;
+	if (! empty($needsNewPhpcs)) {
+		try {
+			$batchStartTime = microtime(true);
+			$batchResults = $shell->getPhpcsOutputForNewGitFiles($needsNewPhpcs);
+			$newBatchTime = microtime(true) - $batchStartTime;
+		} catch(\Exception $err) {
+			$shell->printError($err->getMessage());
+			$shell->exitWithCode(1);
+			throw $err; // Just in case we do not actually exit
+		}
+		foreach ($needsNewPhpcs as $gitFile) {
+			$newOutputs[$gitFile] = $batchResults[$gitFile] ?? '';
+			if (isCachingEnabled($options->toArray())) {
+				$cache->setCacheForFile($gitFile, 'new', $modifiedHashMap[$gitFile], $phpcsStandard ?? '', $warningSeverity ?? '', $errorSeverity ?? '', $newOutputs[$gitFile]);
+			}
+		}
+	}
+
+	// Phase 3: Determine which files need old (unmodified) phpcs scans.
+	// Only scan old versions for files that have new phpcs messages and are not brand-new.
+	$needsOldPhpcs = [];
+	$oldOutputs = [];
+	$unmodifiedHashMap = [];
+
+	foreach ($options->files as $gitFile) {
+		$newOutput = $newOutputs[$gitFile] ?? '';
+		$newFileMessages = PhpcsMessages::fromPhpcsJson($newOutput, $gitFile);
+		if (count($newFileMessages->getMessages()) === 0) {
+			continue; // No new messages; no need to scan old version
+		}
+
+		try {
+			$isNewFile = $shell->doesUnmodifiedFileExistInGit($gitFile);
+			$isNewFileMap[$gitFile] = $isNewFile;
+			if ($isNewFile) {
+				$debug("File '{$gitFile}' is new; unmodified version will not be scanned.");
+				continue;
+			}
+
+			$unmodifiedHash = '';
+			$oldCached = null;
+			if (isCachingEnabled($options->toArray())) {
+				$unmodifiedHash = $shell->getGitHashOfUnmodifiedFile($gitFile);
+				$oldCached = $cache->getCacheForFile($gitFile, 'old', $unmodifiedHash, $phpcsStandard ?? '', $warningSeverity ?? '', $errorSeverity ?? '');
+				$debug(($oldCached !== null ? 'Using' : 'Not using') . " cache for unmodified file '{$gitFile}' at hash '{$unmodifiedHash}', and standard '{$phpcsStandard}'");
+			}
+			$unmodifiedHashMap[$gitFile] = $unmodifiedHash;
+
+			if ($oldCached !== null) {
+				$oldOutputs[$gitFile] = $oldCached;
+			} else {
+				$needsOldPhpcs[] = $gitFile;
+			}
+		} catch(ShellException $err) {
+			$shell->printError($err->getMessage());
+			$shell->exitWithCode(1);
+			throw $err; // Just in case we do not actually exit
+		}
+	}
+
+	// Phase 4: Batch phpcs on all uncached old (unmodified) file versions
+	$oldBatchTime = 0.0;
+	if (! empty($needsOldPhpcs)) {
+		try {
+			$batchStartTime = microtime(true);
+			$batchResults = $shell->getPhpcsOutputForOldGitFiles($needsOldPhpcs);
+			$oldBatchTime = microtime(true) - $batchStartTime;
+		} catch(\Exception $err) {
+			$shell->printError($err->getMessage());
+			$shell->exitWithCode(1);
+			throw $err; // Just in case we do not actually exit
+		}
+		foreach ($needsOldPhpcs as $gitFile) {
+			$oldOutputs[$gitFile] = $batchResults[$gitFile] ?? '';
+			if (isCachingEnabled($options->toArray())) {
+				$cache->setCacheForFile($gitFile, 'old', $unmodifiedHashMap[$gitFile], $phpcsStandard ?? '', $warningSeverity ?? '', $errorSeverity ?? '', $oldOutputs[$gitFile]);
+			}
+		}
+	}
+
+	$totalBatchSize = count($needsNewPhpcs) + count($needsOldPhpcs);
+	$totalBatchTime = $newBatchTime + $oldBatchTime;
+	$timePerFile = $totalBatchSize > 0 ? $totalBatchTime / $totalBatchSize : 0.0;
+
+	// Phase 5: Filter - compute new messages per file
+	$phpcsMessages = [];
+	foreach ($options->files as $gitFile) {
+		try {
+			$newOutput = $newOutputs[$gitFile] ?? '';
+			$newFileMessages = PhpcsMessages::fromPhpcsJson($newOutput, $gitFile);
+			$newFileMessages->setTiming($gitFile, $timePerFile);
+
+			if (count($newFileMessages->getMessages()) === 0) {
+				throw new NoChangesException("Modified file '{$gitFile}' has no PHPCS messages; skipping");
+			}
+
+			$isNewFile = $isNewFileMap[$gitFile] ?? false;
+			$unifiedDiff = '';
+			$oldOutput = '';
+
+			if (! $isNewFile) {
+				$debug('Checking the unmodified file with PHPCS since the file is not new and contains some messages.');
+				$unifiedDiff = $shell->getGitUnifiedDiff($gitFile);
+				$oldOutput = $oldOutputs[$gitFile] ?? '';
+			} else {
+				$debug('Skipping the linting of the unmodified file as it is a new file.');
+			}
+
+			$phpcsMessages[] = getNewPhpcsMessages($unifiedDiff, PhpcsMessages::fromPhpcsJson($oldOutput, $gitFile), $newFileMessages);
+		} catch(NoChangesException $err) {
+			$debug($err->getMessage());
+			$phpcsMessages[] = PhpcsMessages::fromPhpcsJson('');
+		} catch(\Exception $err) {
+			$shell->printError($err->getMessage());
+			$shell->exitWithCode(1);
+			throw $err; // Just in case we do not actually exit
+		}
+	}
 
 	saveCache($cache, $shell, $options->toArray());
-
 	$shell->clearCaches();
 	return PhpcsMessages::merge($phpcsMessages);
 }

--- a/PhpcsChanged/ShellOperator.php
+++ b/PhpcsChanged/ShellOperator.php
@@ -50,4 +50,38 @@ interface ShellOperator {
 	public function getSvnRevisionId(string $fileName): string;
 
 	public function getSvnUnifiedDiff(string $fileName): string;
+
+	/**
+	 * Run phpcs on all new (modified) versions of the given git files in a single invocation.
+	 *
+	 * @param string[] $fileNames
+	 * @return array<string,string> Maps original file path => single-file phpcs JSON string
+	 */
+	public function getPhpcsOutputForNewGitFiles(array $fileNames): array;
+
+	/**
+	 * Run phpcs on all old (unmodified) versions of the given git files in a single invocation.
+	 * New files (with no prior git history) should not appear here.
+	 *
+	 * @param string[] $fileNames
+	 * @return array<string,string> Maps original file path => single-file phpcs JSON string
+	 */
+	public function getPhpcsOutputForOldGitFiles(array $fileNames): array;
+
+	/**
+	 * Run phpcs on all new (modified) versions of the given svn files in a single invocation.
+	 *
+	 * @param string[] $fileNames
+	 * @return array<string,string> Maps original file path => single-file phpcs JSON string
+	 */
+	public function getPhpcsOutputForNewSvnFiles(array $fileNames): array;
+
+	/**
+	 * Run phpcs on all old (unmodified) versions of the given svn files in a single invocation.
+	 * New files (not yet committed to SVN) should not appear here.
+	 *
+	 * @param string[] $fileNames
+	 * @return array<string,string> Maps original file path => single-file phpcs JSON string
+	 */
+	public function getPhpcsOutputForOldSvnFiles(array $fileNames): array;
 }

--- a/PhpcsChanged/ShellRunner.php
+++ b/PhpcsChanged/ShellRunner.php
@@ -388,4 +388,178 @@ class ShellRunner {
 
 		return $matches[1];
 	}
+
+	private function writeTempFile(string $contentCommand, string $tempPath): void {
+		$dir = dirname($tempPath);
+		if (! is_dir($dir)) {
+			mkdir($dir, 0777, true);
+		}
+		$content = $this->platform->executeCommand($contentCommand);
+		file_put_contents($tempPath, $content);
+	}
+
+	/**
+	 * @param array<string,string> $tempToOriginal Maps temp file path => original file path
+	 * @return array<string,string> Maps original file path => single-file phpcs JSON string
+	 */
+	private function runBatchPhpcs(array $tempToOriginal): array {
+		if (empty($tempToOriginal)) {
+			return [];
+		}
+		$phpcs = $this->getPhpcsExecutable();
+		$args = implode(' ', array_map('escapeshellarg', array_keys($tempToOriginal)));
+		$command = "{$phpcs} --report=json -q" . $this->getPhpcsStandardOption() . $this->getPhpcsExtensionsOption() . ' ' . $args;
+		$phpcsOutput = $this->platform->executeCommand($command);
+
+		if (! $phpcsOutput) {
+			return [];
+		}
+
+		$decoded = json_decode($phpcsOutput, true);
+		if (! is_array($decoded) || ! isset($decoded['files'])) {
+			return [];
+		}
+
+		$results = [];
+		foreach ($tempToOriginal as $tempPath => $originalPath) {
+			$realTempPath = ($resolved = realpath($tempPath)) !== false ? $resolved : $tempPath;
+			$fileData = $decoded['files'][$realTempPath] ?? $decoded['files'][$tempPath] ?? null;
+			if ($fileData === null) {
+				$results[$originalPath] = '';
+				continue;
+			}
+			$singleFileJson = json_encode([
+				'totals' => [
+					'errors' => $fileData['errors'] ?? 0,
+					'warnings' => $fileData['warnings'] ?? 0,
+					'fixable' => $fileData['fixable'] ?? 0,
+				],
+				'files' => [
+					$originalPath => $fileData,
+				],
+			]);
+			$results[$originalPath] = $singleFileJson !== false ? $singleFileJson : '';
+		}
+
+		return $results;
+	}
+
+	private function cleanupTempDir(string $dir): void {
+		if (! is_dir($dir)) {
+			return;
+		}
+		$files = new \RecursiveIteratorIterator(
+			new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS),
+			\RecursiveIteratorIterator::CHILD_FIRST
+		);
+		foreach ($files as $file) {
+			if ($file->isDir()) {
+				rmdir($file->getPathname());
+			} else {
+				unlink($file->getPathname());
+			}
+		}
+		rmdir($dir);
+	}
+
+	/**
+	 * @param string[] $fileNames
+	 * @return array<string,string>
+	 */
+	public function getPhpcsOutputForNewGitFiles(array $fileNames): array {
+		if (empty($fileNames)) {
+			return [];
+		}
+
+		$tempDir = sys_get_temp_dir() . '/phpcs-changed-' . uniqid();
+		mkdir($tempDir);
+		$tempToOriginal = [];
+
+		try {
+			foreach ($fileNames as $fileName) {
+				$tempPath = $tempDir . '/new/' . ltrim($fileName, '/');
+				$this->writeTempFile($this->getModifiedFileContentsCommand($fileName), $tempPath);
+				$tempToOriginal[$tempPath] = $fileName;
+			}
+			return $this->runBatchPhpcs($tempToOriginal);
+		} finally {
+			$this->cleanupTempDir($tempDir);
+		}
+	}
+
+	/**
+	 * @param string[] $fileNames
+	 * @return array<string,string>
+	 */
+	public function getPhpcsOutputForOldGitFiles(array $fileNames): array {
+		if (empty($fileNames)) {
+			return [];
+		}
+
+		$tempDir = sys_get_temp_dir() . '/phpcs-changed-' . uniqid();
+		mkdir($tempDir);
+		$tempToOriginal = [];
+
+		try {
+			foreach ($fileNames as $fileName) {
+				$tempPath = $tempDir . '/old/' . ltrim($fileName, '/');
+				$this->writeTempFile($this->getUnmodifiedFileContentsCommand($fileName), $tempPath);
+				$tempToOriginal[$tempPath] = $fileName;
+			}
+			return $this->runBatchPhpcs($tempToOriginal);
+		} finally {
+			$this->cleanupTempDir($tempDir);
+		}
+	}
+
+	/**
+	 * @param string[] $fileNames
+	 * @return array<string,string>
+	 */
+	public function getPhpcsOutputForNewSvnFiles(array $fileNames): array {
+		if (empty($fileNames)) {
+			return [];
+		}
+
+		$tempDir = sys_get_temp_dir() . '/phpcs-changed-' . uniqid();
+		mkdir($tempDir);
+		$tempToOriginal = [];
+
+		try {
+			foreach ($fileNames as $fileName) {
+				$tempPath = $tempDir . '/new/' . ltrim($fileName, '/');
+				$this->writeTempFile($this->platform->getLocalFileContentsCommand($fileName), $tempPath);
+				$tempToOriginal[$tempPath] = $fileName;
+			}
+			return $this->runBatchPhpcs($tempToOriginal);
+		} finally {
+			$this->cleanupTempDir($tempDir);
+		}
+	}
+
+	/**
+	 * @param string[] $fileNames
+	 * @return array<string,string>
+	 */
+	public function getPhpcsOutputForOldSvnFiles(array $fileNames): array {
+		if (empty($fileNames)) {
+			return [];
+		}
+
+		$tempDir = sys_get_temp_dir() . '/phpcs-changed-' . uniqid();
+		mkdir($tempDir);
+		$tempToOriginal = [];
+
+		try {
+			$svn = $this->options->getExecutablePath('svn');
+			foreach ($fileNames as $fileName) {
+				$tempPath = $tempDir . '/old/' . ltrim($fileName, '/');
+				$this->writeTempFile("{$svn} cat " . escapeshellarg($fileName), $tempPath);
+				$tempToOriginal[$tempPath] = $fileName;
+			}
+			return $this->runBatchPhpcs($tempToOriginal);
+		} finally {
+			$this->cleanupTempDir($tempDir);
+		}
+	}
 }

--- a/PhpcsChanged/UnixShell.php
+++ b/PhpcsChanged/UnixShell.php
@@ -188,4 +188,24 @@ class UnixShell implements ShellOperator, ShellPlatform {
 	public function getPhpcsVersion(): string {
 		return $this->runner->getPhpcsVersion();
 	}
+
+	#[\Override]
+	public function getPhpcsOutputForNewGitFiles(array $fileNames): array {
+		return $this->runner->getPhpcsOutputForNewGitFiles($fileNames);
+	}
+
+	#[\Override]
+	public function getPhpcsOutputForOldGitFiles(array $fileNames): array {
+		return $this->runner->getPhpcsOutputForOldGitFiles($fileNames);
+	}
+
+	#[\Override]
+	public function getPhpcsOutputForNewSvnFiles(array $fileNames): array {
+		return $this->runner->getPhpcsOutputForNewSvnFiles($fileNames);
+	}
+
+	#[\Override]
+	public function getPhpcsOutputForOldSvnFiles(array $fileNames): array {
+		return $this->runner->getPhpcsOutputForOldSvnFiles($fileNames);
+	}
 }

--- a/PhpcsChanged/WindowsShell.php
+++ b/PhpcsChanged/WindowsShell.php
@@ -212,4 +212,24 @@ class WindowsShell implements ShellOperator, ShellPlatform {
 	public function getPhpcsVersion(): string {
 		return $this->runner->getPhpcsVersion();
 	}
+
+	#[\Override]
+	public function getPhpcsOutputForNewGitFiles(array $fileNames): array {
+		return $this->runner->getPhpcsOutputForNewGitFiles($fileNames);
+	}
+
+	#[\Override]
+	public function getPhpcsOutputForOldGitFiles(array $fileNames): array {
+		return $this->runner->getPhpcsOutputForOldGitFiles($fileNames);
+	}
+
+	#[\Override]
+	public function getPhpcsOutputForNewSvnFiles(array $fileNames): array {
+		return $this->runner->getPhpcsOutputForNewSvnFiles($fileNames);
+	}
+
+	#[\Override]
+	public function getPhpcsOutputForOldSvnFiles(array $fileNames): array {
+		return $this->runner->getPhpcsOutputForOldSvnFiles($fileNames);
+	}
 }

--- a/tests/helpers/TestShell.php
+++ b/tests/helpers/TestShell.php
@@ -105,4 +105,36 @@ class TestShell extends UnixShell {
 	public function wasCommandCalled(string $registeredCommand): bool {
 		return isset($this->commandsCalled[$registeredCommand]);
 	}
+
+	public function getPhpcsOutputForNewGitFiles(array $fileNames): array {
+		$results = [];
+		foreach ($fileNames as $fileName) {
+			$results[$fileName] = $this->getPhpcsOutputOfModifiedGitFile($fileName);
+		}
+		return $results;
+	}
+
+	public function getPhpcsOutputForOldGitFiles(array $fileNames): array {
+		$results = [];
+		foreach ($fileNames as $fileName) {
+			$results[$fileName] = $this->getPhpcsOutputOfUnmodifiedGitFile($fileName);
+		}
+		return $results;
+	}
+
+	public function getPhpcsOutputForNewSvnFiles(array $fileNames): array {
+		$results = [];
+		foreach ($fileNames as $fileName) {
+			$results[$fileName] = $this->getPhpcsOutputOfModifiedSvnFile($fileName);
+		}
+		return $results;
+	}
+
+	public function getPhpcsOutputForOldSvnFiles(array $fileNames): array {
+		$results = [];
+		foreach ($fileNames as $fileName) {
+			$results[$fileName] = $this->getPhpcsOutputOfUnmodifiedSvnFile($fileName);
+		}
+		return $results;
+	}
 }

--- a/tests/helpers/WindowsTestShell.php
+++ b/tests/helpers/WindowsTestShell.php
@@ -101,4 +101,36 @@ class WindowsTestShell extends WindowsShell {
 	public function wasCommandCalled(string $registeredCommand): bool {
 		return isset($this->commandsCalled[$registeredCommand]);
 	}
+
+	public function getPhpcsOutputForNewGitFiles(array $fileNames): array {
+		$results = [];
+		foreach ($fileNames as $fileName) {
+			$results[$fileName] = $this->getPhpcsOutputOfModifiedGitFile($fileName);
+		}
+		return $results;
+	}
+
+	public function getPhpcsOutputForOldGitFiles(array $fileNames): array {
+		$results = [];
+		foreach ($fileNames as $fileName) {
+			$results[$fileName] = $this->getPhpcsOutputOfUnmodifiedGitFile($fileName);
+		}
+		return $results;
+	}
+
+	public function getPhpcsOutputForNewSvnFiles(array $fileNames): array {
+		$results = [];
+		foreach ($fileNames as $fileName) {
+			$results[$fileName] = $this->getPhpcsOutputOfModifiedSvnFile($fileName);
+		}
+		return $results;
+	}
+
+	public function getPhpcsOutputForOldSvnFiles(array $fileNames): array {
+		$results = [];
+		foreach ($fileNames as $fileName) {
+			$results[$fileName] = $this->getPhpcsOutputOfUnmodifiedSvnFile($fileName);
+		}
+		return $results;
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/sirbrillig/phpcs-changed/issues/115

## Summary

This PR modifies the script to only call `phpcs` (at most) twice total, no matter how many files are being scanned. This is compared to trunk currently where we call `phpcs` (potentially) twice for each file.

This approach uses **two separate** phpcs batch calls:

1. **First batch**: Run phpcs on all new (modified) file versions at once
2. **Second batch**: Run phpcs on all old (unmodified) file versions at once — but *only* for files that have new phpcs messages

### Key difference from #110

The single-batch approach (#110) pre-determines which old files need scanning before the new-file results are known, which means it sometimes scans old versions of files that turn out to have no new messages (wasted work).

This two-batch approach waits until the new-file results are in before deciding which old versions to scan, preserving the existing per-file optimization of skipping old-version scans for clean files.

### Trade-offs vs #110

- **Simpler**: Each batch method returns `array<string,string>` instead of `array{new:..., old:...}`
- **Smarter**: Never scans old versions of files with no new messages
- **Two startup costs** instead of one when all files have messages (minor overhead)

### Performance

Measured with `benchmark.sh` on 10 staged PHP files (PSR2 standard, 10 runs):

| | Mean | Relative |
|---|---|---|
| trunk: 20 phpcs calls | 6.94 s ± 0.61 s | 1.00× |
| two-batch (this branch): 2 phpcs calls | 3.57 s ± 0.29 s | 1.95× faster |