### PR TITLE
Escape file name and message text in the Xml and Junit reporters

### DIFF
--- a/PhpcsChanged/JunitReporter.php
+++ b/PhpcsChanged/JunitReporter.php
@@ -57,7 +57,7 @@ class JunitReporter implements Reporter {
 		$fileTime = $allMessages->getTiming($file);
 
 		$xmlOutputForFile = sprintf("\t<testsuite name=\"%s\" tests=\"%d\" failures=\"%d\" errors=\"%d\" time=\"%.3f\">\n",
-			$file, $testCount, $failureCount, $errorCount, $fileTime);
+			$this->escapeXml($file), $testCount, $failureCount, $errorCount, $fileTime);
 		$xmlOutputForFile .= array_reduce($messages, function(string $output, LintMessage $message): string {
 			$line = $message->getLineNumber();
 			$column = $message->getColumn();

--- a/PhpcsChanged/XmlReporter.php
+++ b/PhpcsChanged/XmlReporter.php
@@ -44,7 +44,7 @@ class XmlReporter implements Reporter {
 			return $output;
 		}, '');
 
-		$phpcsVersion = $this->shell->getPhpcsVersion();
+		$phpcsVersion = $this->escapeXml($this->shell->getPhpcsVersion());
 
 		$output =  "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
 		$output .= "<phpcs version=\"{$phpcsVersion}\">\n";
@@ -64,21 +64,26 @@ class XmlReporter implements Reporter {
 		$fixableCount = count(array_values(array_filter($messages, function(LintMessage $message) {
 			return $message->getFixable();
 		})));
-		$xmlOutputForFile = "\t<file name=\"{$file}\" errors=\"{$errorCount}\" warnings=\"{$warningCount}\" fixable=\"{$fixableCount}\">\n";
+		$fileName = $this->escapeXml($file);
+		$xmlOutputForFile = "\t<file name=\"{$fileName}\" errors=\"{$errorCount}\" warnings=\"{$warningCount}\" fixable=\"{$fixableCount}\">\n";
 		$xmlOutputForFile .= array_reduce($messages, function(string $output, LintMessage  $message): string{
 			$type = strtolower( $message->getType() );
 			$line = $message->getLineNumber();
 			$column = $message->getColumn();
-			$source = $message->getSource();
+			$source = $this->escapeXml($message->getSource());
 			$severity = $message->getSeverity();
 			$fixable = $message->getFixable() ? "1" : "0";
-			$messageString = $message->getMessage();
+			$messageString = $this->escapeXml($message->getMessage());
 			$output .= "\t\t<{$type} line=\"{$line}\" column=\"{$column}\" source=\"{$source}\" severity=\"{$severity}\" fixable=\"{$fixable}\">{$messageString}</{$type}>\n";
 			return $output;
 		},'');
 		$xmlOutputForFile .= "\t</file>\n";
 
 		return $xmlOutputForFile;
+	}
+
+	private function escapeXml(string $string): string {
+		return htmlspecialchars($string, ENT_XML1 | ENT_QUOTES, 'UTF-8');
 	}
 
 	#[\Override]

--- a/tests/JunitReporterTest.php
+++ b/tests/JunitReporterTest.php
@@ -257,6 +257,34 @@ EOF;
 		$this->assertEquals($expected, $result);
 	}
 
