### PR TITLE
Create the batch temp directory privately and fail if it exists

### DIFF
--- a/PhpcsChanged/ShellRunner.php
+++ b/PhpcsChanged/ShellRunner.php
@@ -338,8 +338,10 @@ class ShellRunner {
 
 	private function writeTempFile(string $contentCommand, string $tempPath): void {
 		$dir = dirname($tempPath);
-		if (! is_dir($dir)) {
-			mkdir($dir, 0777, true);
+		// 0700 matches the batch root created by createTempDir(); these directories mirror
+		// the scanned files' paths and hold copies of their contents.
+		if (! is_dir($dir) && ! mkdir($dir, 0700, true)) {
+			throw new ShellException("Cannot create temp directory '{$dir}'");
 		}
 		// Redirect the content command's stdout straight to the temp file rather than
 		// round-tripping through the line-oriented executeCommand(), which would force a
@@ -410,6 +412,24 @@ class ShellRunner {
 		return $results;
 	}
 
+	/**
+	 * Create the private root directory for one batch of temp files.
+	 *
+	 * The name is random rather than derived from uniqid(), which is microtime-based
+	 * and so guessable: on a shared machine another user could pre-create the
+	 * predicted path with 'new' and 'old' as symlinks and capture, or tamper with,
+	 * the copies phpcs is about to scan. Mode 0700 keeps those copies unreadable by
+	 * other local users, and a failed mkdir() is fatal rather than ignored, since an
+	 * existing path here means something is wrong.
+	 */
+	private function createTempDir(): string {
+		$tempDir = sys_get_temp_dir() . '/phpcs-changed-' . bin2hex(random_bytes(16));
+		if (! mkdir($tempDir, 0700)) {
+			throw new ShellException("Cannot create temp directory '{$tempDir}'");
+		}
+		return $tempDir;
+	}
+
 	private function cleanupTempDir(string $dir): void {
 		if (! is_dir($dir)) {
 			return;
@@ -438,8 +458,7 @@ class ShellRunner {
 			return ['new' => [], 'old' => []];
 		}
 
-		$tempDir = sys_get_temp_dir() . '/phpcs-changed-' . uniqid();
-		mkdir($tempDir);
+		$tempDir = $this->createTempDir();
 		$modifiedTempToOriginal = [];
 		$unmodifiedTempToOriginal = [];
 
@@ -475,8 +494,7 @@ class ShellRunner {
 			return ['new' => [], 'old' => []];
 		}
 
-		$tempDir = sys_get_temp_dir() . '/phpcs-changed-' . uniqid();
-		mkdir($tempDir);
+		$tempDir = $this->createTempDir();
 		$modifiedTempToOriginal = [];
 		$unmodifiedTempToOriginal = [];
 

--- a/tests/GitWorkflowTest.php
+++ b/tests/GitWorkflowTest.php
@@ -70,10 +70,20 @@ final class GitWorkflowTest extends TestCase {
 		$this->assertFalse($shell->wasCommandCalledContaining("/new/foobar.php"), 'temp file paths must not be inlined as phpcs arguments');
 	}
 
+	private function isWindows(): bool {
+		// PHP_OS_FAMILY is only available in PHP 7.2+.
+		return strtoupper(substr(PHP_OS, 0, 3)) === 'WIN';
+	}
+
 	public function testFullGitWorkflowCreatesBatchTempDirsPrivateToTheCurrentUser() {
 		// The batch temp tree holds copies of the scanned files' contents. Every directory in
 		// it must be 0700 so other local users cannot read those copies, or swap a temp file
 		// for a symlink between creation and the phpcs run.
+		if ($this->isWindows()) {
+			// Windows ignores mkdir()'s mode argument and reports 0777 for every directory;
+			// access there is governed by ACLs inherited from the parent instead.
+			$this->markTestSkipped('POSIX permissions are not applied on Windows');
+		}
 		$gitFile = 'foobar.php';
 		$options = CliOptions::fromArray(['no-cache-git-root' => false, 'git-staged' => false, 'files' => [$gitFile]]);
 		$shell = new TestShell($options, [$gitFile]);

--- a/tests/GitWorkflowTest.php
+++ b/tests/GitWorkflowTest.php
@@ -119,7 +119,9 @@ final class GitWorkflowTest extends TestCase {
 			return strlen($a) - strlen($b);
 		});
 		$batchRoot = basename($dirs[0]);
-		$this->assertMatchesRegularExpression('/^phpcs-changed-[0-9a-f]{32}$/', $batchRoot, 'batch temp dir name must be randomly generated');
+		// preg_match() rather than a regex assertion: assertMatchesRegularExpression() needs
+		// PHPUnit 9.1+, and this suite still runs on PHPUnit 8.5 for PHP 7.2.
+		$this->assertSame(1, preg_match('/^phpcs-changed-[0-9a-f]{32}$/', $batchRoot), 'batch temp dir name must be randomly generated');
 	}
 
 	public function testFullGitWorkflowThrowsWhenBatchPhpcsErrors() {

--- a/tests/GitWorkflowTest.php
+++ b/tests/GitWorkflowTest.php
@@ -70,6 +70,58 @@ final class GitWorkflowTest extends TestCase {
 		$this->assertFalse($shell->wasCommandCalledContaining("/new/foobar.php"), 'temp file paths must not be inlined as phpcs arguments');
 	}
 
+	public function testFullGitWorkflowCreatesBatchTempDirsPrivateToTheCurrentUser() {
+		// The batch temp tree holds copies of the scanned files' contents. Every directory in
+		// it must be 0700 so other local users cannot read those copies, or swap a temp file
+		// for a symlink between creation and the phpcs run.
+		$gitFile = 'foobar.php';
+		$options = CliOptions::fromArray(['no-cache-git-root' => false, 'git-staged' => false, 'files' => [$gitFile]]);
+		$shell = new TestShell($options, [$gitFile]);
+		$shell->registerExecutable('git');
+		$shell->registerExecutable('phpcs');
+		$fixture = $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;');
+		$shell->registerCommand("git diff --staged --no-prefix 'foobar.php'", $fixture);
+		$shell->registerCommand("git status --porcelain 'foobar.php'", $this->fixture->getModifiedFileInfo('foobar.php'));
+		$shell->registerCommand("git ls-files --full-name 'foobar.php'", "files/foobar.php");
+		$shell->registerCommand("git show HEAD:'files/foobar.php'", $this->phpcs->getResults('STDIN', [20])->toPhpcsJson());
+		$shell->registerCommand("git show :0:'files/foobar.php'", $this->phpcs->getResults('STDIN', [20, 21], 'Found unused symbol Foobar.')->toPhpcsJson());
+		$shell->registerCommand("git rev-parse --show-toplevel", 'run-from-git-root');
+		$cache = new CacheManager( new TestCache() );
+		runGitWorkflow($options, $shell, $cache, '\PhpcsChangedTests\Debug');
+
+		$modes = $shell->getObservedTempDirModes();
+		$this->assertNotEmpty($modes, 'expected the batch to create temp directories');
+		foreach ($modes as $dir => $mode) {
+			$this->assertSame('0700', sprintf('%04o', $mode), "temp directory '{$dir}' must not be accessible to other users");
+		}
+	}
+
+	public function testFullGitWorkflowNamesTheBatchTempDirUnpredictably() {
+		// uniqid() is derived from the current microtime and so is guessable; another user on
+		// a shared machine could pre-create the predicted directory and plant symlinks in it.
+		$gitFile = 'foobar.php';
+		$options = CliOptions::fromArray(['no-cache-git-root' => false, 'git-staged' => false, 'files' => [$gitFile]]);
+		$shell = new TestShell($options, [$gitFile]);
+		$shell->registerExecutable('git');
+		$shell->registerExecutable('phpcs');
+		$fixture = $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;');
+		$shell->registerCommand("git diff --staged --no-prefix 'foobar.php'", $fixture);
+		$shell->registerCommand("git status --porcelain 'foobar.php'", $this->fixture->getModifiedFileInfo('foobar.php'));
+		$shell->registerCommand("git ls-files --full-name 'foobar.php'", "files/foobar.php");
+		$shell->registerCommand("git show HEAD:'files/foobar.php'", $this->phpcs->getResults('STDIN', [20])->toPhpcsJson());
+		$shell->registerCommand("git show :0:'files/foobar.php'", $this->phpcs->getResults('STDIN', [20, 21], 'Found unused symbol Foobar.')->toPhpcsJson());
+		$shell->registerCommand("git rev-parse --show-toplevel", 'run-from-git-root');
+		$cache = new CacheManager( new TestCache() );
+		runGitWorkflow($options, $shell, $cache, '\PhpcsChangedTests\Debug');
+
+		$dirs = array_keys($shell->getObservedTempDirModes());
+		usort($dirs, function(string $a, string $b): int {
+			return strlen($a) - strlen($b);
+		});
+		$batchRoot = basename($dirs[0]);
+		$this->assertMatchesRegularExpression('/^phpcs-changed-[0-9a-f]{32}$/', $batchRoot, 'batch temp dir name must be randomly generated');
+	}
+
 	public function testFullGitWorkflowThrowsWhenBatchPhpcsErrors() {
 		// When phpcs cannot run (eg: an uninstalled standard) it writes a non-JSON error to
 		// stdout and exits non-zero. The batch path must surface this as a failure rather than

--- a/tests/helpers/TestShell.php
+++ b/tests/helpers/TestShell.php
@@ -18,6 +18,15 @@ class TestShell extends UnixShell {
 
 	private $executables = [];
 
+	/**
+	 * Permissions of each batch temp directory, keyed by path, recorded as
+	 * phpcs-changed builds them. The batch removes the whole tree before it
+	 * returns, so tests cannot stat these directories afterwards.
+	 *
+	 * @var array<string, int>
+	 */
+	private $observedTempDirModes = [];
+
 	public function __construct(CliOptions $options, array $readableFileNames) {
 		foreach ($readableFileNames as $fileName) {
 			$this->registerReadableFileName($fileName);
@@ -80,6 +89,7 @@ class TestShell extends UnixShell {
 	}
 
 	public function writeCommandOutputToFile(string $command, string $filePath): int {
+		$this->recordTempDirModes(dirname($filePath));
 		// The real shell redirects the content command's stdout to the file to preserve exact
 		// bytes. Here we capture the registered output and write it verbatim (file_put_contents
 		// does not alter bytes), keeping the batch test harness working.
@@ -87,6 +97,21 @@ class TestShell extends UnixShell {
 		$content = $this->executeCommand($command, $return_val);
 		file_put_contents($filePath, $content);
 		return $return_val;
+	}
+
+	private function recordTempDirModes(string $dir): void {
+		$tempRoot = sys_get_temp_dir();
+		while ($dir !== $tempRoot && $dir !== dirname($dir) && strpos($dir, $tempRoot . '/') === 0) {
+			$this->observedTempDirModes[$dir] = fileperms($dir) & 0777;
+			$dir = dirname($dir);
+		}
+	}
+
+	/**
+	 * @return array<string, int>
+	 */
+	public function getObservedTempDirModes(): array {
+		return $this->observedTempDirModes;
 	}
 
 	public function executeCommand(string $command, ?int &$return_val = null): string {

--- a/tests/helpers/WindowsTestShell.php
+++ b/tests/helpers/WindowsTestShell.php
@@ -18,6 +18,15 @@ class WindowsTestShell extends WindowsShell {
 
 	private $executables = [];
 
+	/**
+	 * Permissions of each batch temp directory, keyed by path, recorded as
+	 * phpcs-changed builds them. The batch removes the whole tree before it
+	 * returns, so tests cannot stat these directories afterwards.
+	 *
+	 * @var array<string, int>
+	 */
+	private $observedTempDirModes = [];
+
 	public function __construct(CliOptions $options, array $readableFileNames) {
 		foreach ($readableFileNames as $fileName) {
 			$this->registerReadableFileName($fileName);
@@ -80,6 +89,7 @@ class WindowsTestShell extends WindowsShell {
 	}
 
 	public function writeCommandOutputToFile(string $command, string $filePath): int {
+		$this->recordTempDirModes(dirname($filePath));
 		// The real shell redirects the content command's stdout to the file to preserve exact
 		// bytes. Here we capture the registered output and write it verbatim (file_put_contents
 		// does not alter bytes), keeping the batch test harness working.
@@ -87,6 +97,21 @@ class WindowsTestShell extends WindowsShell {
 		$content = $this->executeCommand($command, $return_val);
 		file_put_contents($filePath, $content);
 		return $return_val;
+	}
+
+	private function recordTempDirModes(string $dir): void {
+		$tempRoot = sys_get_temp_dir();
+		while ($dir !== $tempRoot && $dir !== dirname($dir) && strpos($dir, $tempRoot . '/') === 0) {
+			$this->observedTempDirModes[$dir] = fileperms($dir) & 0777;
+			$dir = dirname($dir);
+		}
+	}
+
+	/**
+	 * @return array<string, int>
+	 */
+	public function getObservedTempDirModes(): array {
+		return $this->observedTempDirModes;
 	}
 
 	public function executeCommand(string $command, ?int &$return_val = null): string {


### PR DESCRIPTION
Fixes #120.

The batch scan built its temp root from `uniqid()`, ignored the `mkdir()` return value, and created every directory with the default `0777 & ~umask`:

```php
$tempDir = sys_get_temp_dir() . '/phpcs-changed-' . uniqid();
mkdir($tempDir);
```

`uniqid()` is derived from the current microtime, so the path is guessable. On a shared machine (CI runner, shared build box) another local user can pre-create the predicted directory with `new` and `old` as symlinks; because the failed `mkdir()` was ignored, the batch then writes git or svn file contents through those symlinks, or tampers with the copies between creation and the single phpcs run that gates a commit. Even with no attacker present, the `0777` directories exposed copies of the scanned source to other local users for the duration of the scan. CWE-377 / CWE-378.

### Changes

Both batch entry points now share a `createTempDir()` helper that names the directory from `random_bytes(16)`, creates it with mode `0700`, and throws a `ShellException` if `mkdir()` fails rather than continuing into a directory it does not own. `writeTempFile()`'s nested `mkdir($dir, 0777, true)` is likewise `0700` and checked.

The temp files themselves are still created by shell redirection and so land at the umask default; the `0700` parent is what keeps them private.

### Testing

Two tests in `GitWorkflowTest`, driven through the existing mocked-shell batch path:

- `testFullGitWorkflowCreatesBatchTempDirsPrivateToTheCurrentUser` — asserts every directory in the batch tree is `0700`.
- `testFullGitWorkflowNamesTheBatchTempDirUnpredictably` — asserts the root matches `phpcs-changed-[0-9a-f]{32}`.

The batch deletes the whole tree in a `finally` before returning, so the directories cannot be inspected after the fact. `TestShell`/`WindowsTestShell` now record each temp directory's permissions as `writeCommandOutputToFile` is called, which is the point where the tree exists. Both tests fail on trunk and pass with this change.

`composer precommit` passes: 165 tests / 270 assertions, phpcs clean, psalm no errors.

### Follow-up, not fixed here

Temp paths are built as `$tempDir . '/new/' . ltrim($fileName, '/')`, and file names reach that point exactly as typed on the command line — nothing calls `realpath()` on them. A relative argument containing `..` therefore places the temp copy outside the batch directory:

```
/tmp/phpcs-changed-abc/new/../../evil.php
```

which resolves to `/tmp/evil.php` — outside the tree `cleanupTempDir()` removes, and able to clobber an existing file there. It is not a privilege boundary, since the user is scanning their own files as themselves, but it writes and leaks files outside the temp dir. Filed separately.
