### PR TITLE
Report the real version in Checkstyle output and ignore all benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 vendor
 composer.lock
-.bench-trunk/
+.bench-*/
 benchmark-results.md

--- a/PhpcsChanged/CheckstyleReporter.php
+++ b/PhpcsChanged/CheckstyleReporter.php
@@ -6,6 +6,7 @@ namespace PhpcsChanged;
 use PhpcsChanged\Reporter;
 use PhpcsChanged\PhpcsMessages;
 use PhpcsChanged\LintMessage;
+use function PhpcsChanged\getVersion;
 
 class CheckstyleReporter implements Reporter {
 	#[\Override]
@@ -26,7 +27,7 @@ class CheckstyleReporter implements Reporter {
 		}, '');
 
 		$output = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
-		$output .= "<checkstyle version=\"phpcs-changed-2.11.8\">\n";
+		$output .= "<checkstyle version=\"phpcs-changed-" . getVersion() . "\">\n";
 		$output .= $outputByFile;
 		$output .= "</checkstyle>\n";
 

--- a/tests/CheckstyleReporterTest.php
+++ b/tests/CheckstyleReporterTest.php
@@ -7,6 +7,7 @@ require_once __DIR__ . '/helpers/helpers.php';
 use PHPUnit\Framework\TestCase;
 use PhpcsChanged\PhpcsMessages;
 use PhpcsChanged\CheckstyleReporter;
+use function PhpcsChanged\getVersion;
 
 final class CheckstyleReporterTest extends TestCase {
 	public function testSingleWarning() {
@@ -21,9 +22,10 @@ final class CheckstyleReporterTest extends TestCase {
 				'message' => 'Found unused symbol Foo.',
 			],
 		], 'fileA.php');
+		$version = getVersion();
 		$expected = <<<EOF
 <?xml version="1.0" encoding="UTF-8"?>
-<checkstyle version="phpcs-changed-2.11.8">
+<checkstyle version="phpcs-changed-{$version}">
 	<file name="fileA.php">
 		<error line="15" column="5" severity="warning" message="Found unused symbol Foo." source="ImportDetection.Imports.RequireImports.Import"/>
 	</file>
@@ -47,9 +49,10 @@ EOF;
 				'message' => 'Found unused symbol Foo.',
 			],
 		], 'fileA.php');
+		$version = getVersion();
 		$expected = <<<EOF
 <?xml version="1.0" encoding="UTF-8"?>
-<checkstyle version="phpcs-changed-2.11.8">
+<checkstyle version="phpcs-changed-{$version}">
 	<file name="fileA.php">
 		<error line="15" column="5" severity="error" message="Found unused symbol Foo." source="ImportDetection.Imports.RequireImports.Import"/>
 	</file>
@@ -82,9 +85,10 @@ EOF;
 				'message' => 'Found unused symbol Bar.',
 			],
 		], 'fileA.php');
+		$version = getVersion();
 		$expected = <<<EOF
 <?xml version="1.0" encoding="UTF-8"?>
-<checkstyle version="phpcs-changed-2.11.8">
+<checkstyle version="phpcs-changed-{$version}">
 	<file name="fileA.php">
 		<error line="133825" column="5" severity="warning" message="Found unused symbol Foo." source="ImportDetection.Imports.RequireImports.Import"/>
 		<error line="15" column="5" severity="warning" message="Found unused symbol Bar." source="ImportDetection.Imports.RequireImports.Import"/>
@@ -139,9 +143,10 @@ EOF;
 			],
 		], 'fileB.php');
 		$messages = PhpcsMessages::merge([$messagesA, $messagesB]);
+		$version = getVersion();
 		$expected = <<<EOF
 <?xml version="1.0" encoding="UTF-8"?>
-<checkstyle version="phpcs-changed-2.11.8">
+<checkstyle version="phpcs-changed-{$version}">
 	<file name="fileA.php">
 		<error line="12" column="2" severity="error" message="Found unused symbol Faa." source="ImportDetection.Imports.RequireImports.Something"/>
 		<error line="15" column="5" severity="error" message="Found unused symbol Foo." source="ImportDetection.Imports.RequireImports.Import"/>