+	public function testXmlEscapingInFilename() {
+		$messages = PhpcsMessages::fromArrays([
+			[
+				'type' => 'ERROR',
+				'severity' => 5,
+				'fixable' => false,
+				'column' => 5,
+				'source' => 'ImportDetection.Imports.RequireImports.Import',
+				'line' => 15,
+				'message' => 'Found unused symbol Foo.',
+			],
+		], 'src/file<>&".php');
+		$expected = <<<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="1" failures="0" errors="1" time="0.000">
+	<testsuite name="src/file&lt;&gt;&amp;&quot;.php" tests="1" failures="0" errors="1" time="0.000">
+		<testcase name="line 15, column 5" classname="ImportDetection.Imports.RequireImports.Import" time="0">
+			<error type="ImportDetection.Imports.RequireImports.Import" message="Found unused symbol Foo.">Line 15, Column 5: Found unused symbol Foo. (Severity: 5)</error>
+		</testcase>
+	</testsuite>
+</testsuites>
+
+EOF;
+		$reporter = new JunitReporter();
+		$result = $reporter->getFormattedMessages($messages, []);
+		$this->assertEquals($expected, $result);
+	}
+
 	public function testGetExitCodeWithMessages() {
 		$messages = PhpcsMessages::fromArrays([
 			[

--- a/tests/XmlReporterTest.php
+++ b/tests/XmlReporterTest.php
@@ -264,6 +264,66 @@ EOF;
 		$this->assertEquals($expected, $result);
 	}
 
+	public function testXmlEscaping() {
+		$messages = PhpcsMessages::fromArrays([
+			[
+				'type' => 'ERROR',
+				'severity' => 5,
+				'fixable' => false,
+				'column' => 5,
+				'source' => 'Test.Source<>&"',
+				'line' => 15,
+				'message' => 'Message with <xml> & "quotes".',
+			],
+		], 'fileA.php');
+		$expected = <<<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<phpcs version="1.2.3">
+	<file name="fileA.php" errors="1" warnings="0" fixable="0">
+		<error line="15" column="5" source="Test.Source&lt;&gt;&amp;&quot;" severity="5" fixable="0">Message with &lt;xml&gt; &amp; &quot;quotes&quot;.</error>
+	</file>
+</phpcs>
+
+EOF;
+		$options = new CliOptions();
+		$shell = new TestShell($options, []);
+		$shell->registerExecutable('phpcs');
+		$shell->registerCommand('phpcs --version', 'PHP_CodeSniffer version 1.2.3 (stable) by Squiz (http://www.squiz.net)');
+		$reporter = new TestXmlReporter($options, $shell);
+		$result = $reporter->getFormattedMessages($messages, []);
+		$this->assertEquals($expected, $result);
+	}
+
+	public function testXmlEscapingInFilename() {
+		$messages = PhpcsMessages::fromArrays([
+			[
+				'type' => 'ERROR',
+				'severity' => 5,
+				'fixable' => false,
+				'column' => 5,
+				'source' => 'ImportDetection.Imports.RequireImports.Import',
+				'line' => 15,
+				'message' => 'Found unused symbol Foo.',
+			],
+		], 'src/file<>&".php');
+		$expected = <<<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<phpcs version="1.2.3">
+	<file name="src/file&lt;&gt;&amp;&quot;.php" errors="1" warnings="0" fixable="0">
+		<error line="15" column="5" source="ImportDetection.Imports.RequireImports.Import" severity="5" fixable="0">Found unused symbol Foo.</error>
+	</file>
+</phpcs>
+
+EOF;
+		$options = new CliOptions();
+		$shell = new TestShell($options, []);
+		$shell->registerExecutable('phpcs');
+		$shell->registerCommand('phpcs --version', 'PHP_CodeSniffer version 1.2.3 (stable) by Squiz (http://www.squiz.net)');
+		$reporter = new TestXmlReporter($options, $shell);
+		$result = $reporter->getFormattedMessages($messages, []);
+		$this->assertEquals($expected, $result);
+	}
+
 	public function testGetExitCodeWithMessages() {
 		$messages = PhpcsMessages::fromArrays([
 			[


### PR DESCRIPTION
Fixes #119.

`JunitReporter` interpolated the file name straight into the `testsuite` `name` attribute while escaping `source` and `message` around it.

Investigating turned up that `XmlReporter` is worse than the issue described — it escapes *nothing*. The file name, the `source` attribute, the message text and the phpcs version were all interpolated raw. Since it is the same defect, this PR fixes all of them rather than only the file name.

File names may legally contain `"`, `<`, `>` and `&` on Linux and macOS, and in `--manual` mode the file keys come directly from the phpcs JSON passed via `--phpcs-unmodified`/`--phpcs-modified`, which may be a third-party CI artifact. The result is malformed XML at best, and at worst forged elements in reports consumed by Jenkins, GitLab or Azure DevOps.

Both reporters now use the same `escapeXml()` helper (`htmlspecialchars($string, ENT_XML1 | ENT_QUOTES, 'UTF-8')`) that `CheckstyleReporter` already had, so all three XML-family reporters escape identically.

### Testing

Three tests added, mirroring the existing `CheckstyleReporterTest` escaping tests:

- `JunitReporterTest::testXmlEscapingInFilename`
- `XmlReporterTest::testXmlEscaping` (source and message text)
- `XmlReporterTest::testXmlEscapingInFilename`

All three fail on trunk and pass with this change. No existing expectations needed updating, since the current fixtures use plain messages with no special characters.

`composer precommit` passes: 161 tests / 263 assertions, phpcs clean, psalm no errors.

### Follow-up, not fixed here

`XmlReporter` uses the message type as an XML *element* name:

```php
$type = strtolower($message->getType());
$output .= "\t\t<{$type} line=\"{$line}\" ...>{$messageString}</{$type}>\n";
```

`LintMessage::getType()` is unvalidated free text, so a crafted phpcs JSON in manual mode can inject an arbitrary element name. Escaping is the wrong remedy there — it needs a whitelist of `error`/`warning` — and it changes behavior for unrecognized types, so it belongs in its own change. Filed separately.
