### PR TITLE
Throw ShellException from getFileHash to avoid an uncaught fatal

### DIFF
--- a/PhpcsChanged/UnixShell.php
+++ b/PhpcsChanged/UnixShell.php
@@ -108,7 +108,7 @@ class UnixShell implements ShellOperator, ShellPlatform {
 	public function getFileHash(string $fileName): string {
 		$result = md5_file($fileName);
 		if ($result === false) {
-			throw new \Exception("Cannot get hash for file '{$fileName}'.");
+			throw new ShellException("Cannot get hash for file '{$fileName}'.");
 		}
 		return $result;
 	}

--- a/PhpcsChanged/WindowsShell.php
+++ b/PhpcsChanged/WindowsShell.php
@@ -127,7 +127,7 @@ class WindowsShell implements ShellOperator, ShellPlatform {
 	public function getFileHash(string $fileName): string {
 		$result = md5_file($fileName);
 		if ($result === false) {
-			throw new \Exception("Cannot get hash for file '{$fileName}'.");
+			throw new ShellException("Cannot get hash for file '{$fileName}'.");
 		}
 		return $result;
 	}

--- a/tests/UnixShellTest.php
+++ b/tests/UnixShellTest.php
@@ -6,6 +6,7 @@ require_once dirname(__DIR__) . '/index.php';
 use PHPUnit\Framework\TestCase;
 use PhpcsChanged\CliOptions;
 use PhpcsChanged\UnixShell;
+use PhpcsChanged\ShellException;
 
 /**
  * Tests for the real (non-mocked) UnixShell platform behavior.
@@ -81,5 +82,38 @@ final class UnixShellTest extends TestCase {
 		$returnVal = $shell->writeCommandOutputToFile('cat ' . escapeshellarg($missing) . ' 2>/dev/null', $dest);
 
 		$this->assertNotSame(0, $returnVal);
+	}
+
+	public function testGetFileHashReturnsMd5OfFileContents() {
+		if ($this->isWindows()) {
+			$this->markTestSkipped('UnixShell test does not run on Windows');
+		}
+		$contents = "<?php\n\$a = 1;\n";
+		$source = $this->makeTempFile($contents);
+
+		$this->assertSame(md5($contents), $this->shell()->getFileHash($source));
+	}
+
+	public function testGetFileHashThrowsShellExceptionWhenFileCannotBeRead() {
+		if ($this->isWindows()) {
+			$this->markTestSkipped('UnixShell test does not run on Windows');
+		}
+		$missing = sys_get_temp_dir() . '/phpcs-changed-does-not-exist-' . getmypid();
+
+		// A ShellException (not a bare Exception) is required here: the per-file catch
+		// blocks in Cli.php only catch ShellException, so any other type escapes as an
+		// uncaught fatal instead of a clean error message and exit code 1.
+		//
+		// md5_file() also emits a PHP warning for an unreadable file, which PHPUnit
+		// would convert into an exception before the ShellException could surface.
+		set_error_handler(static function (): bool {
+			return true;
+		});
+		try {
+			$this->expectException(ShellException::class);
+			$this->shell()->getFileHash($missing);
+		} finally {
+			restore_error_handler();
+		}
 	}
 }


### PR DESCRIPTION
Fixes #118.

`prepareSvnScanPlan()` catches only `ShellException`, but `getFileHash()` threw a bare `\Exception` when `md5_file()` failed. In SVN mode with `--cache` enabled that exception escaped `runSvnWorkflow()` and `run()` uncaught, producing a PHP fatal with a stack trace and exit code 255 instead of a clean error message and exit code 1.

`md5_file()` can fail after the preceding `isReadable()` check if the file is removed or its permissions change in between.

### Approach

Changed the thrown type in `UnixShell::getFileHash()` and `WindowsShell::getFileHash()` rather than widening the `catch` in `Cli.php`. `getFileHash()` was the only hash method on `ShellOperator` throwing a bare `\Exception` — `getGitHashOfModifiedFile()` and `getGitHashOfUnmodifiedFile()` already throw `ShellException`, which is why the git scan plan was unaffected. Widening the catch would have left the same trap for the next caller.

`ShellException extends \Exception`, so nothing that previously caught this stops catching it.

### Testing

Two tests added to `tests/UnixShellTest.php`, which exercises the real (unmocked) `UnixShell`:

- `testGetFileHashReturnsMd5OfFileContents` — pins the happy path, which had no coverage.
- `testGetFileHashThrowsShellExceptionWhenFileCannotBeRead` — the regression guard. Reverting the `UnixShell` change makes it fail with `Failed asserting that exception of type "Exception" matches expected exception "PhpcsChanged\ShellException"`.

`md5_file()` emits a PHP warning for an unreadable file, and PHPUnit 9 converts warnings to exceptions by default, which would mask the `ShellException` before the assertion could see it. The test installs a no-op error handler around the call and restores it in a `finally`.

Note that no `@` suppression was added to the production `md5_file()` call — nothing else in `PhpcsChanged/` suppresses errors, and that's a separate question from this bug. A real hash failure will still print a PHP warning ahead of the clean error message.

`composer precommit` passes: 160 tests / 262 assertions, phpcs clean, psalm no errors.