@@ -160,9 +165,10 @@ EOF;
 
 	public function testNoWarnings() {
 		$messages = PhpcsMessages::fromArrays([]);
+		$version = getVersion();
 		$expected = <<<EOF
 <?xml version="1.0" encoding="UTF-8"?>
-<checkstyle version="phpcs-changed-2.11.8">
+<checkstyle version="phpcs-changed-{$version}">
 </checkstyle>
 
 EOF;
@@ -183,9 +189,10 @@ EOF;
 				'message' => 'Found unused symbol Foo.',
 			],
 		]);
+		$version = getVersion();
 		$expected = <<<EOF
 <?xml version="1.0" encoding="UTF-8"?>
-<checkstyle version="phpcs-changed-2.11.8">
+<checkstyle version="phpcs-changed-{$version}">
 	<file name="STDIN">
 		<error line="15" column="5" severity="warning" message="Found unused symbol Foo." source="ImportDetection.Imports.RequireImports.Import"/>
 	</file>
@@ -209,9 +216,10 @@ EOF;
 				'message' => 'Message with <xml> & "quotes".',
 			],
 		], 'fileA.php');
+		$version = getVersion();
 		$expected = <<<EOF
 <?xml version="1.0" encoding="UTF-8"?>
-<checkstyle version="phpcs-changed-2.11.8">
+<checkstyle version="phpcs-changed-{$version}">
 	<file name="fileA.php">
 		<error line="15" column="5" severity="error" message="Message with &lt;xml&gt; &amp; &quot;quotes&quot;." source="Test.Source&lt;&gt;&amp;&quot;"/>
 	</file>
@@ -235,9 +243,10 @@ EOF;
 				'message' => 'Found unused symbol Foo.',
 			],
 		], 'src/file<>&".php');
+		$version = getVersion();
 		$expected = <<<EOF
 <?xml version="1.0" encoding="UTF-8"?>
-<checkstyle version="phpcs-changed-2.11.8">
+<checkstyle version="phpcs-changed-{$version}">
 	<file name="src/file&lt;&gt;&amp;&quot;.php">
 		<error line="15" column="5" severity="error" message="Found unused symbol Foo." source="ImportDetection.Imports.RequireImports.Import"/>
 	</file>


### PR DESCRIPTION
Two unrelated one-liners, bundled since neither warrants its own PR.

### Fixes #122 — Checkstyle reports the real version

`CheckstyleReporter` hardcoded the version in its root element:

```php
$output .= "<checkstyle version=\"phpcs-changed-2.11.8\">\n";
```

The attribute has been wrong since 2.11.8 (the tool is at 3.0.1) and would drift again at every release. It now calls `getVersion()`, which is what `CacheManager` already does, using the same `use function PhpcsChanged\getVersion;` convention.

The eight expected blocks in `CheckstyleReporterTest` interpolate `getVersion()` as well rather than pinning a literal, so a version bump no longer has to touch the test file. Worth being explicit about what that does and does not buy: since both sides now read the same function, the assertion cannot catch a "wrong" version — what it does catch is someone re-hardcoding a literal, which would start failing at the next version bump. That is the failure mode this issue is about.

I checked for other stale copies of the version string across the repo and there are none.

### Fixes #121 — ignore every benchmark worktree

`benchmark.sh` creates one git worktree per branch under test — `.bench-trunk/` and `.bench-<branch>/` — but `.gitignore` only listed `.bench-trunk/`. Every candidate branch's worktree showed up as untracked noise in `git status`, which is particularly unhelpful given the tool being benchmarked reads the working tree.

Widened to `.bench-*/`. Verified by creating `.bench-trunk/`, `.bench-my-feature/` and `.bench-fix/nested/` (covering a branch name containing a slash) and confirming all three are ignored and `git status` is clean.

`composer precommit` passes: 163 tests / 265 assertions, phpcs clean, psalm no errors.
