### PR TITLE
Escape file name in checkstyle report output

### DIFF
--- a/PhpcsChanged/CheckstyleReporter.php
+++ b/PhpcsChanged/CheckstyleReporter.php
@@ -38,7 +38,8 @@ class CheckstyleReporter implements Reporter {
 			return '';
 		}
 
-		$xmlOutputForFile = "\t<file name=\"{$file}\">\n";
+		$fileName = $this->escapeXml($file);
+		$xmlOutputForFile = "\t<file name=\"{$fileName}\">\n";
 		$xmlOutputForFile .= array_reduce($messages, function(string $output, LintMessage $message): string {
 			$line = $message->getLineNumber();
 			$column = $message->getColumn();

--- a/tests/CheckstyleReporterTest.php
+++ b/tests/CheckstyleReporterTest.php
@@ -223,6 +223,32 @@ EOF;
 		$this->assertEquals($expected, $result);
 	}
 
+	public function testXmlEscapingInFilename() {
+		$messages = PhpcsMessages::fromArrays([
+			[
+				'type' => 'ERROR',
+				'severity' => 5,
+				'fixable' => false,
+				'column' => 5,
+				'source' => 'ImportDetection.Imports.RequireImports.Import',
+				'line' => 15,
+				'message' => 'Found unused symbol Foo.',
+			],
+		], 'src/file<>&".php');
+		$expected = <<<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<checkstyle version="phpcs-changed-2.11.8">
+	<file name="src/file&lt;&gt;&amp;&quot;.php">
+		<error line="15" column="5" severity="error" message="Found unused symbol Foo." source="ImportDetection.Imports.RequireImports.Import"/>
+	</file>
+</checkstyle>
+
+EOF;
+		$reporter = new CheckstyleReporter();
+		$result = $reporter->getFormattedMessages($messages, []);
+		$this->assertEquals($expected, $result);
+	}
+
 	public function testGetExitCodeWithMessages() {
 		$messages = PhpcsMessages::fromArrays([
 			[


### PR DESCRIPTION
## Summary

`CheckstyleReporter` escapes the `message` and `source` attributes but interpolates the file name into the `<file name="...">` element raw. A path that contains an XML metacharacter (`"`, `<`, `>`, `&`) therefore produces malformed checkstyle XML.

## Impact

Any consumer that parses the checkstyle report — for example `cs2pr`, which turns it into GitHub PR annotations — fails to parse the output, so that run's findings silently don't render. File names come from the diff being linted, so this triggers whenever a changed file's path contains one of those characters. (The checkstyle reporter was added in #108.)

## Fix

Escape the file name with the same `escapeXml` helper already used for the other attributes, and add a regression test (`testXmlEscapingInFilename`). `./vendor/bin/phpunit` and `composer lint` pass.

## Note

`XmlReporter` interpolates the file name (and its `message`/`source`) the same way; I've kept this PR scoped to the checkstyle format and am happy to follow up on the XML reporter separately if you'd like.

---

*Prepared with AI assistance (Claude).*
