### PR TITLE
Support single-file sizing and multiple candidate branches in benchmark.sh

### DIFF
--- a/benchmark.sh
+++ b/benchmark.sh
@@ -1,23 +1,26 @@
 #!/usr/bin/env bash
-# benchmark.sh — compare the current branch vs trunk
+# benchmark.sh — compare candidate branches vs trunk
 #
 # Usage:
 #   ./benchmark.sh
 #
 # Environment variables (all optional):
-#   N_FILES=10   number of changed PHP files to scan
-#   RUNS=10      hyperfine measurement runs
-#   WARMUP=2     hyperfine warmup runs
+#   N_FILES=10              number of changed PHP files to scan
+#   LINES_PER_FILE=14       approximate target line count per file (committed version)
+#   RUNS=10                 hyperfine measurement runs
+#   WARMUP=2                hyperfine warmup runs
+#   CANDIDATES="<branches>" space-separated branches to compare against trunk.
+#                           Defaults to the currently checked-out branch.
+#                           Example: CANDIDATES="two-batch-phpcs-invocations batch-phpcs-invocations"
 #
 # Artifacts left in the repo root (not tracked by git):
-#   .bench-trunk/          git worktree for trunk (reused on subsequent runs)
-#   benchmark-results.md   hyperfine markdown export
+#   .bench-trunk/, .bench-<branch>/   git worktrees (reused on subsequent runs)
+#   benchmark-results.md              hyperfine markdown export
 
 set -euo pipefail
 
 # ── Paths ──────────────────────────────────────────────────────────────────
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-CURRENT_BIN="$SCRIPT_DIR/bin/phpcs-changed"
 TRUNK_WORKTREE="$SCRIPT_DIR/.bench-trunk"
 TRUNK_BIN="$TRUNK_WORKTREE/bin/phpcs-changed"
 PHPCS="$SCRIPT_DIR/vendor/bin/phpcs"
@@ -25,8 +28,11 @@ RESULTS_FILE="$SCRIPT_DIR/benchmark-results.md"
 
 # ── Tuneable ───────────────────────────────────────────────────────────────
 N_FILES=${N_FILES:-10}
+LINES_PER_FILE=${LINES_PER_FILE:-14}
 RUNS=${RUNS:-10}
 WARMUP=${WARMUP:-2}
+CURRENT_BRANCH_DEFAULT="$(git -C "$SCRIPT_DIR" branch --show-current)"
+CANDIDATES=${CANDIDATES:-$CURRENT_BRANCH_DEFAULT}
 
 # ── Sanity checks ─────────────────────────────────────────────────────────
 command -v hyperfine >/dev/null 2>&1 \
@@ -34,13 +40,29 @@ command -v hyperfine >/dev/null 2>&1 \
 [ -f "$PHPCS" ] \
   || { echo "ERROR: phpcs not found at $PHPCS. Run: composer install"; exit 1; }
 
-# ── 1. Trunk worktree ─────────────────────────────────────────────────────
-if [ ! -d "$TRUNK_WORKTREE" ]; then
-  echo "→ Creating trunk worktree at $TRUNK_WORKTREE …"
-  git -C "$SCRIPT_DIR" worktree add "$TRUNK_WORKTREE" trunk
-else
-  echo "→ Trunk worktree already exists."
-fi
+# ── 1. Worktrees ──────────────────────────────────────────────────────────
+ensure_worktree () {
+  local branch="$1"
+  local path="$2"
+  if [ ! -d "$path" ]; then
+    echo "→ Creating worktree for '$branch' at $path …"
+    # --detach lets us add a worktree even if the branch is checked out elsewhere.
+    git -C "$SCRIPT_DIR" worktree add --detach "$path" "$branch"
+  else
+    echo "→ Worktree for '$branch' already exists at $path."
+  fi
+}
+
+ensure_worktree "trunk" "$TRUNK_WORKTREE"
+
+CANDIDATE_PATHS=()
+CANDIDATE_NAMES=()
+for branch in $CANDIDATES; do
+  path="$SCRIPT_DIR/.bench-${branch}"
+  ensure_worktree "$branch" "$path"
+  CANDIDATE_PATHS+=("$path")
+  CANDIDATE_NAMES+=("$branch")
+done
 
 # ── 2. Ephemeral benchmark git repo ───────────────────────────────────────
 BENCH_REPO="$(mktemp -d)"
@@ -50,39 +72,42 @@ git -C "$BENCH_REPO" init -q
 git -C "$BENCH_REPO" config user.email "bench@example.com"
 git -C "$BENCH_REPO" config user.name "Benchmark"
 
