### PR TITLE
Stop pinning advisory-affected PHPCS versions in the test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,36 +20,24 @@ jobs:
 
     strategy:
       matrix:
-        # The GHA matrix works different from Travis.
-        # You can define jobs here and then augment them with extra variables in `include`,
-        # as well as add extra jobs in `include`.
-        # @link https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix
+        # This job runs the unit test suite, which drives every shell interaction
+        # through the mocked TestShell and so never invokes the phpcs binary. The
+        # PHPCS version is therefore irrelevant here and is left to Composer to
+        # resolve from the `^3.2.1` constraint in composer.json; real phpcs runs
+        # are covered by the integration workflows instead.
         #
-        # IMPORTANT: test runs shouldn't fail because of PHPCS being incompatible with a PHP version.
-        # - PHPCS will run without errors on PHP 5.4 - 7.4 on all supported PHPCS versions.
-        # - PHP 8.0 needs PHPCS 3.5.7+ to run without errors.
-        # - PHP 8.1 needs PHPCS 3.6.1+ to run without errors.
-        php: ['7.1', '7.2', '7.3']
-        phpcs_version: ['3.5.6', '3.x-dev']
+        # The matrix pinned specific old PHPCS releases until GHSA-hmqg-cxww-wqhq
+        # (OS command injection, affecting < 3.13.6) made Composer refuse to
+        # install any of them.
+        #
+        # PHP 7.1 is not covered: it can only run PHPUnit 6/7 (8.5 requires PHP
+        # >= 7.2), and those releases carry their own advisories, so Composer
+        # will not install a working test harness for it at all.
+        #
+        # 8.2 is the experimental "nightly" build; see continue-on-error below.
+        php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
 
-        include:
-          # Make the matrix complete without duplicating builds run in code coverage.
-          - php: '8.1'
-            phpcs_version: '3.6.1'
-
-          - php: '8.0'
-            phpcs_version: '3.x-dev'
-          - php: '8.0'
-            phpcs_version: '3.5.7'
-
-          - php: '7.4'
-            phpcs_version: '3.x-dev'
-
-          # Experimental builds.
-          - php: '8.2' # Nightly.
-            phpcs_version: '3.x-dev'
-
-    name: "Test: PHP ${{ matrix.php }} on PHPCS ${{ matrix.phpcs_version }}"
+    name: "Test: PHP ${{ matrix.php }}"
 
     continue-on-error: ${{ matrix.php == '8.2' }}
 
@@ -57,28 +45,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Setup ini config
-        id: set_ini
-        run: |
-          # On stable PHPCS versions, allow for PHP deprecation notices.
-          # Unit tests don't need to fail on those for stable releases where those issues won't get fixed anymore.
-          if [ "${{ matrix.phpcs_version }}" != "3.x-dev" ]; then
-            echo '::set-output name=PHP_INI::error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On, zend.assertions=1'
-          else
-            echo '::set-output name=PHP_INI::error_reporting=-1, display_errors=On, zend.assertions=1'
-          fi
-
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          ini-values: ${{ steps.set_ini.outputs.PHP_INI }}
+          # Dependencies resolve to stable releases here, so allow PHP deprecation
+          # notices: the unit tests should not fail on deprecations in a released
+          # dependency that will not be fixed there anyway.
+          ini-values: "error_reporting=E_ALL & ~E_DEPRECATED, display_errors=On, zend.assertions=1"
           coverage: none
-
-      - name: 'Composer: adjust dependencies'
-        run: |
-          # Set the PHPCS version for this test run.
-          composer require --no-update squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}"
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies


### PR DESCRIPTION
Fixes the `Test` workflow, which has been failing on `trunk` and on the `v3.0.1` tag since before the current round of bugfix PRs. Not caused by any of them.

### Root cause

A new advisory landed: [GHSA-hmqg-cxww-wqhq](https://github.com/PHPCSStandards/PHP_CodeSniffer/security/advisories/GHSA-hmqg-cxww-wqhq) / `PKSA-rdkp-vv9z-mjkg`, OS command injection, affecting PHPCS `< 3.13.6` and `>= 4.0.0, < 4.0.2`. Recent Composer refuses by default to install packages with a known advisory.

Every version the matrix pinned is inside that range — `3.5.6`, `3.5.7`, `3.6.1` — so `composer require --no-update squizlabs/php_codesniffer:"..."` can no longer resolve. `3.x-dev` resolves above 3.13.6, which is why the `CS and QA` workflow still passes and only the pinned jobs fail.

### Why drop the pins rather than ignore the advisory

The `phpcs_version` dimension was not testing anything. This job runs `composer test`, which is the unit suite, and every shell interaction there goes through the mocked `TestShell` — the phpcs binary is never invoked. Verified by deleting `vendor/bin/phpcs` and running the suite: 161 tests, 263 assertions, all passing. Real phpcs runs are covered by `test-unix.yml` and `test-windows.yml`, neither of which pins a version.

So the pins bought no coverage while forcing CI to install a package with a known command-injection advisory. Dropping them lets Composer resolve the `^3.2.1` constraint already in `composer.json`, which lands on 3.13.6.

I checked the alternative: `--no-audit` does **not** bypass the block, only the policy config does, and that config key was renamed between Composer versions (`audit.block-insecure` on 2.9.8 locally vs `policy.advisories.block` in the CI error), so pinning-plus-ignoring would have been brittle.

### PHP 7.1

Dropped from the matrix, for a separate reason the phpcs pin was masking. PHP 7.1 can only run PHPUnit 6/7 — 8.5 requires PHP >= 7.2 — and those releases carry advisories of their own, so Composer will not install a working test harness for 7.1 at all. Confirmed by resolving each matrix entry locally with advisory blocking on:

| PHP | resolves | phpunit | phpcs |
| --- | --- | --- | --- |
| 7.1 | no | (6/7 blocked) | — |
| 7.2 | yes | 8.5.54 | 3.13.6 |
| 7.3 | yes | 9.6.36 | 3.13.6 |
| 7.4 | yes | 9.6.36 | 3.13.6 |
| 8.0 | yes | 9.6.36 | 3.13.6 |
| 8.1 | yes | 9.6.36 | 3.13.6 |
| 8.2 | yes | 9.6.36 | 3.13.6 |

### Also removed

The `Setup ini config` step existed only to switch `error_reporting` based on whether the pinned PHPCS was stable or `3.x-dev`. With the dimension gone, dependencies always resolve to stable releases, so the ini values are set directly on the `setup-php` step and the deprecation allowance is kept.
