### PR TITLE
Match batch phpcs results when a ruleset sets a basepath

### DIFF
--- a/PhpcsChanged/ShellRunner.php
+++ b/PhpcsChanged/ShellRunner.php
@@ -388,10 +388,24 @@ class ShellRunner {
 			throw new ShellException("Failed to run phpcs on batch of files; phpcs output: " . var_export($phpcsOutput, true));
 		}
 
+		// phpcs does not necessarily report a file under the path we gave it. It reports the
+		// realpath, and when the ruleset sets a basepath it also strips the leading slash from
+		// every reported path, including paths outside that basepath (see the unconditional
+		// ltrim() in PHP_CodeSniffer's Common::stripBasepath()). Our temp files always live
+		// outside the project, so with a basepath in play every one of them comes back
+		// slash-stripped. Index the reported paths by a normalized form so the lookup below
+		// matches regardless.
+		$reportedByNormalizedPath = [];
+		foreach ($decoded['files'] as $reportedPath => $reportedData) {
+			$reportedByNormalizedPath[ltrim((string) $reportedPath, '/\\')] = $reportedData;
+		}
+
 		$results = [];
 		foreach ($tempToOriginal as $tempPath => $originalPath) {
 			$realTempPath = ($resolved = realpath($tempPath)) !== false ? $resolved : $tempPath;
-			$fileData = $decoded['files'][$realTempPath] ?? $decoded['files'][$tempPath] ?? null;
+			$fileData = $reportedByNormalizedPath[ltrim($realTempPath, '/\\')]
+				?? $reportedByNormalizedPath[ltrim($tempPath, '/\\')]
+				?? null;
 			if ($fileData === null) {
 				$results[$tempPath] = '';
 				continue;

--- a/PhpcsChanged/ShellRunner.php
+++ b/PhpcsChanged/ShellRunner.php
@@ -401,11 +401,17 @@ class ShellRunner {
 		}
 
 		$results = [];
+		$matchedReportedPaths = [];
 		foreach ($tempToOriginal as $tempPath => $originalPath) {
 			$realTempPath = ($resolved = realpath($tempPath)) !== false ? $resolved : $tempPath;
-			$fileData = $reportedByNormalizedPath[ltrim($realTempPath, '/\\')]
-				?? $reportedByNormalizedPath[ltrim($tempPath, '/\\')]
-				?? null;
+			$fileData = null;
+			foreach ([ltrim($realTempPath, '/\\'), ltrim($tempPath, '/\\')] as $candidate) {
+				if (isset($reportedByNormalizedPath[$candidate])) {
+					$fileData = $reportedByNormalizedPath[$candidate];
+					$matchedReportedPaths[$candidate] = true;
+					break;
+				}
+			}
 			if ($fileData === null) {
 				$results[$tempPath] = '';
 				continue;
@@ -421,6 +427,21 @@ class ShellRunner {
 				],
 			]);
 			$results[$tempPath] = $singleFileJson !== false ? $singleFileJson : '';
+		}
+
+		// We hand phpcs an explicit list of temp files, so every path it reports on should be
+		// one of them. A reported path we cannot match back means our matching is wrong, not
+		// that a file was clean, and silently dropping it would report no violations for the
+		// whole batch and exit 0 -- as a CI gate that enforces nothing. Fail loudly instead.
+		// The reverse is not an error: phpcs legitimately omits files it did not scan, such as
+		// those the ruleset excludes or whose extension it is not configured to check.
+		$unmatchedReportedPaths = array_values(array_diff(
+			array_keys($reportedByNormalizedPath),
+			array_keys($matchedReportedPaths)
+		));
+		if (! empty($unmatchedReportedPaths)) {
+			$count = count($unmatchedReportedPaths);
+			throw new ShellException("phpcs reported results for {$count} path(s) which do not match any of the files it was asked to scan, the first being '{$unmatchedReportedPaths[0]}'; refusing to report possibly incomplete results");
 		}
 
 		return $results;

--- a/tests/GitWorkflowTest.php
+++ b/tests/GitWorkflowTest.php
@@ -156,6 +156,79 @@ final class GitWorkflowTest extends TestCase {
 		runGitWorkflow($options, $shell, $cache, '\PhpcsChangedTests\Debug');
 	}
 
+	public function testFullGitWorkflowFindsMessagesWhenPhpcsStripsLeadingSlashFromReportedPaths() {
+		// When the ruleset sets a basepath, phpcs strips the leading slash from every path it
+		// reports, including our temp files, which always live outside that basepath. Matching
+		// those results back to the files we scanned must survive that rewrite; when it did
+		// not, every file in the batch looked clean and the whole run exited 0 reporting
+		// nothing. See https://github.com/sirbrillig/phpcs-changed/issues/131
+		$gitFile = 'foobar.php';
+		$options = CliOptions::fromArray(['no-cache-git-root' => false, 'git-staged' => false, 'files' => [$gitFile]]);
+		$shell = new TestShell($options, [$gitFile]);
+		$shell->batchReportPathTransform = function(string $path): string {
+			return ltrim($path, '/');
+		};
+		$shell->registerExecutable('git');
+		$shell->registerExecutable('phpcs');
+		$fixture = $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;');
+		$shell->registerCommand("git diff --staged --no-prefix 'foobar.php'", $fixture);
+		$shell->registerCommand("git status --porcelain 'foobar.php'", $this->fixture->getModifiedFileInfo('foobar.php'));
+		$shell->registerCommand("git ls-files --full-name 'foobar.php'", "files/foobar.php");
+		$shell->registerCommand("git show HEAD:'files/foobar.php'", $this->phpcs->getResults('STDIN', [20])->toPhpcsJson());
+		$shell->registerCommand("git show :0:'files/foobar.php'", $this->phpcs->getResults('STDIN', [20, 21], 'Found unused symbol Foobar.')->toPhpcsJson());
+		$shell->registerCommand("git rev-parse --show-toplevel", 'run-from-git-root');
+		$cache = new CacheManager( new TestCache() );
+		$expected = $this->phpcs->getResults('bin/foobar.php', [20], 'Found unused symbol Foobar.');
+		$messages = runGitWorkflow($options, $shell, $cache, '\PhpcsChangedTests\Debug');
+		$this->assertEquals($expected->getMessages(), $messages->getMessages());
+	}
+
+	public function testFullGitWorkflowThrowsWhenBatchPhpcsReportsAnUnmatchedPath() {
+		// phpcs is handed an explicit list of temp files, so a reported path we cannot match
+		// back to one of them means our matching is broken. Treating that as "this file was
+		// clean" would report no violations and exit 0, so it must fail loudly instead.
+		$gitFile = 'foobar.php';
+		$options = CliOptions::fromArray(['no-cache-git-root' => false, 'git-staged' => false, 'files' => [$gitFile]]);
+		$shell = new TestShell($options, [$gitFile]);
+		$shell->batchReportPathTransform = function(string $path): string {
+			return '/somewhere/else' . $path;
+		};
+		$shell->registerExecutable('git');
+		$shell->registerExecutable('phpcs');
+		$fixture = $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;');
+		$shell->registerCommand("git diff --staged --no-prefix 'foobar.php'", $fixture);
+		$shell->registerCommand("git status --porcelain 'foobar.php'", $this->fixture->getModifiedFileInfo('foobar.php'));
+		$shell->registerCommand("git ls-files --full-name 'foobar.php'", "files/foobar.php");
+		$shell->registerCommand("git show HEAD:'files/foobar.php'", $this->phpcs->getResults('STDIN', [20])->toPhpcsJson());
+		$shell->registerCommand("git show :0:'files/foobar.php'", $this->phpcs->getResults('STDIN', [20, 21], 'Found unused symbol Foobar.')->toPhpcsJson());
+		$shell->registerCommand("git rev-parse --show-toplevel", 'run-from-git-root');
+		$cache = new CacheManager( new TestCache() );
+		$this->expectException(ShellException::class);
+		runGitWorkflow($options, $shell, $cache, '\PhpcsChangedTests\Debug');
+	}
+
+	public function testFullGitWorkflowDoesNotThrowWhenPhpcsOmitsAFileItDidNotScan() {
+		// phpcs leaves out files it did not scan, such as those the ruleset excludes. That is
+		// not a matching failure, so it must stay a quiet "no messages" rather than an error.
+		$gitFile = 'foobar.php';
+		$options = CliOptions::fromArray(['no-cache-git-root' => false, 'git-staged' => false, 'files' => [$gitFile]]);
+		$shell = new TestShell($options, [$gitFile]);
+		$shell->registerExecutable('git');
+		$shell->registerExecutable('phpcs');
+		$fixture = $this->fixture->getAddedLineDiff('foobar.php', 'use Foobar;');
+		$shell->registerCommand("git diff --staged --no-prefix 'foobar.php'", $fixture);
+		$shell->registerCommand("git status --porcelain 'foobar.php'", $this->fixture->getModifiedFileInfo('foobar.php'));
+		$shell->registerCommand("git ls-files --full-name 'foobar.php'", "files/foobar.php");
+		// An empty string for the file's contents makes the harness omit it from the batch
+		// report entirely, the way phpcs omits a file it was not configured to scan.
+		$shell->registerCommand("git show HEAD:'files/foobar.php'", '');
+		$shell->registerCommand("git show :0:'files/foobar.php'", '');
+		$shell->registerCommand("git rev-parse --show-toplevel", 'run-from-git-root');
+		$cache = new CacheManager( new TestCache() );
+		$messages = runGitWorkflow($options, $shell, $cache, '\PhpcsChangedTests\Debug');
+		$this->assertEquals([], $messages->getMessages());
+	}
+
 	public function testFullGitWorkflowForOneFileStagedWithReplacedGit() {
 		$gitFile = 'foobar.php';
 		$gitPath = 'bin/foo/git';

--- a/tests/helpers/Functions.php
+++ b/tests/helpers/Functions.php
@@ -20,7 +20,7 @@ function debugWithOutput(...$messages) {
  * file's data under its temp path exactly as phpcs would, so the production batch and
  * JSON-splitting logic is exercised for real rather than mocked away.
  */
-function buildBatchPhpcsOutput(string $command): string {
+function buildBatchPhpcsOutput(string $command, ?callable $pathTransform = null): string {
 	$tempPaths = readBatchPhpcsFileList($command);
 	$files = [];
 	foreach ($tempPaths as $tempPath) {
@@ -39,6 +39,11 @@ function buildBatchPhpcsOutput(string $command): string {
 			continue;
 		}
 		$key = realpath($tempPath) ?: $tempPath;
+		// phpcs does not always echo back the path it was given. $pathTransform lets a test
+		// reproduce those rewrites, eg: the leading slash a ruleset basepath strips off.
+		if ($pathTransform !== null) {
+			$key = $pathTransform($key);
+		}
 		$files[$key] = reset($decoded['files']);
 	}
 	$output = json_encode(['totals' => ['errors' => 0, 'warnings' => 0, 'fixable' => 0], 'files' => $files]);

--- a/tests/helpers/TestShell.php
+++ b/tests/helpers/TestShell.php
@@ -27,6 +27,14 @@ class TestShell extends UnixShell {
 	 */
 	private $observedTempDirModes = [];
 
+	/**
+	 * Rewrites the paths the synthesized batch phpcs output reports, mimicking a phpcs whose
+	 * reported paths differ from the ones it was handed. Null reports them back verbatim.
+	 *
+	 * @var callable|null
+	 */
+	public $batchReportPathTransform = null;
+
 	public function __construct(CliOptions $options, array $readableFileNames) {
 		foreach ($readableFileNames as $fileName) {
 			$this->registerReadableFileName($fileName);
@@ -121,7 +129,7 @@ class TestShell extends UnixShell {
 		if (strpos($command, 'phpcs-changed-') !== false && strpos($command, '--report=json') !== false) {
 			$return_val = 0;
 			$this->commandsCalled[$command] = $command;
-			return buildBatchPhpcsOutput($command);
+			return buildBatchPhpcsOutput($command, $this->batchReportPathTransform);
 		}
 		// Normalize double quotes to single quotes so commands registered with Unix-style
 		// quoting (single quotes) also match on Windows where escapeshellarg() uses double quotes.

--- a/tests/helpers/WindowsTestShell.php
+++ b/tests/helpers/WindowsTestShell.php
@@ -27,6 +27,14 @@ class WindowsTestShell extends WindowsShell {
 	 */
 	private $observedTempDirModes = [];
 
+	/**
+	 * Rewrites the paths the synthesized batch phpcs output reports, mimicking a phpcs whose
+	 * reported paths differ from the ones it was handed. Null reports them back verbatim.
+	 *
+	 * @var callable|null
+	 */
+	public $batchReportPathTransform = null;
+
 	public function __construct(CliOptions $options, array $readableFileNames) {
 		foreach ($readableFileNames as $fileName) {
 			$this->registerReadableFileName($fileName);
@@ -121,7 +129,7 @@ class WindowsTestShell extends WindowsShell {
 		if (strpos($command, 'phpcs-changed-') !== false && strpos($command, '--report=json') !== false) {
 			$return_val = 0;
 			$this->commandsCalled[$command] = $command;
-			return buildBatchPhpcsOutput($command);
+			return buildBatchPhpcsOutput($command, $this->batchReportPathTransform);
 		}
 		// Normalize double quotes to single quotes so commands registered with Unix-style
 		// quoting (single quotes) also match on Windows where escapeshellarg() uses double quotes.


### PR DESCRIPTION
Fixes #131.

On a repository whose ruleset sets a basepath, 3.0.1 reports no violations and exits 0 for any input. As a CI gate it goes green and enforces nothing. 2.13.0 is unaffected.

`runBatchPhpcs()` matched phpcs results back to the files it scanned by exact path:

```php
$realTempPath = ($resolved = realpath($tempPath)) !== false ? $resolved : $tempPath;
$fileData = $decoded['files'][$realTempPath] ?? $decoded['files'][$tempPath] ?? null;
```

But phpcs does not always echo back the path it was given. `Common::stripBasepath()` ends with:

```php
$path = ltrim($path, DIRECTORY_SEPARATOR);
```

That `ltrim()` is unconditional — it runs whenever a basepath is set, **including for paths that do not lie under that basepath**, where the preceding prefix check did not match. Batch scanning writes its temp files under `sys_get_temp_dir()`, always outside the project, so with a basepath in play every reported path comes back slash-stripped:

```
handed to phpcs:  /private/var/folders/…/new/includes/probe.php
reported back:     private/var/folders/…/new/includes/probe.php
```

Every lookup missed, each file got an empty result, and each was skipped as "has no PHPCS messages" — so the run reported nothing and exited 0.

This is a 3.0 regression from #110. 2.13.0 ran one phpcs per file and `PhpcsMessagesHelpers::fromPhpcsJson()` just takes `array_keys($parsed['files'])[0]`, so it never had to match a path.

The report narrowed this to the leading slash but could not reproduce it from a clean repo. The missing ingredient is a ruleset that sets a basepath, which the minimal PSR12 reproduction did not have.

## Changes

- `runBatchPhpcs()` indexes the reported paths by a leading-separator-stripped form and looks them up that way, so results match whether or not phpcs echoed the path back verbatim.
- An unmatched **reported** path is now a `ShellException`. phpcs gets an explicit file list, so every path it reports on should be one of ours; a leftover means our matching is broken, not that a file was clean. This is what kept the original bug silent — the mismatch hit every file at once.
- A **missing** file stays quiet on purpose. phpcs omits files it did not scan, such as those the ruleset excludes or whose extension it does not check, and erroring on those would break rulesets that exclude some of the files passed in.

## Testing

Three tests in `GitWorkflowTest`, each verified to fail against the right baseline:

- `…FindsMessagesWhenPhpcsStripsLeadingSlashFromReportedPaths` — fails on trunk.
- `…ThrowsWhenBatchPhpcsReportsAnUnmatchedPath` — fails with the path fix alone, so it pins the guard specifically.
- `…DoesNotThrowWhenPhpcsOmitsAFileItDidNotScan` — passes both before and after, pinning the exclusion case as a non-error.

The mocked phpcs always echoed back the exact path it was handed, so no test could previously reproduce a mismatch. `TestShell`/`WindowsTestShell` gain a `batchReportPathTransform` hook to rewrite the paths in the synthesized batch report.

Also checked against real phpcs 3.13.5 in a scratch repo: with `<arg name="basepath">` the probe file now reports 4 errors and exits 1 (was silent, exit 0); removing that one line is the difference. A batch mixing a violating file with two changed-and-excluded files does not trip the guard.

`composer precommit` passes: 170 tests / 275 assertions, lint clean, no psalm errors.

## Not fixed here

Results poisoned in the cache by 3.0.x need no guard, provided this ships under a bumped version. `CacheManager::load()` keys the cache on `getVersion()` and clears on mismatch, so those entries are discarded on upgrade. Skipping the cache write for empty output would also stop clean files from ever being cached, costing the performance `--cache` exists for.