-# Create initial PHP files with PSR2 violations (uppercase TRUE / FALSE).
-# Both the committed and staged versions have violations so both builds must
-# scan both file versions — this is the worst-case and ensures a fair comparison.
-echo "→ Preparing $N_FILES PHP test files …"
+# Each method block adds 6 lines and one violation (TRUE/FALSE).
+# Class scaffold (header + closer) costs ~5 lines, so derive block count from target.
+BLOCKS_PER_FILE=$(( (LINES_PER_FILE - 5) / 6 ))
+[ "$BLOCKS_PER_FILE" -lt 2 ] && BLOCKS_PER_FILE=2
+
+# Alternate violations across blocks for variety.
+VIOLATIONS=(TRUE FALSE)
+
+echo "→ Preparing $N_FILES PHP test files (~$LINES_PER_FILE lines, $BLOCKS_PER_FILE method blocks each) …"
 FILES=()
 for i in $(seq 1 "$N_FILES"); do
   fname="file${i}.php"
+  fpath="$BENCH_REPO/$fname"
 
-  # Committed (HEAD) version ─ existing violations: TRUE, FALSE
-  cat > "$BENCH_REPO/$fname" << PHPEOF
-<?php
-class Foo${i}
-{
-    public function check(): bool
-    {
-        \$a = TRUE;
-        return \$a;
-    }
-
-    public function invert(): bool
-    {
-        \$b = FALSE;
-        return !\$b;
-    }
-}
-PHPEOF
+  {
+    echo "<?php"
+    echo "class Foo${i}"
+    echo "{"
+    for b in $(seq 1 "$BLOCKS_PER_FILE"); do
+      violation=${VIOLATIONS[$(( (b - 1) % ${#VIOLATIONS[@]} ))]}
+      printf '    public function method%d(): bool\n' "$b"
+      echo  '    {'
+      printf '        $v = %s;\n' "$violation"
+      echo  '        return $v;'
+      echo  '    }'
+      echo  ''
+    done
+    echo "}"
+  } > "$fpath"
 
   FILES+=("$fname")
   git -C "$BENCH_REPO" add "$fname"
 done
 git -C "$BENCH_REPO" commit -q -m "initial commit"
 
-# Staged version ─ add a new violation to each file
+# Staged version ─ add a new violation (NULL) to each file
 for i in $(seq 1 "$N_FILES"); do
   fname="file${i}.php"
   cat >> "$BENCH_REPO/$fname" << PHPEOF
@@ -96,31 +121,39 @@ PHPEOF
   git -C "$BENCH_REPO" add "$fname"
 done
 
+ACTUAL_LINES=$(wc -l < "$BENCH_REPO/file1.php" | tr -d ' ')
+echo "→ Actual line count per file (staged): $ACTUAL_LINES"
+
 # ── 3. Run hyperfine ──────────────────────────────────────────────────────
 FILES_STR="${FILES[*]}"
-CURRENT_BRANCH="$(git -C "$SCRIPT_DIR" branch --show-current)"
-CURRENT_SHA="$(git -C "$SCRIPT_DIR" rev-parse --short HEAD)"
 TRUNK_SHA="$(git -C "$TRUNK_WORKTREE" rev-parse --short HEAD)"
 
-CURRENT_CMD="php '$CURRENT_BIN' --git-staged --phpcs-path='$PHPCS' --standard=PSR2 --always-exit-zero $FILES_STR"
+HF_ARGS=(--warmup "$WARMUP" --runs "$RUNS")
+
+# Trunk baseline first so it appears at the top of the table.
 TRUNK_CMD="php '$TRUNK_BIN' --git-staged --phpcs-path='$PHPCS' --standard=PSR2 --always-exit-zero $FILES_STR"
+HF_ARGS+=(-n "trunk ($TRUNK_SHA)" "$TRUNK_CMD")
+
+for idx in "${!CANDIDATE_PATHS[@]}"; do
+  path="${CANDIDATE_PATHS[$idx]}"
+  name="${CANDIDATE_NAMES[$idx]}"
+  sha="$(git -C "$path" rev-parse --short HEAD)"
+  bin="$path/bin/phpcs-changed"
+  cmd="php '$bin' --git-staged --phpcs-path='$PHPCS' --standard=PSR2 --always-exit-zero $FILES_STR"
+  HF_ARGS+=(-n "$name ($sha)" "$cmd")
+done
 
 echo ""
-printf "Benchmark: %d staged PHP files, --standard=PSR2\n" "$N_FILES"
-printf "  %-30s  %s\n" "$CURRENT_BRANCH" "$CURRENT_SHA"
-printf "  %-30s  %s\n" "trunk" "$TRUNK_SHA"
+printf "Benchmark: %d staged PHP files, ~%d lines/file, --standard=PSR2\n" "$N_FILES" "$ACTUAL_LINES"
+printf "  baseline: trunk (%s)\n" "$TRUNK_SHA"
+for idx in "${!CANDIDATE_NAMES[@]}"; do
+  path="${CANDIDATE_PATHS[$idx]}"
+  printf "  candidate: %s (%s)\n" "${CANDIDATE_NAMES[$idx]}" "$(git -C "$path" rev-parse --short HEAD)"
+done
 echo ""
 
 cd "$BENCH_REPO"
-# shellcheck disable=SC2086
-hyperfine \
-  --warmup "$WARMUP" \
-  --runs   "$RUNS" \
-  -n "$CURRENT_BRANCH ($CURRENT_SHA)" \
-  -n "trunk ($TRUNK_SHA)" \
-  "$CURRENT_CMD" \
-  "$TRUNK_CMD" \
-  --export-markdown "$RESULTS_FILE"
+hyperfine "${HF_ARGS[@]}" --export-markdown "$RESULTS_FILE"
 
 echo ""
 echo "Results written to $RESULTS_FILE"

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -33,6 +33,10 @@ RUNS=${RUNS:-10}
 WARMUP=${WARMUP:-2}
 CURRENT_BRANCH_DEFAULT="$(git -C "$SCRIPT_DIR" branch --show-current)"
 CANDIDATES=${CANDIDATES:-$CURRENT_BRANCH_DEFAULT}
+# CACHE_MODE: cold (no --cache), hot (--cache, warmups prime everything),
+# partial (--cache, but modified side is dirtied each iteration so only the
+# unmodified side hits).
+CACHE_MODE=${CACHE_MODE:-cold}
 
 # ── Sanity checks ─────────────────────────────────────────────────────────
 command -v hyperfine >/dev/null 2>&1 \
@@ -128,10 +132,27 @@ echo "→ Actual line count per file (staged): $ACTUAL_LINES"
 FILES_STR="${FILES[*]}"
 TRUNK_SHA="$(git -C "$TRUNK_WORKTREE" rev-parse --short HEAD)"
 
+case "$CACHE_MODE" in
+  cold)    CACHE_FLAG="" ;;
+  hot)     CACHE_FLAG="--cache" ;;
+  partial) CACHE_FLAG="--cache" ;;
+  *) echo "ERROR: CACHE_MODE must be cold, hot, or partial"; exit 1 ;;
+esac
+
 HF_ARGS=(--warmup "$WARMUP" --runs "$RUNS")
 
+# Ensure each benchmark starts from a clean cache so the first warmup populates
+# it consistently rather than inheriting the previous branch's cache file.
+HF_ARGS+=(--setup "rm -f $BENCH_REPO/.phpcs-changed-cache")
+
+# In partial mode, dirty file1.php before each iteration so the modified-side
+# cache misses while the unmodified-side cache (keyed on git revision) still hits.
+if [ "$CACHE_MODE" = "partial" ]; then
+  HF_ARGS+=(--prepare "echo '// noise' >> $BENCH_REPO/file1.php && git -C $BENCH_REPO add file1.php")
+fi
+
 # Trunk baseline first so it appears at the top of the table.
-TRUNK_CMD="php '$TRUNK_BIN' --git-staged --phpcs-path='$PHPCS' --standard=PSR2 --always-exit-zero $FILES_STR"
+TRUNK_CMD="php '$TRUNK_BIN' --git-staged --phpcs-path='$PHPCS' --standard=PSR2 --always-exit-zero $CACHE_FLAG $FILES_STR"
 HF_ARGS+=(-n "trunk ($TRUNK_SHA)" "$TRUNK_CMD")
 
 for idx in "${!CANDIDATE_PATHS[@]}"; do
@@ -139,12 +160,12 @@ for idx in "${!CANDIDATE_PATHS[@]}"; do
   name="${CANDIDATE_NAMES[$idx]}"
   sha="$(git -C "$path" rev-parse --short HEAD)"
   bin="$path/bin/phpcs-changed"
-  cmd="php '$bin' --git-staged --phpcs-path='$PHPCS' --standard=PSR2 --always-exit-zero $FILES_STR"
+  cmd="php '$bin' --git-staged --phpcs-path='$PHPCS' --standard=PSR2 --always-exit-zero $CACHE_FLAG $FILES_STR"
   HF_ARGS+=(-n "$name ($sha)" "$cmd")
 done
 
 echo ""
-printf "Benchmark: %d staged PHP files, ~%d lines/file, --standard=PSR2\n" "$N_FILES" "$ACTUAL_LINES"
+printf "Benchmark: %d staged PHP files, ~%d lines/file, cache=%s, --standard=PSR2\n" "$N_FILES" "$ACTUAL_LINES" "$CACHE_MODE"
 printf "  baseline: trunk (%s)\n" "$TRUNK_SHA"
 for idx in "${!CANDIDATE_NAMES[@]}"; do
   path="${CANDIDATE_PATHS[$idx]}"


### PR DESCRIPTION
This modifies the benchmark script to support more options. This is useful for comparison of approaches in https://github.com/sirbrillig/phpcs-changed/issues/115.

Adds `LINES_PER_FILE` to size each generated file, and `CANDIDATES` to compare multiple branches against trunk in one hyperfine run. Worktrees are now created with `--detach` so trunk can be benchmarked even when checked out
in the main worktree.

Add `CACHE_MODE` to benchmark.sh for cold/hot/partial cache scenarios

Adds `--cache` via `CACHE_MODE=hot` and a partial-cache mode that dirties file1.php before each iteration so the modified-side cache misses while the unmodified-side cache (keyed on git revision) still hits. Each benchmark also clears the cache via hyperfine `--setup` so branches start fresh.