### PR TITLE
Use a whitelisted element name for the message type in the Xml reporter

### DIFF
--- a/PhpcsChanged/XmlReporter.php
+++ b/PhpcsChanged/XmlReporter.php
@@ -59,7 +59,7 @@ class XmlReporter implements Reporter {
 			return $message->getType() === 'ERROR';
 		})));
 		$warningCount = count(array_values(array_filter($messages, function(LintMessage $message) {
-			return $message->getType() === 'WARNING';
+			return $this->getElementNameForType($message->getType()) === 'warning';
 		})));
 		$fixableCount = count(array_values(array_filter($messages, function(LintMessage $message) {
 			return $message->getFixable();
@@ -67,7 +67,7 @@ class XmlReporter implements Reporter {
 		$fileName = $this->escapeXml($file);
 		$xmlOutputForFile = "\t<file name=\"{$fileName}\" errors=\"{$errorCount}\" warnings=\"{$warningCount}\" fixable=\"{$fixableCount}\">\n";
 		$xmlOutputForFile .= array_reduce($messages, function(string $output, LintMessage  $message): string{
-			$type = strtolower( $message->getType() );
+			$type = $this->getElementNameForType($message->getType());
 			$line = $message->getLineNumber();
 			$column = $message->getColumn();
 			$source = $this->escapeXml($message->getSource());
@@ -80,6 +80,18 @@ class XmlReporter implements Reporter {
 		$xmlOutputForFile .= "\t</file>\n";
 
 		return $xmlOutputForFile;
+	}
+
+	/**
+	 * Return the XML element name to use for a phpcs message type.
+	 *
+	 * The message type is not validated anywhere along the path from the phpcs
+	 * JSON output (which, in manual mode, may come from an untrusted source), so
+	 * it cannot be used directly as an element name. Anything which is not an
+	 * error is reported as a warning.
+	 */
+	private function getElementNameForType(string $type): string {
+		return $type === 'ERROR' ? 'error' : 'warning';
 	}
 
 	private function escapeXml(string $string): string {

--- a/tests/XmlReporterTest.php
+++ b/tests/XmlReporterTest.php
@@ -324,6 +324,66 @@ EOF;
 		$this->assertEquals($expected, $result);
 	}
 
+	public function testUnrecognizedTypeIsReportedAsWarning() {
+		$messages = PhpcsMessages::fromArrays([
+			[
+				'type' => 'INFO',
+				'severity' => 5,
+				'fixable' => false,
+				'column' => 5,
+				'source' => 'ImportDetection.Imports.RequireImports.Import',
+				'line' => 15,
+				'message' => 'Found unused symbol Foo.',
+			],
+		], 'fileA.php');
+		$expected = <<<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<phpcs version="1.2.3">
+	<file name="fileA.php" errors="0" warnings="1" fixable="0">
+		<warning line="15" column="5" source="ImportDetection.Imports.RequireImports.Import" severity="5" fixable="0">Found unused symbol Foo.</warning>
+	</file>
+</phpcs>
+
+EOF;
+		$options = new CliOptions();
+		$shell = new TestShell($options, []);
+		$shell->registerExecutable('phpcs');
+		$shell->registerCommand('phpcs --version', 'PHP_CodeSniffer version 1.2.3 (stable) by Squiz (http://www.squiz.net)');
+		$reporter = new TestXmlReporter($options, $shell);
+		$result = $reporter->getFormattedMessages($messages, []);
+		$this->assertEquals($expected, $result);
+	}
+
+	public function testTypeWithXmlMarkupDoesNotChangeElementName() {
+		$messages = PhpcsMessages::fromArrays([
+			[
+				'type' => 'WARNING line="1"><injected/><x a="',
+				'severity' => 5,
+				'fixable' => false,
+				'column' => 5,
+				'source' => 'ImportDetection.Imports.RequireImports.Import',
+				'line' => 15,
+				'message' => 'Found unused symbol Foo.',
+			],
+		], 'fileA.php');
+		$expected = <<<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<phpcs version="1.2.3">
+	<file name="fileA.php" errors="0" warnings="1" fixable="0">
+		<warning line="15" column="5" source="ImportDetection.Imports.RequireImports.Import" severity="5" fixable="0">Found unused symbol Foo.</warning>
+	</file>
+</phpcs>
+
+EOF;
+		$options = new CliOptions();
+		$shell = new TestShell($options, []);
+		$shell->registerExecutable('phpcs');
+		$shell->registerCommand('phpcs --version', 'PHP_CodeSniffer version 1.2.3 (stable) by Squiz (http://www.squiz.net)');
+		$reporter = new TestXmlReporter($options, $shell);
+		$result = $reporter->getFormattedMessages($messages, []);
+		$this->assertEquals($expected, $result);
+	}
+
 	public function testGetExitCodeWithMessages() {
 		$messages = PhpcsMessages::fromArrays([
 			[


### PR DESCRIPTION
Fixes #125.

`XmlReporter::getFormattedMessagesForFile()` used the phpcs message type directly as an XML element name:

```php
$type = strtolower( $message->getType() );
$output .= "\t\t<{$type} line=\"{$line}\" ...>{$messageString}</{$type}>\n";
```

`LintMessage::getType()` is unvalidated free text — nothing between the phpcs JSON output and the reporter checks it against `ERROR`/`WARNING`. In `--manual` mode that JSON comes from `--phpcs-unmodified`/`--phpcs-modified`, which may be a third-party CI artifact, so a crafted `type` produced an arbitrary element name and could inject markup into the report.

Escaping is not the remedy here: an element name cannot be entity-escaped and remain a valid element name. This was deliberately left out of #119 / #124, which only covered attribute and text-node escaping.

## Changes

- Added `XmlReporter::getElementNameForType()`, which maps `ERROR` to `error` and anything else to `warning` — the same whitelist approach `CheckstyleReporter` already uses for its `severity` attribute. The element name now comes from that mapping.
- The `warnings=` count attribute uses the same mapping so it stays consistent with the elements actually emitted. Previously an unrecognized type rendered as its own element and was counted in neither `errors` nor `warnings`.
- Two new tests in `tests/XmlReporterTest.php`: an unrecognized-but-benign type (`INFO`) is reported and counted as a `<warning>`, and a type containing XML markup produces an unchanged `<warning>` element.

## Behavior change

Unrecognized message types now report as `warning` rather than as their own element. phpcs only emits `ERROR` and `WARNING`, so this should not affect real output.

`JunitReporter` and `CheckstyleReporter` were checked for the same pattern; neither uses the message type as an element name, so no change was needed there.

## Testing

`composer precommit` passes: 167 tests, lint clean, no psalm errors.
